### PR TITLE
fix: CI 이슈 2건 — CoworkSetupGuide 테스트 + e2e pnpm

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,9 +12,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/packages/web/src/__tests__/team-guide-components.test.tsx
+++ b/packages/web/src/__tests__/team-guide-components.test.tsx
@@ -97,7 +97,7 @@ describe("CoworkSetupGuide", () => {
   it("renders step cards", () => {
     render(<CoworkSetupGuide />);
     expect(screen.getByText("환경 확인")).toBeInTheDocument();
-    expect(screen.getByText("플러그인 설치")).toBeInTheDocument();
+    expect(screen.getByText("팀 스킬 설치")).toBeInTheDocument();
     expect(screen.getByText("설정 확인")).toBeInTheDocument();
     expect(screen.getByText("첫 실행")).toBeInTheDocument();
   });
@@ -110,7 +110,7 @@ describe("CoworkSetupGuide", () => {
   it("toggles to Claude Code environment", () => {
     render(<CoworkSetupGuide />);
     fireEvent.click(screen.getByText("Claude Code"));
-    expect(screen.getByText(/\.claude\/skills\/ 디렉토리에 스킬 복사/)).toBeInTheDocument();
+    expect(screen.getAllByText(/cp -r \/tmp\/ax-config\/skills\/ax-\*/).length).toBeGreaterThanOrEqual(1);
   });
 });
 


### PR DESCRIPTION
## Summary
- `team-guide-components.test.tsx`: CoworkSetupGuide 스텝 제목 변경 반영 ("플러그인 설치"→"팀 스킬 설치")
- `e2e.yml`: `pnpm/action-setup@v4`에서 `version: 9` 제거 — `package.json` `packageManager` 필드와 충돌 방지

## Test plan
- [x] team-guide-components.test.tsx 17/17 로컬 통과
- [ ] CI e2e 워크플로우 정상 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)