### PR TITLE
fix: prod E2E 콘텐츠 불일치 수정

### DIFF
--- a/packages/web/e2e/prod/critical-path.spec.ts
+++ b/packages/web/e2e/prod/critical-path.spec.ts
@@ -12,9 +12,9 @@ test.describe("Production Critical Path", () => {
     // Features 링크 클릭
     await page.getByRole("link", { name: "Features" }).first().click();
 
-    // Features 섹션이 뷰포트에 보이는지 확인
+    // Core Pillars 섹션이 뷰포트에 보이는지 확인 (F74 개편 후)
     await expect(
-      page.getByRole("heading", { name: /Features|핵심 기능/i }),
+      page.getByRole("heading", { name: /차별점|Core Pillars/i }),
     ).toBeVisible();
   });
 

--- a/packages/web/e2e/prod/smoke.spec.ts
+++ b/packages/web/e2e/prod/smoke.spec.ts
@@ -24,13 +24,13 @@ test.describe("Production Smoke", () => {
     await page.goto("/");
     await page.waitForLoadState("networkidle");
 
-    // Hero headline — 기존 landing.spec.ts와 동일한 선택자
+    // Hero headline — F74 개편 후 한국어 헤드라인
     await expect(
-      page.getByRole("heading", { name: /Where Humans & AI/i }),
+      page.getByRole("heading", { name: /사람과 AI가/i }),
     ).toBeVisible();
 
-    // "Forge Together" 브랜딩 텍스트
-    await expect(page.getByText("Forge Together")).toBeVisible();
+    // Hero 브랜딩 텍스트
+    await expect(page.getByText("함께 만드는 곳")).toBeVisible();
   });
 
   /**


### PR DESCRIPTION
## Summary
- prod-e2e CI job 첫 실행에서 2/9 실패 감지 (7 passed, 2 failed)
- 원인: F74 소개 페이지 개편 후 Hero/Features 텍스트가 바뀌었으나 E2E spec 미갱신
- smoke.spec.ts: `"Where Humans & AI"` → `"사람과 AI가"` + `"함께 만드는 곳"`
- critical-path.spec.ts: `"Features|핵심 기능"` → `"차별점|Core Pillars"`

## Test plan
- [ ] PR CI: test 통과 확인
- [ ] master merge 후: prod-e2e 9/9 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)