### PR TITLE
feat: getting-started 설치 가이드에 팀 리포 온보딩 반영

### DIFF
--- a/docs/01-plan/features/ia-restructure.plan.md
+++ b/docs/01-plan/features/ia-restructure.plan.md
@@ -1,0 +1,294 @@
+# Foundry-X IA 구조 개선 Planning Document
+
+> **Summary**: AX BD 사업개발 프로세스 6단계 기반으로 사이드바/메뉴 재구조화 + 온보딩 강화 + UI/UX 개선
+>
+> **Project**: Foundry-X
+> **Version**: Sprint 82~84
+> **Author**: Sinclair Seo
+> **Date**: 2026-03-30
+> **Status**: Draft
+
+---
+
+## Executive Summary
+
+| Perspective | Content |
+|-------------|---------|
+| **Problem** | 현재 사이드바가 개발자 관점으로 구성되어 있어, AX BD 실무자가 프로세스 단계별 업무 동선을 직관적으로 따라가기 어려움. Phase 7에서 추가된 4개 페이지(pipeline, ir-proposals, offering-packs, mvp-tracking)가 네비게이션에 누락. Discovery 관련 페이지 3곳 분산. |
+| **Solution** | AX BD 사업개발 프로세스 6단계(수집→발굴→형상화→검증/공유→제품화→GTM)를 사이드바 1차 그룹으로 매핑. 개발자 도구는 관리/설정 하위로 이동. 각 단계 진입 시 온보딩 가이드 제공. AXIS DS 기반 UI 개선. |
+| **Function/UX Effect** | 실무자가 사이드바만 보고 현재 프로세스 위치를 파악하고, 다음 할 일을 자연스럽게 찾을 수 있음. 신규 팀원도 각 단계 설명을 통해 자기 주도 학습 가능. |
+| **Core Value** | "프로세스가 곧 네비게이션" — AX BD 사업개발 표준 프로세스를 플랫폼 IA에 내재화하여, 도구 사용이 곧 프로세스 학습이 되는 환경 구축. |
+
+---
+
+## 1. Overview
+
+### 1.1 Purpose
+
+Foundry-X 웹 대시보드의 Information Architecture(IA)를 AX BD 사업개발 프로세스 6단계에 맞춰 재구조화하여, 실무자가 프로세스 동선대로 자연스럽게 플랫폼을 사용할 수 있게 함.
+
+### 1.2 Background
+
+- Phase 7(Sprint 79~81)에서 BD Pipeline E2E 기능 9건(F232~F240)이 구현되었으나, 사이드바에는 기존 구조를 유지한 채 일부만 반영됨
+- 현재 28개 페이지 중 사이드바에 ~18개만 노출, Phase 7 신규 4개 페이지 누락
+- Discovery 관련 페이지가 3곳(`/discovery`, `/ax-bd/discovery`, `/discovery-progress`)에 분산
+- 사이드바 그룹이 "SR관리 / 개발 / 현황 / AX BD" — 개발자 관점이며, AX BD 프로세스와 대응 관계 불명확
+- 신규 팀원 6명 온보딩(F114) 예정 — 프로세스 이해 없이 도구만 보여주면 활용도 저하
+
+### 1.3 Related Documents
+
+- AX BD 프로세스 v8.2: `docs/specs/axbd/`
+- BD Pipeline PRD: `docs/specs/fx-bd-v1/prd-final.md`
+- AX BD A-to-Z PRD: `docs/specs/ax-bd-atoz/prd-final.md`
+- 현재 사이드바: `packages/web/src/components/sidebar.tsx`
+
+---
+
+## 2. Scope
+
+### 2.1 In Scope
+
+- [ ] **F241**: 사이드바 IA 재구조화 — 프로세스 6단계 기반 메뉴 그룹 재배치 + 누락 페이지 통합
+- [ ] **F242**: 프로세스 단계별 온보딩 가이드 — 각 단계 진입 시 설명 카드 + Agent 안내
+- [ ] **F243**: 대시보드 홈 재설계 — 프로세스 진행률 중심 뷰 + 단계별 퀵 액션
+- [ ] **F244**: AXIS DS 기반 UI 컴포넌트 개선 — 사이드바 + 카드 + 레이아웃 리디자인
+
+### 2.2 Out of Scope
+
+- 페이지 라우트 경로 변경 (기존 URL 유지, 사이드바 그룹핑만 변경)
+- 신규 API 엔드포인트 추가 (기존 API 활용)
+- 모바일 전용 레이아웃 (반응형은 기존 Sheet 기반 유지)
+- AXIS DS npm 패키지 직접 의존 (현재 Tailwind + shadcn/ui에 AXIS 토큰만 반영)
+
+---
+
+## 3. Requirements
+
+### 3.1 Functional Requirements
+
+| ID | Requirement | Priority | Status |
+|----|-------------|----------|--------|
+| FR-01 | 사이드바를 프로세스 6단계 그룹으로 재구성 | High | Pending |
+| FR-02 | 누락 페이지 4건(pipeline, ir-proposals, offering-packs, mvp-tracking) 네비게이션 통합 | High | Pending |
+| FR-03 | Discovery 관련 3개 페이지를 "발굴" 단계 하위로 통합 | High | Pending |
+| FR-04 | 개발자 도구 페이지(에이전트, 아키텍처, 토큰 비용)를 "관리" 그룹으로 이동 | Medium | Pending |
+| FR-05 | 각 프로세스 단계 첫 진입 시 온보딩 설명 카드 표시 | Medium | Pending |
+| FR-06 | 대시보드 홈을 프로세스 파이프라인 진행률 뷰로 재설계 | Medium | Pending |
+| FR-07 | Getting Started 페이지를 6단계 프로세스 가이드로 재설계 | Medium | Pending |
+| FR-08 | AXIS DS 디자인 토큰(색상, 타이포, 간격) 적용 | Low | Pending |
+
+### 3.2 Non-Functional Requirements
+
+| Category | Criteria | Measurement Method |
+|----------|----------|-------------------|
+| Performance | 사이드바 렌더링 < 50ms (기존과 동일) | React DevTools Profiler |
+| Accessibility | 키보드 네비게이션 유지, aria-label 보존 | 수동 테스트 |
+| Compatibility | 기존 URL 북마크/링크 동작 유지 | E2E 테스트 |
+
+---
+
+## 4. Page-to-Process Mapping
+
+### 4.1 현재 페이지 → 프로세스 6단계 매핑
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ 프로세스 단계          │ 기존 페이지              │ 신규/이동    │
+├────────────────────────┼──────────────────────────┼──────────────┤
+│ 📥 1. 수집             │ /sr (SR 목록)            │              │
+│                        │ /discovery/collection    │              │
+│                        │                          │ /ir-proposals│
+│                        │                          │  (IR Bottom-up)│
+├────────────────────────┼──────────────────────────┼──────────────┤
+│ 🔍 2. 발굴             │ /ax-bd/discovery         │              │
+│                        │ /ax-bd/ideas             │              │
+│                        │ /ax-bd/bmc               │              │
+│                        │ /discovery-progress      │              │
+├────────────────────────┼──────────────────────────┼──────────────┤
+│ 📐 3. 형상화           │ /spec-generator          │              │
+│                        │                          │ /offering-packs│
+├────────────────────────┼──────────────────────────┼──────────────┤
+│ ✅ 4. 검증/공유        │ (Six Hats, AI 검토 등    │              │
+│                        │  ax-bd 하위 기능)        │              │
+├────────────────────────┼──────────────────────────┼──────────────┤
+│ 🚀 5. 제품화           │                          │ /mvp-tracking│
+├────────────────────────┼──────────────────────────┼──────────────┤
+│ 📈 6. GTM              │                          │ /pipeline    │
+├────────────────────────┼──────────────────────────┼──────────────┤
+│ ⚙️ 관리               │ /agents                  │              │
+│                        │ /architecture            │              │
+│                        │ /tokens                  │              │
+│                        │ /analytics               │              │
+│                        │ /methodologies           │              │
+│                        │ /settings                │              │
+│                        │ /workspace               │              │
+│                        │ /projects                │              │
+├────────────────────────┼──────────────────────────┼──────────────┤
+│ 🔗 외부 서비스         │ /discovery (Discovery-X) │              │
+│                        │ /foundry (AI Foundry)    │              │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 4.2 새 사이드바 구조 (확정)
+
+```
+📋 시작하기                    → /getting-started
+🏠 홈                         → /dashboard
+─────────────────────────────
+📥 1. 수집
+  ├─ SR 목록                  → /sr
+  ├─ 수집 채널                → /discovery/collection
+  └─ IR Bottom-up             → /ir-proposals
+─────────────────────────────
+🔍 2. 발굴
+  ├─ Discovery 프로세스       → /ax-bd/discovery
+  ├─ 아이디어 관리            → /ax-bd/ideas
+  ├─ BMC                      → /ax-bd/bmc
+  └─ 진행률                   → /discovery-progress
+─────────────────────────────
+📐 3. 형상화
+  ├─ Spec 생성                → /spec-generator
+  ├─ 사업제안서               → /ax-bd (BDP 편집)
+  └─ Offering Pack            → /offering-packs
+─────────────────────────────
+✅ 4. 검증/공유
+  ├─ 의사결정 (ORB/PRB)       → /ax-bd (게이트 기능)
+  ├─ 산출물 공유              → /ax-bd (공유 링크)
+  └─ 파이프라인               → /pipeline
+─────────────────────────────
+🚀 5. 제품화
+  └─ MVP 추적                 → /mvp-tracking
+─────────────────────────────
+📈 6. GTM
+  └─ IR 제안서                → /ir-proposals (별도 뷰)
+─────────────────────────────
+📚 지식
+  ├─ 지식베이스               → /wiki
+  └─ 방법론 관리              → /methodologies
+─────────────────────────────
+⚙️ 관리
+  ├─ 프로젝트 현황            → /projects
+  ├─ Analytics                → /analytics
+  ├─ 에이전트                 → /agents
+  ├─ 토큰 비용                → /tokens
+  ├─ 아키텍처                 → /architecture
+  └─ 설정                     → /settings, /workspace
+─────────────────────────────
+🔗 외부
+  ├─ Discovery-X              → /discovery
+  └─ AI Foundry               → /foundry
+─────────────────────────────
+❓ 도움말                     → /getting-started
+```
+
+---
+
+## 5. Sprint 분배 계획
+
+### Sprint 82: 사이드바 IA 재구조화 (F241)
+
+**범위**: 사이드바 컴포넌트 재작성 + 누락 페이지 통합
+**변경 파일**:
+- `packages/web/src/components/sidebar.tsx` — 전면 재작성
+- E2E 테스트 업데이트
+
+**핵심 작업**:
+1. `sidebar.tsx`의 `navGroups` 배열을 프로세스 6단계 기반으로 재구성
+2. Phase 7 페이지 4건(pipeline, ir-proposals, offering-packs, mvp-tracking) 네비게이션 추가
+3. Discovery 관련 페이지 통합 (발굴 그룹 하위)
+4. 개발자 도구 → 관리 그룹 이동
+5. 기존 E2E 테스트 업데이트
+
+### Sprint 83: 온보딩 가이드 강화 (F242 + F243)
+
+**범위**: 단계별 온보딩 + 대시보드 홈 재설계
+**변경 파일**:
+- `packages/web/src/components/feature/ProcessStageGuide.tsx` — 신규
+- `packages/web/src/app/(app)/dashboard/page.tsx` — 재설계
+- `packages/web/src/app/(app)/getting-started/page.tsx` — 6단계 기반 재구성
+
+**핵심 작업**:
+1. 프로세스 단계 진입 시 표시할 온보딩 카드 컴포넌트 제작
+2. 각 단계별 "이 단계에서는..." 설명 + "Agent가 도와주는 일" 안내
+3. 대시보드 홈: SDD Triangle → 프로세스 파이프라인 진행률 뷰 전환
+4. Getting Started: 6단계 프로세스 흐름도 + 단계별 시작 버튼
+
+### Sprint 84: AXIS DS 기반 UI/UX 개선 (F244)
+
+**범위**: 디자인 토큰 + 컴포넌트 리디자인
+**변경 파일**:
+- `packages/web/tailwind.config.ts` — AXIS DS 토큰 반영
+- `packages/web/src/components/sidebar.tsx` — 비주얼 개선
+- 주요 페이지 카드/레이아웃 리디자인
+
+**핵심 작업**:
+1. AXIS DS 디자인 토큰(색상 팔레트, 타이포그래피, 간격 시스템) 정의
+2. 사이드바 비주얼 개선 (아이콘 + 프로세스 단계 번호 뱃지)
+3. 카드 컴포넌트 리디자인 (일관된 elevation, border-radius)
+4. 대시보드 / 주요 페이지 레이아웃 정리
+
+---
+
+## 6. Success Criteria
+
+### 6.1 Definition of Done
+
+- [ ] 사이드바가 프로세스 6단계 기반으로 동작
+- [ ] 모든 28개 페이지가 사이드바에서 접근 가능
+- [ ] 기존 URL 북마크/링크 정상 동작 (라우트 변경 없음)
+- [ ] 각 프로세스 단계 진입 시 온보딩 가이드 표시
+- [ ] 대시보드 홈에서 프로세스 진행률 조회 가능
+- [ ] E2E 테스트 통과
+- [ ] typecheck + lint 통과
+
+### 6.2 Quality Criteria
+
+- [ ] 기존 E2E 테스트 깨지지 않음
+- [ ] 사이드바 그룹 open/close 상태 localStorage 영속 유지
+- [ ] 모바일 Sheet 사이드바 정상 동작
+
+---
+
+## 7. Risks and Mitigation
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| 라우트 변경 시 기존 북마크 깨짐 | High | Low | 라우트 변경 없이 사이드바 그룹핑만 변경 |
+| E2E 테스트 data-tour 속성 의존 | Medium | Medium | data-tour 속성은 유지하며 그룹 key만 변경 |
+| AXIS DS 토큰 미확정 | Medium | Medium | Sprint 84로 분리, 토큰 확정 후 진행 |
+| 온보딩 가이드가 기존 사용자에게 방해 | Low | Medium | "다시 보지 않기" 옵션 + localStorage 기억 |
+
+---
+
+## 8. Architecture Considerations
+
+### 8.1 Project Level
+
+| Level | Selected |
+|-------|:--------:|
+| **Dynamic** | ✅ |
+
+### 8.2 Key Decisions
+
+| Decision | Selected | Rationale |
+|----------|----------|-----------|
+| 라우트 변경 여부 | 변경 없음 | 기존 URL 호환성 + 최소 변경 원칙 |
+| 사이드바 구현 | 기존 sidebar.tsx 리팩토링 | 구조 동일, 데이터만 변경 |
+| 온보딩 저장 | localStorage | 서버 저장 불필요, 기존 패턴 재사용 |
+| AXIS DS 연동 | Tailwind 토큰 레벨 | npm 직접 의존 대신 디자인 토큰만 반영 |
+
+---
+
+## 9. Next Steps
+
+1. [ ] SPEC.md에 F241~F244 등록
+2. [ ] Design 문서 작성 (`ia-restructure.design.md`)
+3. [ ] Sprint 82 시작 (사이드바 IA 재구조화)
+
+---
+
+## Version History
+
+| Version | Date | Changes | Author |
+|---------|------|---------|--------|
+| 0.1 | 2026-03-30 | Initial draft | Sinclair Seo |

--- a/docs/02-design/features/ia-restructure.design.md
+++ b/docs/02-design/features/ia-restructure.design.md
@@ -1,0 +1,372 @@
+# Foundry-X IA 구조 개선 Design Document
+
+> **Summary**: 사이드바 IA 재구조화 + 온보딩 가이드 + UI/UX 개선 상세 설계
+>
+> **Project**: Foundry-X
+> **Plan**: [[ia-restructure.plan.md]]
+> **Author**: Sinclair Seo
+> **Date**: 2026-03-30
+> **Status**: Draft
+
+---
+
+## 1. Sprint 82: 사이드바 IA 재구조화 (F241)
+
+### 1.1 sidebar.tsx 데이터 구조 변경
+
+**변경 파일**: `packages/web/src/components/sidebar.tsx`
+
+기존 `navGroups` + `axBdGroup` + `utilItems` + `serviceGroup` 4개 데이터 구조를 **프로세스 6단계 기반 단일 배열**로 통합.
+
+```typescript
+// ── 새 사이드바 구조 ──
+
+const topItems: NavItem[] = [
+  { href: "/getting-started", label: "시작하기", icon: Rocket },
+  { href: "/dashboard", label: "홈", icon: LayoutDashboard },
+];
+
+const processGroups: NavGroup[] = [
+  {
+    key: "collect",
+    label: "1. 수집",
+    icon: Inbox,        // 기존 SR 그룹 아이콘 재사용
+    items: [
+      { href: "/sr", label: "SR 목록", icon: ClipboardList },
+      { href: "/discovery/collection", label: "수집 채널", icon: Radio },
+      { href: "/ir-proposals", label: "IR Bottom-up", icon: ArrowUpFromLine },
+    ],
+  },
+  {
+    key: "discover",
+    label: "2. 발굴",
+    icon: Search,
+    items: [
+      { href: "/ax-bd/discovery", label: "Discovery 프로세스", icon: Map },
+      { href: "/ax-bd/ideas", label: "아이디어 관리", icon: Lightbulb },
+      { href: "/ax-bd/bmc", label: "BMC", icon: Blocks },
+      { href: "/discovery-progress", label: "진행률", icon: BarChart3 },
+    ],
+  },
+  {
+    key: "shape",
+    label: "3. 형상화",
+    icon: PenTool,
+    items: [
+      { href: "/spec-generator", label: "Spec 생성", icon: FileText },
+      { href: "/ax-bd", label: "사업제안서", icon: FileSignature },
+      { href: "/offering-packs", label: "Offering Pack", icon: Package },
+    ],
+  },
+  {
+    key: "validate",
+    label: "4. 검증/공유",
+    icon: CheckCircle,
+    items: [
+      { href: "/pipeline", label: "파이프라인", icon: GitBranch },
+    ],
+  },
+  {
+    key: "productize",
+    label: "5. 제품화",
+    icon: Rocket,       // 다른 Rocket 인스턴스 — 구분 위해 다른 아이콘 고려
+    items: [
+      { href: "/mvp-tracking", label: "MVP 추적", icon: Target },
+    ],
+  },
+  {
+    key: "gtm",
+    label: "6. GTM",
+    icon: TrendingUp,
+    items: [
+      { href: "/projects", label: "프로젝트 현황", icon: FolderKanban },
+    ],
+  },
+];
+
+const knowledgeGroup: NavGroup = {
+  key: "knowledge",
+  label: "지식",
+  icon: BookOpen,
+  items: [
+    { href: "/wiki", label: "지식베이스", icon: BookOpen },
+    { href: "/methodologies", label: "방법론 관리", icon: Library },
+  ],
+};
+
+const adminGroup: NavGroup = {
+  key: "admin",
+  label: "관리",
+  icon: Settings,
+  items: [
+    { href: "/analytics", label: "Analytics", icon: BarChart3 },
+    { href: "/agents", label: "에이전트", icon: Bot },
+    { href: "/tokens", label: "토큰 비용", icon: Coins },
+    { href: "/architecture", label: "아키텍처", icon: Blocks },
+    { href: "/workspace", label: "내 작업", icon: FolderKanban },
+    { href: "/settings/jira", label: "설정", icon: Settings },
+  ],
+};
+
+const externalGroup: NavGroup = {
+  key: "external",
+  label: "외부 서비스",
+  icon: Link2,
+  items: [
+    { href: "/discovery", label: "Discovery-X", icon: Search },
+    { href: "/foundry", label: "AI Foundry", icon: FlaskConical },
+  ],
+};
+```
+
+### 1.2 NavLinks 렌더링 변경
+
+```tsx
+function NavLinks({ onSelect }: { onSelect?: () => void }) {
+  const pathname = usePathname();
+  const { openGroups, toggle } = useGroupState();
+
+  return (
+    <nav className="flex flex-col gap-0.5">
+      {/* 시작하기 + 홈 */}
+      {topItems.map((item) => (
+        <NavLink key={item.href} item={item} pathname={pathname} onSelect={onSelect} />
+      ))}
+
+      <div className="my-2 border-t border-border/40" />
+
+      {/* 프로세스 6단계 */}
+      {processGroups.map((group) => (
+        <CollapsibleGroup
+          key={group.key}
+          group={group}
+          pathname={pathname}
+          isOpen={openGroups.has(group.key)}
+          onToggle={() => toggle(group.key)}
+          onSelect={onSelect}
+        />
+      ))}
+
+      <div className="my-2 border-t border-border/40" />
+
+      {/* 지식 */}
+      <CollapsibleGroup
+        group={knowledgeGroup}
+        pathname={pathname}
+        isOpen={openGroups.has(knowledgeGroup.key)}
+        onToggle={() => toggle(knowledgeGroup.key)}
+        onSelect={onSelect}
+      />
+
+      {/* 관리 */}
+      <CollapsibleGroup
+        group={adminGroup}
+        pathname={pathname}
+        isOpen={openGroups.has(adminGroup.key)}
+        onToggle={() => toggle(adminGroup.key)}
+        onSelect={onSelect}
+      />
+
+      <div className="my-2 border-t border-border/40" />
+
+      {/* 외부 서비스 */}
+      <CollapsibleGroup
+        group={externalGroup}
+        pathname={pathname}
+        isOpen={openGroups.has(externalGroup.key)}
+        onToggle={() => toggle(externalGroup.key)}
+        onSelect={onSelect}
+      />
+
+      {/* 도움말 */}
+      <NavLink
+        item={{ href: "/getting-started", label: "도움말", icon: HelpCircle }}
+        pathname={pathname}
+        onSelect={onSelect}
+      />
+    </nav>
+  );
+}
+```
+
+### 1.3 localStorage 마이그레이션
+
+기존 그룹 키(`sr`, `dev`, `status`, `ax-bd`, `services`)가 새 키(`collect`, `discover`, `shape`, `validate`, `productize`, `gtm`, `knowledge`, `admin`, `external`)로 변경되므로, 기존 사용자의 열림/닫힘 상태가 초기화됨.
+
+**전략**: 새 기본값으로 프로세스 그룹 전체 펼침 + 관리/외부 접힘.
+
+```typescript
+const DEFAULT_OPEN = new Set(["collect", "discover", "shape", "validate", "productize", "gtm"]);
+```
+
+### 1.4 OnboardingTour 업데이트
+
+기존 `TOUR_STEPS`의 `target` 값이 변경된 그룹 키에 맞게 수정 필요:
+
+| 기존 target | 새 target | 설명 |
+|-------------|-----------|------|
+| `group-sr` | `group-collect` | 수집 |
+| `group-dev` | `group-shape` | 형상화 |
+| `group-status` | `group-validate` | 검증/공유 |
+
+**Tour 스텝 재구성** (6단계 프로세스 기반):
+
+```typescript
+const TOUR_STEPS: TourStep[] = [
+  { target: "getting-started", title: "🚀 시작하기", description: "..." },
+  { target: "dashboard", title: "🏠 홈", description: "프로세스 전체 진행률을 한눈에" },
+  { target: "group-collect", title: "📥 1. 수집", description: "SR, IR, 외부 채널에서 아이디어를 수집" },
+  { target: "group-discover", title: "🔍 2. 발굴", description: "아이디어를 분석하고 사업성 평가" },
+  { target: "group-shape", title: "📐 3. 형상화", description: "Spec과 사업제안서로 구체화" },
+  { target: "group-validate", title: "✅ 4~6. 검증→제품화→GTM", description: "게이트 통과, MVP 제작, 시장 진출" },
+  { target: "getting-started", title: "🎉 투어 완료!", description: "..." },
+];
+```
+
+### 1.5 `/ax-bd` 리다이렉트 변경
+
+현재 `/ax-bd`는 `/ax-bd/ideas`로 리다이렉트. 형상화 단계에서 "사업제안서"로 사용하므로 **BDP 편집 기능**이 있는 페이지로 변경하거나, 현재 리다이렉트를 유지.
+
+**결정**: Sprint 80에서 만든 BDP 편집 기능이 `/ax-bd` 하위에 이미 라우트가 있을 수 있으므로 확인 필요. 없다면 리다이렉트를 `/ax-bd/ideas`로 유지하고, 사이드바 label만 "사업제안서"로 표기.
+
+### 1.6 변경 영향 분석
+
+| 파일 | 변경 유형 | 영향 |
+|------|-----------|------|
+| `sidebar.tsx` | 데이터 구조 전면 변경 | 핵심 변경 |
+| `OnboardingTour.tsx` | target 키 + 스텝 내용 변경 | 연동 변경 |
+| E2E 테스트 (`dashboard.spec.ts` 등) | `data-tour` 셀렉터 변경 | 테스트 수정 |
+| `globals.css` | 변경 없음 | - |
+| 각 page.tsx | 변경 없음 (라우트 유지) | - |
+
+---
+
+## 2. Sprint 83: 온보딩 가이드 강화 (F242 + F243)
+
+### 2.1 ProcessStageGuide 컴포넌트 (F242)
+
+**신규 파일**: `packages/web/src/components/feature/ProcessStageGuide.tsx`
+
+각 프로세스 단계 페이지 진입 시 표시하는 안내 카드. localStorage 기반 "다시 보지 않기" 지원.
+
+```typescript
+interface ProcessStageGuideProps {
+  stage: 1 | 2 | 3 | 4 | 5 | 6;
+  title: string;
+  description: string;
+  agentHelp: string;      // "이 단계에서 Agent가 도와주는 일"
+  nextAction: {
+    label: string;
+    href: string;
+  };
+}
+```
+
+**동작**:
+1. 페이지 첫 진입 시 상단에 안내 카드 표시
+2. `localStorage`에 `fx-stage-guide-{stage}` 키로 완료 여부 저장
+3. "다시 보지 않기" 클릭 시 숨김, "가이드 다시 보기" 링크로 복원
+4. 카드 내용은 각 page.tsx에서 props로 전달 (하드코딩 아님)
+
+### 2.2 대시보드 홈 재설계 (F243)
+
+**변경 파일**: `packages/web/src/app/(app)/dashboard/page.tsx`
+
+현재: SDD Triangle Health Score + 요구사항 + 하네스 무결성 + 신선도
+변경: **프로세스 파이프라인 진행률** 중심 + 기존 위젯은 하단 보조
+
+```
+┌─────────────────────────────────────────────────┐
+│ 프로세스 파이프라인 (가로 스테퍼)                   │
+│ 📥 수집 → 🔍 발굴 → 📐 형상화 → ✅ 검증         │
+│  (N건)     (N건)     (N건)       (N건)           │
+│ → 🚀 제품화 → 📈 GTM                             │
+├─────────────────────────────────────────────────┤
+│ 퀵 액션              │ Sprint Status             │
+│ [SR 등록]            │ Done / In Progress /      │
+│ [아이디어 추가]       │ Planned                   │
+│ [Spec 생성]          │                            │
+│ [파이프라인]          │                            │
+├─────────────────────────────────────────────────┤
+│ SDD Triangle         │ Harness Health             │
+│ Harness Freshness    │                            │
+└─────────────────────────────────────────────────┘
+```
+
+**구현 특이사항**:
+- `STAGES` 배열을 `ProcessStageGuide.tsx`에서 import하여 파이프라인 뷰에서 재사용 (DRY)
+- "최근 활동" 영역은 별도 Sprint으로 분리 (scope-out)
+
+**데이터 소스**: 기존 API `/pipeline/stats`에서 `byStage` 데이터 활용.
+
+### 2.3 Getting Started 재구성 (scope-out → 별도 Sprint)
+
+> **결정**: 기존 getting-started 페이지의 3대 업무 동선 + 5탭 구조는 이미 충분히 기능하므로, 6단계 플로우 차트 재구성은 온보딩 피드백 수집 후 별도 Sprint에서 진행.
+
+---
+
+## 3. Sprint 84: AXIS DS 기반 UI/UX 개선 (F244)
+
+### 3.1 기존 AXIS DS 토큰 활용
+
+`globals.css`에 이미 AXIS semantic colors가 정의되어 있음:
+- `--axis-primary`, `--axis-blue`, `--axis-green`, `--axis-violet`, `--axis-warm`
+
+### 3.2 사이드바 비주얼 개선
+
+- 프로세스 단계 번호 뱃지 (원형, AXIS 색상)
+- 그룹 헤더에 단계 번호 + 아이콘 조합
+- 활성 단계 하이라이트 (왼쪽 바 또는 배경색)
+
+```
+프로세스 단계별 AXIS 색상 매핑 (Tailwind utility class 방식):
+1. 수집    → bg-axis-blue    (oklch 0.623 0.214 259.815)
+2. 발굴    → bg-axis-violet  (oklch 0.58 0.2 290)
+3. 형상화  → bg-axis-warm    (oklch 0.65 0.16 55)
+4. 검증    → bg-axis-green   (oklch 0.62 0.17 145)
+5. 제품화  → bg-axis-indigo  (oklch 0.55 0.22 270)
+6. GTM    → bg-axis-rose    (oklch 0.60 0.19 15)
+```
+
+**구현 방식**: CSS `[data-stage]` selector 대신 `stageColor` prop을 통해 Tailwind utility 직접 적용. dark 모드 토큰은 globals.css에서 자동 전환.
+
+### 3.3 카드/레이아웃 통일
+
+- `elevation` 통일: 카드는 `shadow-sm` + `border` (기존 shadcn/ui 유지)
+- `border-radius` 통일: `rounded-lg` (12px)
+- 간격 시스템: Tailwind 기본 (4px 배수) — AXIS 토큰과 동일
+
+---
+
+## 4. 구현 순서 체크리스트
+
+### Sprint 82 (F241)
+- [ ] sidebar.tsx 데이터 구조 변경 (processGroups 배열)
+- [ ] NavLinks 렌더링 로직 업데이트
+- [ ] 새 아이콘 import 추가 (Radio, ArrowUpFromLine, PenTool, etc.)
+- [ ] useGroupState 기본값 변경
+- [ ] OnboardingTour.tsx target/content 업데이트
+- [ ] E2E 테스트 data-tour 셀렉터 업데이트
+- [ ] typecheck + lint 통과 확인
+
+### Sprint 83 (F242 + F243)
+- [x] ProcessStageGuide.tsx 컴포넌트 제작 (경로 자동 감지 방식, layout.tsx 전역 적용)
+- [x] layout.tsx에 ProcessStageGuide 통합 (각 page.tsx 개별 수정 불필요)
+- [x] dashboard/page.tsx 프로세스 파이프라인 뷰 + 퀵 액션 추가
+- [ ] ~~getting-started/page.tsx 6단계 플로우 차트 재구성~~ (scope-out → 별도 Sprint)
+- [x] E2E 테스트 갱신 (dashboard.spec.ts)
+
+### Sprint 84 (F244)
+- [x] AXIS 색상 토큰을 단계별로 매핑 (globals.css에 indigo/rose 추가)
+- [x] 사이드바 단계 번호 뱃지 추가 (stageColor prop + 원형 번호 뱃지)
+- [x] 활성 단계 좌측 border 하이라이트
+- [x] 카드/레이아웃 일관성 유지 (기존 shadcn/ui 기반)
+- [x] typecheck 통과
+
+---
+
+## Version History
+
+| Version | Date | Changes | Author |
+|---------|------|---------|--------|
+| 0.1 | 2026-03-30 | Initial draft | Sinclair Seo |

--- a/docs/04-report/features/ia-restructure.report.md
+++ b/docs/04-report/features/ia-restructure.report.md
@@ -1,0 +1,119 @@
+# Foundry-X IA 구조 개선 — 완료 보고서
+
+> **Feature**: ia-restructure
+> **Sprint**: 82~84 (F241~F244)
+> **Author**: Sinclair Seo
+> **Date**: 2026-03-30
+> **Status**: Completed
+
+---
+
+## Executive Summary
+
+| 항목 | 내용 |
+|------|------|
+| **Feature** | IA 구조 개선 (사이드바 + 온보딩 + UI/UX) |
+| **기간** | 2026-03-30 (단일 세션) |
+| **Sprint** | 82 (F241), 83 (F242+F243), 84 (F244) |
+| **Match Rate** | 79% → **~93%** (Gap 해소 후) |
+
+### Value Delivered
+
+| Perspective | Content |
+|-------------|---------|
+| **Problem** | 사이드바가 개발자 관점으로 구성, Phase 7 페이지 4건 누락, Discovery 3곳 분산 |
+| **Solution** | AX BD 프로세스 6단계 기반 사이드바 재구성 + 온보딩 가이드 + AXIS DS 색상 뱃지 |
+| **Function/UX Effect** | 사이드바 노출 페이지 18→24개, 프로세스 동선 직관화, 신규 팀원 자기주도 학습 지원 |
+| **Core Value** | "프로세스가 곧 네비게이션" — 도구 사용이 곧 프로세스 학습 |
+
+---
+
+## 1. 구현 결과
+
+### 1.1 Sprint 82 — F241 사이드바 IA 재구조화
+
+| 항목 | Before | After |
+|------|--------|-------|
+| 사이드바 그룹 구조 | SR관리/개발/현황/AX BD (4그룹) | 수집/발굴/형상화/검증/제품화/GTM (6단계) + 지식/관리/외부 |
+| 사이드바 노출 페이지 | 18개 | **24개** |
+| 누락 페이지 | pipeline, ir-proposals, offering-packs, mvp-tracking | **0개** (전부 통합) |
+| Discovery 분산 | 3곳 | **1곳** (발굴 그룹) |
+| 개발자 도구 위치 | 메인 동선 | **관리 그룹** 하위 |
+
+**변경 파일**: `sidebar.tsx`, `OnboardingTour.tsx`
+
+### 1.2 Sprint 83 — F242 온보딩 가이드 + F243 대시보드
+
+| 항목 | 구현 |
+|------|------|
+| ProcessStageGuide | 경로 자동 감지 + localStorage dismiss + layout.tsx 전역 적용 |
+| STAGES 데이터 | 6단계 정보 중앙 정의, 대시보드에서 재사용 |
+| 대시보드 | 프로세스 파이프라인 진행률 (상단) + 퀵 액션 4개 + 기존 위젯 (하단) |
+| ResetStageGuides | 가이드 초기화 컴포넌트 (설정에서 사용 가능) |
+
+**신규 파일**: `ProcessStageGuide.tsx`
+**변경 파일**: `layout.tsx`, `dashboard/page.tsx`
+
+### 1.3 Sprint 84 — F244 AXIS DS 기반 UI/UX
+
+| 항목 | 구현 |
+|------|------|
+| AXIS 색상 토큰 | globals.css에 indigo/rose 추가 (light + dark) |
+| 단계 번호 뱃지 | stageColor prop → 원형 숫자 뱃지 (AXIS 색상) |
+| 활성 단계 하이라이트 | 좌측 border 색상 변경 |
+| 색상 매핑 | blue/violet/warm/green/indigo/rose (6색) |
+
+**변경 파일**: `sidebar.tsx`, `globals.css`
+
+---
+
+## 2. 변경 파일 요약
+
+| 파일 | Sprint | 유형 |
+|------|--------|------|
+| `packages/web/src/components/sidebar.tsx` | 82, 84 | 수정 |
+| `packages/web/src/components/feature/OnboardingTour.tsx` | 82 | 수정 |
+| `packages/web/src/components/feature/ProcessStageGuide.tsx` | 83 | **신규** |
+| `packages/web/src/app/(app)/layout.tsx` | 83 | 수정 |
+| `packages/web/src/app/(app)/dashboard/page.tsx` | 83 | 수정 |
+| `packages/web/src/app/globals.css` | 84 | 수정 |
+| `packages/web/e2e/dashboard.spec.ts` | Act | 수정 |
+| `docs/01-plan/features/ia-restructure.plan.md` | Plan | 신규 |
+| `docs/02-design/features/ia-restructure.design.md` | Design | 신규 |
+
+---
+
+## 3. 품질 검증
+
+| 검증 항목 | 결과 |
+|-----------|------|
+| typecheck (tsc --noEmit) | ✅ 통과 |
+| 라우트 변경 | 없음 (기존 URL 100% 유지) |
+| E2E 테스트 | ✅ 프로세스 6단계 기준으로 갱신 |
+| Match Rate | 79% → ~93% (Design 현행화 후) |
+
+---
+
+## 4. Scope-out 항목 (후속 Sprint)
+
+| 항목 | 사유 | 권장 시점 |
+|------|------|-----------|
+| getting-started 6단계 플로우 차트 | 기존 5탭 구조 충분, 온보딩 피드백 후 결정 | F114 온보딩 킥오프 후 |
+| Dashboard "최근 활동" 영역 | API 설계 필요, 현재 퀵 액션으로 대체 | 다음 Sprint |
+| 카드 컴포넌트 리디자인 | 기존 shadcn/ui 일관성 유지 중 | AXIS DS 고도화 시 |
+
+---
+
+## 5. PDCA 흐름
+
+```
+[Plan] ✅ → [Design] ✅ → [Do] ✅ → [Check] ✅ 93% → [Act] ✅ → [Report] ✅
+```
+
+---
+
+## Version History
+
+| Version | Date | Changes | Author |
+|---------|------|---------|--------|
+| 1.0 | 2026-03-30 | 완료 보고서 작성 | Sinclair Seo |

--- a/packages/web/e2e/dashboard.spec.ts
+++ b/packages/web/e2e/dashboard.spec.ts
@@ -4,7 +4,7 @@ test.describe("Dashboard", () => {
   test("sidebar navigation is visible", async ({ authenticatedPage: page }) => {
     await page.goto("/dashboard");
 
-    // Sidebar nav items (desktop viewport) — IA 재설계 후 한국어 레이블
+    // 프로세스 6단계 기반 IA — 상단 + 관리 그룹 항목
     await expect(page.getByRole("link", { name: "홈" }).first()).toBeVisible();
     await expect(page.getByRole("link", { name: "에이전트" })).toBeVisible();
     await expect(page.getByRole("link", { name: "지식베이스" })).toBeVisible();
@@ -12,28 +12,29 @@ test.describe("Dashboard", () => {
     await expect(page.getByRole("link", { name: "아키텍처" })).toBeVisible();
   });
 
-  test("sidebar AX BD 그룹 + 현황 그룹 항목 확인", async ({ authenticatedPage: page }) => {
+  test("sidebar 프로세스 6단계 그룹 항목 확인", async ({ authenticatedPage: page }) => {
     await page.goto("/dashboard");
 
-    // AX BD 사업개발 그룹 펼치기 (기본 접힘)
-    const axBdGroup = page.getByText("AX BD 사업개발");
-    if (await axBdGroup.isVisible({ timeout: 3000 }).catch(() => false)) {
-      await axBdGroup.click();
-      await expect(page.getByRole("link", { name: "아이디어 관리" })).toBeVisible();
-      await expect(page.getByRole("link", { name: "BMC" })).toBeVisible();
-    }
+    // 수집 그룹 (기본 펼침)
+    await expect(page.getByRole("link", { name: "SR 목록" })).toBeVisible();
 
-    // 현황 그룹 (기본 펼침)
-    await expect(page.getByRole("link", { name: "Discovery 진행률" })).toBeVisible();
-    await expect(page.getByRole("link", { name: "방법론 관리" })).toBeVisible();
-    await expect(page.getByRole("link", { name: "Analytics" })).toBeVisible();
+    // 발굴 그룹 (기본 펼침)
+    await expect(page.getByRole("link", { name: "아이디어 관리" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "BMC" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "진행률" })).toBeVisible();
+
+    // 형상화 그룹 (기본 펼침)
+    await expect(page.getByRole("link", { name: "Spec 생성" })).toBeVisible();
+
+    // 검증/공유 그룹 (기본 펼침)
+    await expect(page.getByRole("link", { name: "파이프라인" })).toBeVisible();
   });
 
   test("dashboard heading is visible", async ({ authenticatedPage: page }) => {
     await page.goto("/dashboard");
 
     await expect(
-      page.getByRole("heading", { name: /Foundry-X Dashboard/i }),
+      page.getByRole("heading", { name: /홈/i }),
     ).toBeVisible();
   });
 });

--- a/packages/web/src/app/(app)/dashboard/page.tsx
+++ b/packages/web/src/app/(app)/dashboard/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { fetchApi } from "@/lib/api-client";
 import type {
   HealthScore,
@@ -10,7 +11,20 @@ import type {
 } from "@foundry-x/shared";
 import DashboardCard from "@/components/feature/DashboardCard";
 import HarnessHealth from "@/components/feature/HarnessHealth";
+import { STAGES } from "@/components/feature/ProcessStageGuide";
 import { cn } from "@/lib/utils";
+import {
+  ArrowRight,
+  ClipboardList,
+  Lightbulb,
+  FileText,
+  GitBranch,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+/* ------------------------------------------------------------------ */
+/*  Hooks                                                              */
+/* ------------------------------------------------------------------ */
 
 interface AsyncState<T> {
   data: T | null;
@@ -50,11 +64,112 @@ const gradeClass = (grade: string) => {
   return "text-destructive";
 };
 
+/* ------------------------------------------------------------------ */
+/*  프로세스 파이프라인 진행률                                          */
+/* ------------------------------------------------------------------ */
+
+interface PipelineStats {
+  totalItems: number;
+  byStage: Record<string, number>;
+  avgDaysInStage: Record<string, number>;
+}
+
+const stageColors = [
+  "bg-blue-500",
+  "bg-violet-500",
+  "bg-amber-500",
+  "bg-green-500",
+  "bg-indigo-500",
+  "bg-rose-500",
+];
+
+function ProcessPipeline({ stats }: { stats: PipelineStats | null }) {
+  return (
+    <div className="rounded-lg border bg-card p-5">
+      <h2 className="mb-4 text-sm font-semibold text-muted-foreground">
+        프로세스 파이프라인
+      </h2>
+      <div className="flex items-center gap-1">
+        {STAGES.map((stage, i) => {
+          const count = stats?.byStage?.[stage.label] ?? 0;
+          return (
+            <div key={stage.stage} className="flex items-center">
+              <Link
+                href={stage.paths[0]}
+                className="group flex flex-col items-center rounded-lg p-2 transition-colors hover:bg-muted"
+              >
+                <div
+                  className={cn(
+                    "flex size-10 items-center justify-center rounded-full text-white text-sm font-bold",
+                    stageColors[i],
+                  )}
+                >
+                  {count}
+                </div>
+                <span className="mt-1.5 text-[11px] font-medium text-muted-foreground group-hover:text-foreground">
+                  {stage.stage}. {stage.label}
+                </span>
+              </Link>
+              {i < STAGES.length - 1 && (
+                <ArrowRight className="mx-0.5 size-3.5 shrink-0 text-muted-foreground/40" />
+              )}
+            </div>
+          );
+        })}
+      </div>
+      {stats && (
+        <div className="mt-3 text-xs text-muted-foreground">
+          전체 {stats.totalItems}건 진행 중
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  퀵 액션                                                            */
+/* ------------------------------------------------------------------ */
+
+const quickActions = [
+  { label: "SR 등록", href: "/sr", icon: ClipboardList },
+  { label: "아이디어 추가", href: "/ax-bd/ideas", icon: Lightbulb },
+  { label: "Spec 생성", href: "/spec-generator", icon: FileText },
+  { label: "파이프라인", href: "/pipeline", icon: GitBranch },
+];
+
+function QuickActions() {
+  return (
+    <div className="rounded-lg border bg-card p-5">
+      <h2 className="mb-3 text-sm font-semibold text-muted-foreground">
+        퀵 액션
+      </h2>
+      <div className="grid grid-cols-2 gap-2">
+        {quickActions.map((action) => (
+          <Link key={action.href} href={action.href}>
+            <Button
+              variant="outline"
+              className="h-auto w-full justify-start gap-2 px-3 py-2.5"
+            >
+              <action.icon className="size-4 shrink-0" />
+              <span className="text-sm">{action.label}</span>
+            </Button>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Dashboard Page                                                     */
+/* ------------------------------------------------------------------ */
+
 export default function DashboardPage() {
   const health = useApi<HealthScore>("/health");
   const reqs = useApi<RequirementItem[]>("/requirements");
   const integrity = useApi<HarnessIntegrity>("/integrity");
   const freshness = useApi<FreshnessReport>("/freshness");
+  const pipelineStats = useApi<PipelineStats>("/pipeline/stats");
 
   const reqCounts = reqs.data
     ? {
@@ -66,10 +181,47 @@ export default function DashboardPage() {
 
   return (
     <div>
-      <h1 className="mb-6 text-2xl font-bold">Foundry-X Dashboard</h1>
+      <h1 className="mb-6 text-2xl font-bold">홈</h1>
 
-      <div className="grid gap-4 md:grid-cols-2">
-        {/* SDD Triangle */}
+      {/* 프로세스 파이프라인 (상단 메인) */}
+      <ProcessPipeline stats={pipelineStats.data} />
+
+      {/* 퀵 액션 + Sprint Status */}
+      <div className="mt-4 grid gap-4 md:grid-cols-2">
+        <QuickActions />
+
+        <DashboardCard
+          title="Sprint Status"
+          loading={reqs.loading}
+          error={reqs.error}
+        >
+          {reqCounts && (
+            <div className="flex gap-6">
+              <div className="text-center">
+                <div className="text-4xl font-bold text-green-500">
+                  {reqCounts.done}
+                </div>
+                <div className="text-sm text-muted-foreground">Done</div>
+              </div>
+              <div className="text-center">
+                <div className="text-4xl font-bold text-yellow-500">
+                  {reqCounts.inProgress}
+                </div>
+                <div className="text-sm text-muted-foreground">In Progress</div>
+              </div>
+              <div className="text-center">
+                <div className="text-4xl font-bold text-muted-foreground">
+                  {reqCounts.planned}
+                </div>
+                <div className="text-sm text-muted-foreground">Planned</div>
+              </div>
+            </div>
+          )}
+        </DashboardCard>
+      </div>
+
+      {/* 기존 위젯 (하단 보조) */}
+      <div className="mt-4 grid gap-4 md:grid-cols-2">
         <DashboardCard
           title="SDD Triangle"
           loading={health.loading}
@@ -107,37 +259,6 @@ export default function DashboardPage() {
           )}
         </DashboardCard>
 
-        {/* Sprint Status */}
-        <DashboardCard
-          title="Sprint Status"
-          loading={reqs.loading}
-          error={reqs.error}
-        >
-          {reqCounts && (
-            <div className="flex gap-6">
-              <div className="text-center">
-                <div className="text-4xl font-bold text-green-500">
-                  {reqCounts.done}
-                </div>
-                <div className="text-sm text-muted-foreground">Done</div>
-              </div>
-              <div className="text-center">
-                <div className="text-4xl font-bold text-yellow-500">
-                  {reqCounts.inProgress}
-                </div>
-                <div className="text-sm text-muted-foreground">In Progress</div>
-              </div>
-              <div className="text-center">
-                <div className="text-4xl font-bold text-muted-foreground">
-                  {reqCounts.planned}
-                </div>
-                <div className="text-sm text-muted-foreground">Planned</div>
-              </div>
-            </div>
-          )}
-        </DashboardCard>
-
-        {/* Harness Health */}
         <DashboardCard
           title="Harness Health"
           loading={integrity.loading}
@@ -146,7 +267,6 @@ export default function DashboardPage() {
           {integrity.data && <HarnessHealth data={integrity.data} />}
         </DashboardCard>
 
-        {/* Harness Freshness */}
         <DashboardCard
           title="Harness Freshness"
           loading={freshness.loading}

--- a/packages/web/src/app/(app)/layout.tsx
+++ b/packages/web/src/app/(app)/layout.tsx
@@ -1,6 +1,7 @@
 import { Sidebar } from "@/components/sidebar";
 import { OnboardingTour } from "@/components/feature/OnboardingTour";
 import { FeedbackWidget } from "@/components/feature/FeedbackWidget";
+import { ProcessStageGuide } from "@/components/feature/ProcessStageGuide";
 
 export default function AppLayout({
   children,
@@ -10,7 +11,10 @@ export default function AppLayout({
   return (
     <div className="flex min-h-screen">
       <Sidebar />
-      <main className="flex-1 overflow-auto p-4 lg:p-6">{children}</main>
+      <main className="flex-1 overflow-auto p-4 lg:p-6">
+        <ProcessStageGuide />
+        {children}
+      </main>
       <OnboardingTour />
       <FeedbackWidget />
     </div>

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -22,6 +22,8 @@
     --axis-green: oklch(0.62 0.17 145);
     --axis-violet: oklch(0.58 0.2 290);
     --axis-warm: oklch(0.65 0.16 55);
+    --axis-indigo: oklch(0.55 0.22 270);
+    --axis-rose: oklch(0.60 0.19 15);
 }
 
 .dark {
@@ -42,6 +44,8 @@
     --axis-green: oklch(0.68 0.15 145);
     --axis-violet: oklch(0.65 0.18 290);
     --axis-warm: oklch(0.70 0.14 55);
+    --axis-indigo: oklch(0.62 0.20 270);
+    --axis-rose: oklch(0.67 0.17 15);
 }
 
 @theme inline {
@@ -95,6 +99,8 @@
     --color-axis-green: var(--axis-green);
     --color-axis-violet: var(--axis-violet);
     --color-axis-warm: var(--axis-warm);
+    --color-axis-indigo: var(--axis-indigo);
+    --color-axis-rose: var(--axis-rose);
 }
 
 @layer base {

--- a/packages/web/src/components/feature/CoworkSetupGuide.tsx
+++ b/packages/web/src/components/feature/CoworkSetupGuide.tsx
@@ -25,33 +25,57 @@ const steps: Array<{
     description: "필수 도구가 설치되어 있는지 확인해요.",
     commands: {
       cowork: ["node --version  # v20 이상 필요", "cowork --version"],
-      "claude-code": ["node --version  # v20 이상 필요", "claude --version  # 최신 버전 권장"],
+      "claude-code": [
+        "node --version  # v20 이상 필요",
+        "claude --version  # 최신 버전 권장",
+        "gh auth status  # GitHub CLI 인증 확인",
+      ],
     },
   },
   {
     number: 2,
-    title: "플러그인 설치",
-    description: "AX BD 스킬 플러그인을 설치해요.",
+    title: "팀 스킬 설치",
+    description:
+      "KTDS-AXBD/ax-config 팀 리포에서 최신 스킬을 받아요.",
     commands: {
       cowork: ["cowork plugin install pm-skills ai-biz"],
       "claude-code": [
-        "# .claude/skills/ 디렉토리에 스킬 복사",
-        "cp -r /path/to/pm-skills .claude/skills/",
-        "cp -r /path/to/ai-biz .claude/skills/",
+        "# 팀 리포에서 스킬 받기",
+        "git clone git@github.com:KTDS-AXBD/ax-config.git /tmp/ax-config",
+        "cp -r /tmp/ax-config/skills/ax-* ~/.claude/skills/",
+        "rm -rf /tmp/ax-config",
       ],
     },
   },
   {
     number: 3,
     title: "설정 확인",
-    description: "설치된 플러그인이 정상 동작하는지 확인해요.",
+    description: "설치된 스킬이 정상 동작하는지 확인해요.",
     commands: {
       cowork: ["cowork plugin list", "cowork plugin verify pm-skills ai-biz"],
-      "claude-code": ["ls .claude/skills/", "claude /ax-help"],
+      "claude-code": [
+        "ls ~/.claude/skills/  # 20개 ax-* 스킬 확인",
+        "claude /ax-help  # 스킬 목록 + 사용법",
+      ],
     },
   },
   {
     number: 4,
+    title: "팀 스킬 업데이트",
+    description:
+      "새 스킬이 추가되거나 변경되면 팀 리포에서 다시 받아요.",
+    commands: {
+      cowork: ["cowork plugin update pm-skills ai-biz"],
+      "claude-code": [
+        "# 최신 스킬로 업데이트",
+        "git clone git@github.com:KTDS-AXBD/ax-config.git /tmp/ax-config",
+        "cp -r /tmp/ax-config/skills/ax-* ~/.claude/skills/",
+        "rm -rf /tmp/ax-config",
+      ],
+    },
+  },
+  {
+    number: 5,
     title: "첫 실행",
     description: "Discovery 프로세스를 시작해 보세요.",
     commands: {

--- a/packages/web/src/components/feature/OnboardingTour.tsx
+++ b/packages/web/src/components/feature/OnboardingTour.tsx
@@ -22,35 +22,42 @@ const TOUR_STEPS: TourStep[] = [
     target: "getting-started",
     title: "🚀 시작하기",
     description:
-      "궁금할 때 언제든 여기로 오세요. 업무별 퀵스타트와 가이드를 볼 수 있어요.",
+      "궁금할 때 언제든 여기로 오세요. AX BD 프로세스 가이드와 단계별 안내를 볼 수 있어요.",
     position: "right",
   },
   {
     target: "dashboard",
-    title: "📊 홈 대시보드",
+    title: "🏠 홈",
     description:
-      "프로젝트 전체 건강도를 한눈에 확인하세요. SDD Triangle 점수와 스프린트 현황이 표시돼요.",
+      "프로세스 전체 진행률과 최근 활동을 한눈에 확인하세요.",
     position: "right",
   },
   {
-    target: "group-sr",
-    title: "📥 SR 관리",
+    target: "group-collect",
+    title: "📥 1. 수집",
     description:
-      "고객 서비스 요청(SR)을 접수하고 AI가 자동 분류해요. SR 접수 → 분석 → 제안서의 첫 단계예요.",
+      "SR, IR, 외부 채널에서 사업 아이디어를 수집하는 첫 번째 단계예요.",
     position: "right",
   },
   {
-    target: "group-dev",
-    title: "📝 개발",
+    target: "group-discover",
+    title: "🔍 2. 발굴",
     description:
-      "아이디어를 Spec으로 변환하고, AI 에이전트가 작업을 수행해요. Spec 생성 → 에이전트 실행 동선이에요.",
+      "수집된 아이디어를 분석하고 사업성을 평가해요. Discovery 프로세스, BMC, 진행률을 확인하세요.",
     position: "right",
   },
   {
-    target: "group-status",
-    title: "📈 현황",
+    target: "group-shape",
+    title: "📐 3. 형상화",
     description:
-      "프로젝트 상태, KPI 지표, 토큰 비용을 모니터링하세요. 진행 중인 모든 것을 여기서 추적할 수 있어요.",
+      "검증된 아이디어를 Spec, 사업제안서, Offering Pack으로 구체화해요.",
+    position: "right",
+  },
+  {
+    target: "group-validate",
+    title: "✅ 4~6. 검증→제품화→GTM",
+    description:
+      "게이트 통과(ORB/PRB), MVP 제작, 시장 진출까지 나머지 단계를 진행하세요.",
     position: "right",
   },
   {

--- a/packages/web/src/components/feature/ProcessStageGuide.tsx
+++ b/packages/web/src/components/feature/ProcessStageGuide.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { usePathname } from "next/navigation";
+import Link from "next/link";
+import {
+  Inbox,
+  Search,
+  PenTool,
+  CheckCircle,
+  Rocket,
+  TrendingUp,
+  X,
+  ArrowRight,
+  Bot,
+  Eye,
+  EyeOff,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { LucideIcon } from "lucide-react";
+
+/* ------------------------------------------------------------------ */
+/*  프로세스 단계 정의 — 경로별 자동 매칭                                */
+/* ------------------------------------------------------------------ */
+
+interface StageInfo {
+  stage: number;
+  label: string;
+  icon: LucideIcon;
+  color: string;
+  description: string;
+  agentHelp: string;
+  nextAction: { label: string; href: string };
+  paths: string[]; // 이 단계에 해당하는 라우트 경로 목록
+}
+
+const STAGES: StageInfo[] = [
+  {
+    stage: 1,
+    label: "수집",
+    icon: Inbox,
+    color: "text-blue-500 bg-blue-500/10 border-blue-500/20",
+    description:
+      "고객 요청(SR), IR 제안, 외부 채널에서 사업 아이디어를 수집하는 단계예요. 다양한 출처에서 원석을 모으는 것이 목표예요.",
+    agentHelp:
+      "AI가 SR을 자동 분류하고, 유사 아이템을 감지하여 중복 등록을 방지해요.",
+    nextAction: { label: "아이디어 발굴로 이동", href: "/ax-bd/discovery" },
+    paths: ["/sr", "/discovery/collection", "/ir-proposals"],
+  },
+  {
+    stage: 2,
+    label: "발굴",
+    icon: Search,
+    color: "text-violet-500 bg-violet-500/10 border-violet-500/20",
+    description:
+      "수집된 아이디어를 5유형(I/M/P/T/S)으로 분류하고, Discovery 프로세스를 통해 사업성을 평가하는 단계예요.",
+    agentHelp:
+      "AI가 시장 분석, 경쟁사 조사, BMC 초안 자동 생성을 도와요. Six Hats 토론으로 다각도 검증도 가능해요.",
+    nextAction: { label: "Spec 형상화로 이동", href: "/spec-generator" },
+    paths: ["/ax-bd/discovery", "/ax-bd/ideas", "/ax-bd/bmc", "/discovery-progress"],
+  },
+  {
+    stage: 3,
+    label: "형상화",
+    icon: PenTool,
+    color: "text-amber-500 bg-amber-500/10 border-amber-500/20",
+    description:
+      "검증된 아이디어를 Spec 문서, 사업제안서, Offering Pack으로 구체화하는 단계예요.",
+    agentHelp:
+      "AI가 NL(자연어) 요구사항을 Spec으로 변환하고, 사업제안서 초안을 자동 생성해요.",
+    nextAction: { label: "파이프라인 검증으로", href: "/pipeline" },
+    paths: ["/spec-generator", "/ax-bd", "/offering-packs"],
+  },
+  {
+    stage: 4,
+    label: "검증/공유",
+    icon: CheckCircle,
+    color: "text-green-500 bg-green-500/10 border-green-500/20",
+    description:
+      "ORB/PRB 게이트를 통과하고, 산출물을 공유하여 팀과 의사결정자의 승인을 받는 단계예요.",
+    agentHelp:
+      "AI가 게이트 문서 패키지를 자동 수집하고, 산출물 공유 링크를 생성해요.",
+    nextAction: { label: "MVP 제작으로", href: "/mvp-tracking" },
+    paths: ["/pipeline"],
+  },
+  {
+    stage: 5,
+    label: "제품화",
+    icon: Rocket,
+    color: "text-indigo-500 bg-indigo-500/10 border-indigo-500/20",
+    description:
+      "승인된 아이템의 MVP를 제작하고, PoC 배포를 진행하는 단계예요.",
+    agentHelp:
+      "AI가 MVP 상태를 추적하고, 프로토타입 자동 생성 파이프라인을 지원해요.",
+    nextAction: { label: "GTM 준비로", href: "/projects" },
+    paths: ["/mvp-tracking"],
+  },
+  {
+    stage: 6,
+    label: "GTM",
+    icon: TrendingUp,
+    color: "text-rose-500 bg-rose-500/10 border-rose-500/20",
+    description:
+      "완성된 제품을 시장에 출시하고, 프로젝트 현황을 모니터링하는 최종 단계예요.",
+    agentHelp:
+      "AI가 KPI를 자동 수집하고, 프로젝트 건강도를 실시간으로 추적해요.",
+    nextAction: { label: "대시보드로", href: "/dashboard" },
+    paths: ["/projects"],
+  },
+];
+
+/* ------------------------------------------------------------------ */
+/*  경로로 현재 단계 찾기                                               */
+/* ------------------------------------------------------------------ */
+
+function findStage(pathname: string): StageInfo | null {
+  // 정확한 매칭 우선, 그 다음 prefix 매칭
+  for (const stage of STAGES) {
+    if (stage.paths.some((p) => pathname === p)) return stage;
+  }
+  for (const stage of STAGES) {
+    if (stage.paths.some((p) => pathname.startsWith(p + "/"))) return stage;
+  }
+  return null;
+}
+
+/* ------------------------------------------------------------------ */
+/*  ProcessStageGuide 컴포넌트                                         */
+/* ------------------------------------------------------------------ */
+
+const STORAGE_PREFIX = "fx-stage-guide-";
+
+export function ProcessStageGuide() {
+  const pathname = usePathname();
+  const stage = findStage(pathname);
+  const [dismissed, setDismissed] = useState(true); // 기본 숨김 → hydrate 후 표시
+
+  useEffect(() => {
+    if (!stage) return;
+    const key = STORAGE_PREFIX + stage.stage;
+    setDismissed(localStorage.getItem(key) === "dismissed");
+  }, [stage]);
+
+  if (!stage || dismissed) return null;
+
+  const dismiss = () => {
+    localStorage.setItem(STORAGE_PREFIX + stage.stage, "dismissed");
+    setDismissed(true);
+  };
+
+  const colorParts = stage.color.split(" ");
+
+  return (
+    <div
+      className={cn(
+        "mb-6 rounded-lg border p-4",
+        colorParts[1], // bg
+        colorParts[2], // border
+      )}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-start gap-3">
+          <div
+            className={cn(
+              "mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-full",
+              colorParts[1],
+            )}
+          >
+            <stage.icon className={cn("size-4", colorParts[0])} />
+          </div>
+          <div className="min-w-0">
+            <h3 className="text-sm font-semibold">
+              {stage.stage}단계: {stage.label}
+            </h3>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {stage.description}
+            </p>
+            <div className="mt-3 flex items-start gap-2 rounded-md bg-background/60 p-2.5">
+              <Bot className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+              <p className="text-xs text-muted-foreground">
+                <span className="font-medium text-foreground">Agent 도움:</span>{" "}
+                {stage.agentHelp}
+              </p>
+            </div>
+            <div className="mt-3 flex items-center gap-2">
+              <Link href={stage.nextAction.href}>
+                <Button size="sm" variant="outline" className="h-7 text-xs">
+                  {stage.nextAction.label}
+                  <ArrowRight className="ml-1 size-3" />
+                </Button>
+              </Link>
+            </div>
+          </div>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-6 shrink-0"
+          onClick={dismiss}
+          title="다시 보지 않기"
+        >
+          <X className="size-3.5" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  가이드 다시 보기 버튼 (설정 또는 도움말에서 사용)                     */
+/* ------------------------------------------------------------------ */
+
+export function ResetStageGuides() {
+  const [hidden, setHidden] = useState(false);
+
+  const reset = () => {
+    for (let i = 1; i <= 6; i++) {
+      localStorage.removeItem(STORAGE_PREFIX + i);
+    }
+    setHidden(true);
+    setTimeout(() => setHidden(false), 2000);
+  };
+
+  return (
+    <Button variant="outline" size="sm" onClick={reset} disabled={hidden}>
+      {hidden ? (
+        <>
+          <Eye className="mr-2 size-4" />
+          가이드 초기화 완료
+        </>
+      ) : (
+        <>
+          <EyeOff className="mr-2 size-4" />
+          단계별 가이드 다시 보기
+        </>
+      )}
+    </Button>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  프로세스 단계 요약 데이터 (대시보드 등에서 사용)                      */
+/* ------------------------------------------------------------------ */
+
+export { STAGES };
+export type { StageInfo };

--- a/packages/web/src/components/sidebar.tsx
+++ b/packages/web/src/components/sidebar.tsx
@@ -23,12 +23,19 @@ import {
   HelpCircle,
   Link2,
   Inbox,
-  Code2,
   TrendingUp,
   Settings,
   Map,
   Lightbulb,
-  Layers,
+  Radio,
+  ArrowUpFromLine,
+  PenTool,
+  FileSignature,
+  Package,
+  CheckCircle,
+  GitBranch,
+  Target,
+  Library,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -45,7 +52,7 @@ import { OrgSwitcher } from "@/components/feature/OrgSwitcher";
 import type { LucideIcon } from "lucide-react";
 
 /* ------------------------------------------------------------------ */
-/*  Navigation Structure — 3대 업무 동선 기반 그룹                      */
+/*  Navigation Structure — AX BD 프로세스 6단계 기반 그룹               */
 /* ------------------------------------------------------------------ */
 
 interface NavItem {
@@ -59,6 +66,7 @@ interface NavGroup {
   label: string;
   icon: LucideIcon;
   items: NavItem[];
+  stageColor?: string; // 프로세스 단계 그룹에만 사용 — AXIS 색상 뱃지
 }
 
 const topItems: NavItem[] = [
@@ -66,57 +74,98 @@ const topItems: NavItem[] = [
   { href: "/dashboard", label: "홈", icon: LayoutDashboard },
 ];
 
-const navGroups: NavGroup[] = [
+/* ── 프로세스 6단계: 수집→발굴→형상화→검증/공유→제품화→GTM ── */
+
+const processGroups: NavGroup[] = [
   {
-    key: "sr",
-    label: "SR 관리",
+    key: "collect",
+    label: "1. 수집",
     icon: Inbox,
+    stageColor: "bg-axis-blue",
     items: [
       { href: "/sr", label: "SR 목록", icon: ClipboardList },
+      { href: "/discovery/collection", label: "수집 채널", icon: Radio },
+      { href: "/ir-proposals", label: "IR Bottom-up", icon: ArrowUpFromLine },
     ],
   },
   {
-    key: "dev",
-    label: "개발",
-    icon: Code2,
+    key: "discover",
+    label: "2. 발굴",
+    icon: Search,
+    stageColor: "bg-axis-violet",
+    items: [
+      { href: "/ax-bd/discovery", label: "Discovery 프로세스", icon: Map },
+      { href: "/ax-bd/ideas", label: "아이디어 관리", icon: Lightbulb },
+      { href: "/ax-bd/bmc", label: "BMC", icon: Blocks },
+      { href: "/discovery-progress", label: "진행률", icon: BarChart3 },
+    ],
+  },
+  {
+    key: "shape",
+    label: "3. 형상화",
+    icon: PenTool,
+    stageColor: "bg-axis-warm",
     items: [
       { href: "/spec-generator", label: "Spec 생성", icon: FileText },
-      { href: "/agents", label: "에이전트", icon: Bot },
+      { href: "/ax-bd", label: "사업제안서", icon: FileSignature },
+      { href: "/offering-packs", label: "Offering Pack", icon: Package },
     ],
   },
   {
-    key: "status",
-    label: "현황",
+    key: "validate",
+    label: "4. 검증/공유",
+    icon: CheckCircle,
+    stageColor: "bg-axis-green",
+    items: [
+      { href: "/pipeline", label: "파이프라인", icon: GitBranch },
+    ],
+  },
+  {
+    key: "productize",
+    label: "5. 제품화",
+    icon: Rocket,
+    stageColor: "bg-axis-indigo",
+    items: [
+      { href: "/mvp-tracking", label: "MVP 추적", icon: Target },
+    ],
+  },
+  {
+    key: "gtm",
+    label: "6. GTM",
     icon: TrendingUp,
+    stageColor: "bg-axis-rose",
     items: [
       { href: "/projects", label: "프로젝트 현황", icon: FolderKanban },
-      { href: "/discovery-progress", label: "Discovery 진행률", icon: Search },
-      { href: "/methodologies", label: "방법론 관리", icon: Settings },
-      { href: "/analytics", label: "Analytics", icon: BarChart3 },
-      { href: "/tokens", label: "토큰 비용", icon: Coins },
     ],
   },
 ];
 
-const axBdGroup: NavGroup = {
-  key: "ax-bd",
-  label: "AX BD 사업개발",
-  icon: Layers,
+const knowledgeGroup: NavGroup = {
+  key: "knowledge",
+  label: "지식",
+  icon: BookOpen,
   items: [
-    { href: "/ax-bd/discovery", label: "Discovery 프로세스", icon: Map },
-    { href: "/ax-bd/ideas", label: "아이디어 관리", icon: Lightbulb },
-    { href: "/ax-bd/bmc", label: "BMC", icon: Blocks },
+    { href: "/wiki", label: "지식베이스", icon: BookOpen },
+    { href: "/methodologies", label: "방법론 관리", icon: Library },
   ],
 };
 
-const utilItems: NavItem[] = [
-  { href: "/wiki", label: "지식베이스", icon: BookOpen },
-  { href: "/architecture", label: "아키텍처", icon: Blocks },
-  { href: "/workspace", label: "내 작업", icon: FolderKanban },
-];
+const adminGroup: NavGroup = {
+  key: "admin",
+  label: "관리",
+  icon: Settings,
+  items: [
+    { href: "/analytics", label: "Analytics", icon: BarChart3 },
+    { href: "/agents", label: "에이전트", icon: Bot },
+    { href: "/tokens", label: "토큰 비용", icon: Coins },
+    { href: "/architecture", label: "아키텍처", icon: Blocks },
+    { href: "/workspace", label: "내 작업", icon: FolderKanban },
+    { href: "/settings/jira", label: "설정", icon: Settings },
+  ],
+};
 
-const serviceGroup: NavGroup = {
-  key: "services",
+const externalGroup: NavGroup = {
+  key: "external",
   label: "외부 서비스",
   icon: Link2,
   items: [
@@ -133,7 +182,7 @@ const STORAGE_KEY = "fx-sidebar-groups";
 
 function useGroupState() {
   const [openGroups, setOpenGroups] = useState<Set<string>>(
-    () => new Set(["sr", "dev", "status"]), // 기본 전체 펼침
+    () => new Set(["collect", "discover", "shape", "validate", "productize", "gtm"]), // 프로세스 6단계 기본 펼침
   );
 
   useEffect(() => {
@@ -171,7 +220,7 @@ function NavLink({
   pathname: string;
   onSelect?: () => void;
 }) {
-  const active = pathname === item.href;
+  const active = pathname === item.href || pathname.startsWith(item.href + "/");
   return (
     <Link
       href={item.href}
@@ -203,7 +252,7 @@ function CollapsibleGroup({
   onToggle: () => void;
   onSelect?: () => void;
 }) {
-  const hasActive = group.items.some((item) => pathname === item.href);
+  const hasActive = group.items.some((item) => pathname === item.href || pathname.startsWith(item.href + "/"));
 
   return (
     <div data-tour={`group-${group.key}`}>
@@ -217,7 +266,18 @@ function CollapsibleGroup({
             : "text-muted-foreground hover:bg-muted/50 hover:text-foreground",
         )}
       >
-        <group.icon className="size-4 shrink-0" />
+        {group.stageColor ? (
+          <span
+            className={cn(
+              "flex size-5 shrink-0 items-center justify-center rounded-full text-[10px] font-bold text-white",
+              group.stageColor,
+            )}
+          >
+            {group.label.charAt(0)}
+          </span>
+        ) : (
+          <group.icon className="size-4 shrink-0" />
+        )}
         <span className="flex-1 text-left">{group.label}</span>
         <ChevronRight
           className={cn(
@@ -227,7 +287,12 @@ function CollapsibleGroup({
         />
       </button>
       {isOpen && (
-        <div className="ml-4 flex flex-col gap-0.5 border-l border-border/40 pl-2">
+        <div className={cn(
+          "ml-4 flex flex-col gap-0.5 border-l pl-2",
+          group.stageColor && hasActive
+            ? `border-l-2 ${group.stageColor.replace("bg-", "border-")}`
+            : "border-border/40",
+        )}>
           {group.items.map((item) => (
             <NavLink
               key={item.href}
@@ -246,10 +311,12 @@ function NavLinks({ onSelect }: { onSelect?: () => void }) {
   const pathname = usePathname();
   const { openGroups, toggle } = useGroupState();
 
+  const allGroups = [...processGroups, knowledgeGroup, adminGroup, externalGroup];
+
   // 활성 경로가 포함된 그룹은 자동 펼침
   useEffect(() => {
-    for (const group of [...navGroups, axBdGroup, serviceGroup]) {
-      if (group.items.some((item) => pathname === item.href)) {
+    for (const group of allGroups) {
+      if (group.items.some((item) => pathname === item.href || pathname.startsWith(item.href + "/"))) {
         if (!openGroups.has(group.key)) {
           toggle(group.key);
         }
@@ -274,8 +341,8 @@ function NavLinks({ onSelect }: { onSelect?: () => void }) {
       {/* 구분선 */}
       <div className="my-2 border-t border-border/40" />
 
-      {/* 3대 업무 동선 그룹 */}
-      {navGroups.map((group) => (
+      {/* 프로세스 6단계 */}
+      {processGroups.map((group) => (
         <CollapsibleGroup
           key={group.key}
           group={group}
@@ -286,37 +353,36 @@ function NavLinks({ onSelect }: { onSelect?: () => void }) {
         />
       ))}
 
-      {/* AX BD 사업개발 */}
+      {/* 구분선 */}
+      <div className="my-2 border-t border-border/40" />
+
+      {/* 지식 */}
       <CollapsibleGroup
-        group={axBdGroup}
+        group={knowledgeGroup}
         pathname={pathname}
-        isOpen={openGroups.has(axBdGroup.key)}
-        onToggle={() => toggle(axBdGroup.key)}
+        isOpen={openGroups.has(knowledgeGroup.key)}
+        onToggle={() => toggle(knowledgeGroup.key)}
+        onSelect={onSelect}
+      />
+
+      {/* 관리 */}
+      <CollapsibleGroup
+        group={adminGroup}
+        pathname={pathname}
+        isOpen={openGroups.has(adminGroup.key)}
+        onToggle={() => toggle(adminGroup.key)}
         onSelect={onSelect}
       />
 
       {/* 구분선 */}
       <div className="my-2 border-t border-border/40" />
 
-      {/* 유틸리티 메뉴 */}
-      {utilItems.map((item) => (
-        <NavLink
-          key={item.href}
-          item={item}
-          pathname={pathname}
-          onSelect={onSelect}
-        />
-      ))}
-
-      {/* 구분선 */}
-      <div className="my-2 border-t border-border/40" />
-
-      {/* 외부 서비스 그룹 */}
+      {/* 외부 서비스 */}
       <CollapsibleGroup
-        group={serviceGroup}
+        group={externalGroup}
         pathname={pathname}
-        isOpen={openGroups.has(serviceGroup.key)}
-        onToggle={() => toggle(serviceGroup.key)}
+        isOpen={openGroups.has(externalGroup.key)}
+        onToggle={() => toggle(externalGroup.key)}
         onSelect={onSelect}
       />
 


### PR DESCRIPTION
## Summary
- getting-started?tab=setup 의 설치 가이드를 KTDS-AXBD/ax-config 팀 리포 기반으로 갱신
- Step 2: git clone으로 팀 스킬 설치 (기존 /path/to/ 플레이스홀더 교체)
- Step 4: "팀 스킬 업데이트" 단계 신규 추가
- Step 1: gh auth status 확인 추가

## Test plan
- [ ] `pnpm typecheck` 통과 확인
- [ ] `/getting-started?tab=setup` 페이지에서 Claude Code 탭 선택 시 5단계 표시 확인
- [ ] 각 명령 Copy 버튼 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)