### PR TITLE
feat: Sprint 105 F276 — DERIVED 엔진

### DIFF
--- a/docs/04-report/features/sprint-105.report.md
+++ b/docs/04-report/features/sprint-105.report.md
@@ -1,0 +1,91 @@
+---
+code: FX-RPRT-S105
+title: "Sprint 105 완료 보고서 — F276 DERIVED 엔진"
+version: 1.0
+status: Active
+category: RPRT
+created: 2026-04-02
+updated: 2026-04-02
+author: Sinclair Seo
+references: "[[FX-SPEC-001]], [[FX-PLAN-S105]], [[FX-DSGN-S105]]"
+---
+
+# Sprint 105: F276 DERIVED 엔진 — 완료 보고서
+
+## Executive Summary
+
+| 항목 | 내용 |
+|------|------|
+| Feature | F276: Track C DERIVED 엔진 |
+| Sprint | 105 |
+| 기간 | 2026-04-02 (단일 세션) |
+| Match Rate | **100%** |
+
+### Results Summary
+
+| 지표 | 값 |
+|------|-----|
+| D1 마이그레이션 | 0082 (3테이블 + 7인덱스) |
+| API 엔드포인트 | 8개 신규 |
+| 서비스 | 3개 신규 (PatternExtractor, DerivedSkillGenerator, DerivedReview) |
+| Shared 타입 | 11개 신규 |
+| Zod 스키마 | 5개 신규 |
+| 테스트 | **40개 신규** (전체 2311→2351) |
+| typecheck | ✅ 통과 |
+| Match Rate | **100%** (97/97 항목) |
+
+### Value Delivered
+
+| 관점 | 내용 |
+|------|------|
+| Problem | BD 스킬 반복 성공 패턴이 암묵지로만 존재 — 데이터 기반 스킬 최적화 불가 |
+| Solution | DERIVED 엔진이 skill_executions 성공 패턴 자동 분석 → 스킬 후보 생성 → HITL 승인으로 등록 |
+| Function UX Effect | BD 단계별 고성공률 패턴 자동 추출, 승인 한 번으로 새 스킬 레지스트리 등록 |
+| Core Value | 스킬 자가 진화 — 사용할수록 좋아지는 BD 도구 생태계의 핵심 엔진 |
+
+## 구현 상세
+
+### D1 마이그레이션 0082
+
+| 테이블 | 용도 | 컬럼 수 |
+|--------|------|---------|
+| `derived_patterns` | BD 단계별 반복 성공 패턴 저장소 | 14 |
+| `derived_candidates` | 패턴에서 생성된 스킬 후보 | 14 |
+| `derived_reviews` | HITL 리뷰 이력 (감사 추적) | 7 |
+
+### API 엔드포인트
+
+| # | Method | Path | 구현 |
+|---|--------|------|------|
+| 1 | POST | `/api/skills/derived/extract` | ✅ |
+| 2 | GET | `/api/skills/derived/patterns` | ✅ |
+| 3 | GET | `/api/skills/derived/patterns/:patternId` | ✅ |
+| 4 | POST | `/api/skills/derived/generate` | ✅ |
+| 5 | GET | `/api/skills/derived/candidates` | ✅ |
+| 6 | GET | `/api/skills/derived/candidates/:candidateId` | ✅ |
+| 7 | POST | `/api/skills/derived/candidates/:candidateId/review` | ✅ |
+| 8 | GET | `/api/skills/derived/stats` | ✅ |
+
+### 핵심 알고리즘
+
+- **Wilson Score Lower Bound**: 95% CI 기반 통계적 신뢰도 계산
+- **단일 패턴**: skill_executions GROUP BY (skill_id) + 임계값 필터링
+- **체이닝 패턴**: 30분 이내 연속 실행 스킬 쌍 감지 (julianday 비교)
+- **HITL 워크플로우**: approve → registry 등록 + lineage + audit / reject / revision
+
+### 파일 목록 (13개)
+
+| 구분 | 파일 |
+|------|------|
+| Migration | `0082_derived_engine.sql` |
+| Types | `shared/src/types.ts` (수정) + `shared/src/index.ts` (수정) |
+| Schema | `api/src/schemas/derived-engine.ts` |
+| Services | `pattern-extractor.ts`, `derived-skill-generator.ts`, `derived-review.ts` |
+| Route | `api/src/routes/derived-engine.ts` |
+| Config | `api/src/app.ts` (수정) |
+| Tests | 4개 테스트 파일 (40 tests) |
+
+## 교훈
+
+1. **체이닝 패턴 GROUP BY**: `biz_item_id`를 그룹에 포함하면 각 아이템이 독립 그룹(count=1)이 됨 → 크로스-아이템 집계로 수정
+2. **라우트 테스트 인증**: `createTestEnv` + `createAuthHeaders` 헬퍼 사용 필수 (직접 JWT 토큰 방식은 401 발생)

--- a/packages/api/src/__tests__/derived-engine-routes.test.ts
+++ b/packages/api/src/__tests__/derived-engine-routes.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { app } from "../app.js";
+import { createTestEnv, createAuthHeaders } from "./helpers/test-app.js";
+
+const DERIVED_TABLES = `
+CREATE TABLE IF NOT EXISTS skill_executions (
+  id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, skill_id TEXT NOT NULL,
+  version INTEGER DEFAULT 1, biz_item_id TEXT, artifact_id TEXT,
+  model TEXT NOT NULL, status TEXT DEFAULT 'completed',
+  input_tokens INTEGER DEFAULT 0, output_tokens INTEGER DEFAULT 0,
+  cost_usd REAL DEFAULT 0, duration_ms INTEGER DEFAULT 0,
+  error_message TEXT, executed_by TEXT NOT NULL,
+  executed_at TEXT DEFAULT (datetime('now'))
+);
+CREATE TABLE IF NOT EXISTS derived_patterns (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  pipeline_stage TEXT NOT NULL,
+  discovery_stage TEXT,
+  pattern_type TEXT NOT NULL DEFAULT 'single',
+  skill_ids TEXT NOT NULL,
+  success_rate REAL NOT NULL,
+  sample_count INTEGER NOT NULL,
+  avg_cost_usd REAL DEFAULT 0,
+  avg_duration_ms INTEGER DEFAULT 0,
+  confidence REAL NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active',
+  extracted_at TEXT NOT NULL DEFAULT (datetime('now')),
+  expires_at TEXT
+);
+CREATE TABLE IF NOT EXISTS derived_candidates (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  pattern_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  description TEXT,
+  category TEXT NOT NULL DEFAULT 'general',
+  prompt_template TEXT NOT NULL,
+  source_skills TEXT NOT NULL,
+  similarity_score REAL DEFAULT 0,
+  safety_grade TEXT DEFAULT 'pending',
+  safety_score INTEGER DEFAULT 0,
+  review_status TEXT NOT NULL DEFAULT 'pending',
+  registered_skill_id TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  reviewed_at TEXT,
+  reviewed_by TEXT
+);
+CREATE TABLE IF NOT EXISTS derived_reviews (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  candidate_id TEXT NOT NULL,
+  action TEXT NOT NULL,
+  comment TEXT,
+  modified_prompt TEXT,
+  reviewer_id TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE IF NOT EXISTS skill_registry (
+  id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, skill_id TEXT NOT NULL,
+  name TEXT NOT NULL, description TEXT, category TEXT DEFAULT 'general',
+  tags TEXT, status TEXT DEFAULT 'active',
+  safety_grade TEXT DEFAULT 'pending', safety_score INTEGER DEFAULT 0,
+  safety_checked_at TEXT, source_type TEXT DEFAULT 'marketplace',
+  source_ref TEXT, prompt_template TEXT, model_preference TEXT,
+  max_tokens INTEGER DEFAULT 4096, token_cost_avg REAL DEFAULT 0,
+  success_rate REAL DEFAULT 0, total_executions INTEGER DEFAULT 0,
+  current_version INTEGER DEFAULT 1, created_by TEXT NOT NULL,
+  updated_by TEXT, created_at TEXT DEFAULT (datetime('now')),
+  updated_at TEXT DEFAULT (datetime('now')), deleted_at TEXT,
+  UNIQUE(tenant_id, skill_id)
+);
+CREATE TABLE IF NOT EXISTS skill_search_index (
+  id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, skill_id TEXT NOT NULL,
+  token TEXT NOT NULL, weight REAL DEFAULT 1.0, field TEXT DEFAULT 'name',
+  UNIQUE(tenant_id, skill_id, token, field)
+);
+CREATE TABLE IF NOT EXISTS skill_lineage (
+  id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL,
+  parent_skill_id TEXT NOT NULL, child_skill_id TEXT NOT NULL,
+  derivation_type TEXT DEFAULT 'manual', description TEXT,
+  created_by TEXT NOT NULL, created_at TEXT DEFAULT (datetime('now'))
+);
+CREATE TABLE IF NOT EXISTS skill_audit_log (
+  id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL,
+  entity_type TEXT NOT NULL, entity_id TEXT NOT NULL,
+  action TEXT NOT NULL, actor_id TEXT NOT NULL,
+  details TEXT, created_at TEXT DEFAULT (datetime('now'))
+);
+`;
+
+const TENANT = "org_test";
+let env: ReturnType<typeof createTestEnv>;
+let headers: Record<string, string>;
+
+async function makeRequest(path: string, method = "GET", body?: unknown) {
+  const opts: RequestInit = {
+    method,
+    headers: { ...headers, "Content-Type": "application/json" },
+  };
+  if (body) opts.body = JSON.stringify(body);
+  return app.request(`/api${path}`, opts, env);
+}
+
+function seedData() {
+  const db = env.DB as any;
+  // Seed executions
+  for (let i = 0; i < 10; i++) {
+    db.prepare(
+      `INSERT INTO skill_executions (id, tenant_id, skill_id, biz_item_id, model, status, cost_usd, duration_ms, executed_by)
+       VALUES (?, ?, 'skill-route', 'discovery', 'gpt-4', 'completed', 0.05, 1000, 'actor')`,
+    ).bind(`se_r_${i}`, TENANT).run();
+  }
+
+  // Seed a pattern
+  db.prepare(
+    `INSERT INTO derived_patterns (id, tenant_id, pipeline_stage, pattern_type, skill_ids, success_rate, sample_count, confidence, status)
+     VALUES ('pat_route', ?, 'discovery', 'single', '["skill-route"]', 0.9, 10, 0.8, 'active')`,
+  ).bind(TENANT).run();
+
+  // Seed skill_registry
+  db.prepare(
+    `INSERT INTO skill_registry (id, tenant_id, skill_id, name, category, prompt_template, created_by)
+     VALUES ('sr_route', ?, 'skill-route', 'Route Skill', 'analysis', 'Test prompt', 'actor')`,
+  ).bind(TENANT).run();
+
+  // Seed a candidate
+  db.prepare(
+    `INSERT INTO derived_candidates (id, tenant_id, pattern_id, name, category, prompt_template, source_skills, review_status)
+     VALUES ('cand_route', ?, 'pat_route', 'Route Candidate', 'analysis', 'Test prompt', '[{"skillId":"skill-route","contribution":1}]', 'pending')`,
+  ).bind(TENANT).run();
+}
+
+describe("derived-engine routes (F276)", () => {
+  beforeEach(async () => {
+    env = createTestEnv();
+    (env.DB as any).exec(DERIVED_TABLES);
+    headers = await createAuthHeaders();
+  });
+
+  it("POST /skills/derived/extract — 201", async () => {
+    // Seed executions
+    const db = env.DB as any;
+    for (let i = 0; i < 10; i++) {
+      db.prepare(
+        `INSERT INTO skill_executions (id, tenant_id, skill_id, biz_item_id, model, status, executed_by)
+         VALUES (?, ?, 'skill-ext', 'discovery', 'gpt-4', 'completed', 'actor')`,
+      ).bind(`se_ext_${i}`, TENANT).run();
+    }
+
+    const res = await makeRequest("/skills/derived/extract", "POST", {
+      minSampleCount: 5, minSuccessRate: 0.7,
+    });
+    expect(res.status).toBe(201);
+    const data = (await res.json()) as any;
+    expect(data.count).toBeGreaterThanOrEqual(1);
+  });
+
+  it("POST /skills/derived/extract — 400 invalid input", async () => {
+    const res = await makeRequest("/skills/derived/extract", "POST", {
+      minSampleCount: -1,
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("GET /skills/derived/patterns — 200", async () => {
+    seedData();
+    const res = await makeRequest("/skills/derived/patterns");
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as any;
+    expect(data.patterns).toBeDefined();
+    expect(data.total).toBeGreaterThanOrEqual(1);
+  });
+
+  it("GET /skills/derived/patterns/:patternId — 200", async () => {
+    seedData();
+    const res = await makeRequest("/skills/derived/patterns/pat_route");
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as any;
+    expect(data.id).toBe("pat_route");
+  });
+
+  it("GET /skills/derived/patterns/:patternId — 404", async () => {
+    const res = await makeRequest("/skills/derived/patterns/no_such");
+    expect(res.status).toBe(404);
+  });
+
+  it("POST /skills/derived/generate — 201", async () => {
+    seedData();
+    const res = await makeRequest("/skills/derived/generate", "POST", {
+      patternId: "pat_route",
+    });
+    expect(res.status).toBe(201);
+    const data = (await res.json()) as any;
+    expect(data.patternId).toBe("pat_route");
+    expect(data.reviewStatus).toBe("pending");
+  });
+
+  it("POST /skills/derived/generate — 400 missing patternId", async () => {
+    const res = await makeRequest("/skills/derived/generate", "POST", {});
+    expect(res.status).toBe(400);
+  });
+
+  it("GET /skills/derived/candidates — 200", async () => {
+    seedData();
+    const res = await makeRequest("/skills/derived/candidates");
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as any;
+    expect(data.candidates).toBeDefined();
+  });
+
+  it("GET /skills/derived/candidates/:candidateId — 200", async () => {
+    seedData();
+    const res = await makeRequest("/skills/derived/candidates/cand_route");
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as any;
+    expect(data.id).toBe("cand_route");
+  });
+
+  it("GET /skills/derived/candidates/:candidateId — 404", async () => {
+    const res = await makeRequest("/skills/derived/candidates/no_such");
+    expect(res.status).toBe(404);
+  });
+
+  it("POST /skills/derived/candidates/:candidateId/review — 201 approve", async () => {
+    seedData();
+    const res = await makeRequest("/skills/derived/candidates/cand_route/review", "POST", {
+      action: "approved",
+    });
+    expect(res.status).toBe(201);
+    const data = (await res.json()) as any;
+    expect(data.action).toBe("approved");
+  });
+
+  it("POST /skills/derived/candidates/:candidateId/review — 201 reject", async () => {
+    seedData();
+    const res = await makeRequest("/skills/derived/candidates/cand_route/review", "POST", {
+      action: "rejected", comment: "Not needed",
+    });
+    expect(res.status).toBe(201);
+  });
+
+  it("POST /skills/derived/candidates/:candidateId/review — 400 invalid action", async () => {
+    seedData();
+    const res = await makeRequest("/skills/derived/candidates/cand_route/review", "POST", {
+      action: "invalid_action",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("GET /skills/derived/stats — 200", async () => {
+    seedData();
+    const res = await makeRequest("/skills/derived/stats");
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as any;
+    expect(data.totalPatterns).toBeGreaterThanOrEqual(1);
+    expect(data.totalCandidates).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/api/src/__tests__/derived-generator-service.test.ts
+++ b/packages/api/src/__tests__/derived-generator-service.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createMockD1 } from "./helpers/mock-d1.js";
+import { DerivedSkillGeneratorService } from "../services/derived-skill-generator.js";
+
+const DERIVED_TABLES = `
+CREATE TABLE IF NOT EXISTS derived_patterns (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  pipeline_stage TEXT NOT NULL,
+  discovery_stage TEXT,
+  pattern_type TEXT NOT NULL DEFAULT 'single',
+  skill_ids TEXT NOT NULL,
+  success_rate REAL NOT NULL,
+  sample_count INTEGER NOT NULL,
+  avg_cost_usd REAL DEFAULT 0,
+  avg_duration_ms INTEGER DEFAULT 0,
+  confidence REAL NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active',
+  extracted_at TEXT NOT NULL DEFAULT (datetime('now')),
+  expires_at TEXT
+);
+CREATE TABLE IF NOT EXISTS derived_candidates (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  pattern_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  description TEXT,
+  category TEXT NOT NULL DEFAULT 'general',
+  prompt_template TEXT NOT NULL,
+  source_skills TEXT NOT NULL,
+  similarity_score REAL DEFAULT 0,
+  safety_grade TEXT DEFAULT 'pending',
+  safety_score INTEGER DEFAULT 0,
+  review_status TEXT NOT NULL DEFAULT 'pending',
+  registered_skill_id TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  reviewed_at TEXT,
+  reviewed_by TEXT
+);
+CREATE TABLE IF NOT EXISTS derived_reviews (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  candidate_id TEXT NOT NULL,
+  action TEXT NOT NULL,
+  comment TEXT,
+  modified_prompt TEXT,
+  reviewer_id TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE IF NOT EXISTS skill_registry (
+  id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, skill_id TEXT NOT NULL,
+  name TEXT NOT NULL, description TEXT, category TEXT DEFAULT 'general',
+  tags TEXT, status TEXT DEFAULT 'active',
+  safety_grade TEXT DEFAULT 'pending', safety_score INTEGER DEFAULT 0,
+  safety_checked_at TEXT, source_type TEXT DEFAULT 'marketplace',
+  source_ref TEXT, prompt_template TEXT, model_preference TEXT,
+  max_tokens INTEGER DEFAULT 4096, token_cost_avg REAL DEFAULT 0,
+  success_rate REAL DEFAULT 0, total_executions INTEGER DEFAULT 0,
+  current_version INTEGER DEFAULT 1, created_by TEXT NOT NULL,
+  updated_by TEXT, created_at TEXT DEFAULT (datetime('now')),
+  updated_at TEXT DEFAULT (datetime('now')), deleted_at TEXT,
+  UNIQUE(tenant_id, skill_id)
+);
+CREATE TABLE IF NOT EXISTS skill_search_index (
+  id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, skill_id TEXT NOT NULL,
+  token TEXT NOT NULL, weight REAL DEFAULT 1.0, field TEXT DEFAULT 'name',
+  UNIQUE(tenant_id, skill_id, token, field)
+);
+`;
+
+const TENANT = "org_test";
+
+function seedPattern(db: D1Database, opts?: { status?: string }) {
+  (db as unknown as { prepare: (q: string) => { bind: (...a: unknown[]) => { run: () => void } } })
+    .prepare(
+      `INSERT INTO derived_patterns (id, tenant_id, pipeline_stage, pattern_type, skill_ids, success_rate, sample_count, confidence, status)
+       VALUES ('pat_1', ?, 'discovery', 'single', '["cost-model"]', 0.85, 10, 0.72, ?)`,
+    )
+    .bind(TENANT, opts?.status ?? "active")
+    .run();
+}
+
+function seedSkillRegistry(db: D1Database) {
+  (db as unknown as { prepare: (q: string) => { bind: (...a: unknown[]) => { run: () => void } } })
+    .prepare(
+      `INSERT INTO skill_registry (id, tenant_id, skill_id, name, description, category, prompt_template, created_by)
+       VALUES ('sr_1', ?, 'cost-model', 'Cost Model Analysis', 'Analyze costs', 'analysis', 'Analyze the cost structure for the given business item.', 'actor')`,
+    )
+    .bind(TENANT)
+    .run();
+}
+
+describe("DerivedSkillGeneratorService (F276)", () => {
+  let db: D1Database;
+  let svc: DerivedSkillGeneratorService;
+
+  beforeEach(() => {
+    const mockDb = createMockD1();
+    mockDb.exec(DERIVED_TABLES);
+    db = mockDb as unknown as D1Database;
+    svc = new DerivedSkillGeneratorService(db);
+  });
+
+  it("generates a candidate from active pattern", async () => {
+    seedPattern(db);
+    seedSkillRegistry(db);
+
+    const candidate = await svc.generate(TENANT, "pat_1");
+
+    expect(candidate.id).toBeDefined();
+    expect(candidate.patternId).toBe("pat_1");
+    expect(candidate.reviewStatus).toBe("pending");
+    expect(candidate.name).toContain("Cost Model Analysis");
+    expect(candidate.sourceSkills).toHaveLength(1);
+    expect(candidate.sourceSkills[0]!.skillId).toBe("cost-model");
+    expect(candidate.safetyScore).toBeGreaterThanOrEqual(0);
+  });
+
+  it("throws for non-existent pattern", async () => {
+    await expect(svc.generate(TENANT, "no_such_pattern")).rejects.toThrow("Pattern not found");
+  });
+
+  it("throws for consumed pattern", async () => {
+    seedPattern(db, { status: "consumed" });
+
+    await expect(svc.generate(TENANT, "pat_1")).rejects.toThrow("Pattern is not active");
+  });
+
+  it("applies name and category overrides", async () => {
+    seedPattern(db);
+    seedSkillRegistry(db);
+
+    const candidate = await svc.generate(TENANT, "pat_1", {
+      nameOverride: "Custom Derived Skill",
+      categoryOverride: "generation",
+    });
+
+    expect(candidate.name).toBe("Custom Derived Skill");
+    expect(candidate.category).toBe("generation");
+  });
+
+  it("lists candidates with filters", async () => {
+    seedPattern(db);
+    seedSkillRegistry(db);
+
+    await svc.generate(TENANT, "pat_1");
+
+    const { candidates, total } = await svc.listCandidates(TENANT, {
+      reviewStatus: "pending", limit: 50, offset: 0,
+    });
+
+    expect(total).toBe(1);
+    expect(candidates[0]!.reviewStatus).toBe("pending");
+  });
+
+  it("returns null for non-existent candidate", async () => {
+    const result = await svc.getCandidateById(TENANT, "no_such");
+    expect(result).toBeNull();
+  });
+});

--- a/packages/api/src/__tests__/derived-review-service.test.ts
+++ b/packages/api/src/__tests__/derived-review-service.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createMockD1 } from "./helpers/mock-d1.js";
+import { DerivedReviewService } from "../services/derived-review.js";
+
+const DERIVED_TABLES = `
+CREATE TABLE IF NOT EXISTS derived_patterns (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  pipeline_stage TEXT NOT NULL,
+  discovery_stage TEXT,
+  pattern_type TEXT NOT NULL DEFAULT 'single',
+  skill_ids TEXT NOT NULL,
+  success_rate REAL NOT NULL,
+  sample_count INTEGER NOT NULL,
+  avg_cost_usd REAL DEFAULT 0,
+  avg_duration_ms INTEGER DEFAULT 0,
+  confidence REAL NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active',
+  extracted_at TEXT NOT NULL DEFAULT (datetime('now')),
+  expires_at TEXT
+);
+CREATE TABLE IF NOT EXISTS derived_candidates (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  pattern_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  description TEXT,
+  category TEXT NOT NULL DEFAULT 'general',
+  prompt_template TEXT NOT NULL,
+  source_skills TEXT NOT NULL,
+  similarity_score REAL DEFAULT 0,
+  safety_grade TEXT DEFAULT 'pending',
+  safety_score INTEGER DEFAULT 0,
+  review_status TEXT NOT NULL DEFAULT 'pending',
+  registered_skill_id TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  reviewed_at TEXT,
+  reviewed_by TEXT
+);
+CREATE TABLE IF NOT EXISTS derived_reviews (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  candidate_id TEXT NOT NULL,
+  action TEXT NOT NULL,
+  comment TEXT,
+  modified_prompt TEXT,
+  reviewer_id TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE IF NOT EXISTS skill_registry (
+  id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, skill_id TEXT NOT NULL,
+  name TEXT NOT NULL, description TEXT, category TEXT DEFAULT 'general',
+  tags TEXT, status TEXT DEFAULT 'active',
+  safety_grade TEXT DEFAULT 'pending', safety_score INTEGER DEFAULT 0,
+  safety_checked_at TEXT, source_type TEXT DEFAULT 'marketplace',
+  source_ref TEXT, prompt_template TEXT, model_preference TEXT,
+  max_tokens INTEGER DEFAULT 4096, token_cost_avg REAL DEFAULT 0,
+  success_rate REAL DEFAULT 0, total_executions INTEGER DEFAULT 0,
+  current_version INTEGER DEFAULT 1, created_by TEXT NOT NULL,
+  updated_by TEXT, created_at TEXT DEFAULT (datetime('now')),
+  updated_at TEXT DEFAULT (datetime('now')), deleted_at TEXT,
+  UNIQUE(tenant_id, skill_id)
+);
+CREATE TABLE IF NOT EXISTS skill_lineage (
+  id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL,
+  parent_skill_id TEXT NOT NULL, child_skill_id TEXT NOT NULL,
+  derivation_type TEXT DEFAULT 'manual', description TEXT,
+  created_by TEXT NOT NULL, created_at TEXT DEFAULT (datetime('now'))
+);
+CREATE TABLE IF NOT EXISTS skill_audit_log (
+  id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL,
+  entity_type TEXT NOT NULL, entity_id TEXT NOT NULL,
+  action TEXT NOT NULL, actor_id TEXT NOT NULL,
+  details TEXT, created_at TEXT DEFAULT (datetime('now'))
+);
+`;
+
+const TENANT = "org_test";
+
+function seedCandidate(db: D1Database) {
+  // Pattern
+  (db as unknown as { prepare: (q: string) => { bind: (...a: unknown[]) => { run: () => void } } })
+    .prepare(
+      `INSERT INTO derived_patterns (id, tenant_id, pipeline_stage, pattern_type, skill_ids, success_rate, sample_count, confidence, status)
+       VALUES ('pat_r1', ?, 'discovery', 'single', '["cost-model"]', 0.85, 10, 0.72, 'active')`,
+    )
+    .bind(TENANT)
+    .run();
+
+  // Candidate
+  (db as unknown as { prepare: (q: string) => { bind: (...a: unknown[]) => { run: () => void } } })
+    .prepare(
+      `INSERT INTO derived_candidates (id, tenant_id, pattern_id, name, description, category, prompt_template, source_skills, review_status)
+       VALUES ('cand_1', ?, 'pat_r1', 'Test Derived Skill', 'A test skill', 'analysis', 'Test prompt', '[{"skillId":"cost-model","contribution":1}]', 'pending')`,
+    )
+    .bind(TENANT)
+    .run();
+}
+
+describe("DerivedReviewService (F276)", () => {
+  let db: D1Database;
+  let svc: DerivedReviewService;
+
+  beforeEach(() => {
+    const mockDb = createMockD1();
+    mockDb.exec(DERIVED_TABLES);
+    db = mockDb as unknown as D1Database;
+    svc = new DerivedReviewService(db);
+  });
+
+  it("approves candidate → registers in skill_registry", async () => {
+    seedCandidate(db);
+
+    const review = await svc.review(TENANT, "cand_1", { action: "approved" }, "reviewer_1");
+
+    expect(review.action).toBe("approved");
+    expect(review.candidateId).toBe("cand_1");
+
+    // Check skill_registry
+    const skill = await db
+      .prepare("SELECT * FROM skill_registry WHERE tenant_id = ? AND skill_id LIKE 'derived_%'")
+      .bind(TENANT)
+      .first<{ skill_id: string; source_type: string }>();
+    expect(skill).not.toBeNull();
+    expect(skill!.source_type).toBe("derived");
+  });
+
+  it("approves candidate → records lineage", async () => {
+    seedCandidate(db);
+
+    await svc.review(TENANT, "cand_1", { action: "approved" }, "reviewer_1");
+
+    const lineage = await db
+      .prepare("SELECT * FROM skill_lineage WHERE tenant_id = ? AND derivation_type = 'derived'")
+      .bind(TENANT)
+      .first<{ parent_skill_id: string; child_skill_id: string }>();
+
+    expect(lineage).not.toBeNull();
+    expect(lineage!.parent_skill_id).toBe("cost-model");
+    expect(lineage!.child_skill_id).toContain("derived_cand_1");
+  });
+
+  it("approves candidate → creates audit log", async () => {
+    seedCandidate(db);
+
+    await svc.review(TENANT, "cand_1", { action: "approved" }, "reviewer_1");
+
+    const audit = await db
+      .prepare("SELECT * FROM skill_audit_log WHERE tenant_id = ? AND action = 'created'")
+      .bind(TENANT)
+      .first<{ entity_type: string; details: string }>();
+
+    expect(audit).not.toBeNull();
+    expect(audit!.entity_type).toBe("skill");
+    expect(audit!.details).toContain("DERIVED");
+  });
+
+  it("approves candidate → consumes pattern", async () => {
+    seedCandidate(db);
+
+    await svc.review(TENANT, "cand_1", { action: "approved" }, "reviewer_1");
+
+    const pattern = await db
+      .prepare("SELECT status FROM derived_patterns WHERE id = 'pat_r1'")
+      .bind()
+      .first<{ status: string }>();
+
+    expect(pattern!.status).toBe("consumed");
+  });
+
+  it("rejects candidate — no registry entry", async () => {
+    seedCandidate(db);
+
+    const review = await svc.review(TENANT, "cand_1", {
+      action: "rejected", comment: "Not useful",
+    }, "reviewer_1");
+
+    expect(review.action).toBe("rejected");
+
+    const candidate = await db
+      .prepare("SELECT review_status FROM derived_candidates WHERE id = 'cand_1'")
+      .bind()
+      .first<{ review_status: string }>();
+    expect(candidate!.review_status).toBe("rejected");
+
+    // No skill registered
+    const skill = await db
+      .prepare("SELECT * FROM skill_registry WHERE skill_id LIKE 'derived_%'")
+      .bind()
+      .first();
+    expect(skill).toBeNull();
+  });
+
+  it("revision_requested with modified prompt — updates prompt + safety re-check + returns to pending", async () => {
+    seedCandidate(db);
+
+    await svc.review(TENANT, "cand_1", {
+      action: "revision_requested",
+      modifiedPrompt: "Improved prompt for cost analysis",
+    }, "reviewer_1");
+
+    const candidate = await db
+      .prepare("SELECT review_status, prompt_template, safety_grade, safety_score FROM derived_candidates WHERE id = 'cand_1'")
+      .bind()
+      .first<{ review_status: string; prompt_template: string; safety_grade: string; safety_score: number }>();
+
+    expect(candidate!.review_status).toBe("pending"); // Returns to pending
+    expect(candidate!.prompt_template).toBe("Improved prompt for cost analysis");
+    expect(candidate!.safety_grade).not.toBe("pending"); // Re-checked
+  });
+
+  it("revision_requested without modified prompt — sets revision_requested status", async () => {
+    seedCandidate(db);
+
+    await svc.review(TENANT, "cand_1", {
+      action: "revision_requested",
+      comment: "Please improve",
+    }, "reviewer_1");
+
+    const candidate = await db
+      .prepare("SELECT review_status FROM derived_candidates WHERE id = 'cand_1'")
+      .bind()
+      .first<{ review_status: string }>();
+
+    expect(candidate!.review_status).toBe("revision_requested");
+  });
+
+  it("returns stats with approval rate", async () => {
+    seedCandidate(db);
+
+    // Add another candidate for rejected
+    (db as unknown as { prepare: (q: string) => { bind: (...a: unknown[]) => { run: () => void } } })
+      .prepare(
+        `INSERT INTO derived_candidates (id, tenant_id, pattern_id, name, category, prompt_template, source_skills, review_status)
+         VALUES ('cand_2', ?, 'pat_r1', 'Rejected Skill', 'general', 'Prompt', '[]', 'rejected')`,
+      )
+      .bind(TENANT)
+      .run();
+
+    await svc.review(TENANT, "cand_1", { action: "approved" }, "reviewer_1");
+
+    const stats = await svc.getStats(TENANT);
+
+    expect(stats.totalCandidates).toBe(2);
+    expect(stats.approvedCandidates).toBe(1);
+    expect(stats.rejectedCandidates).toBe(1);
+    expect(stats.approvalRate).toBe(0.5);
+    expect(stats.totalPatterns).toBe(1);
+  });
+
+  it("throws for non-existent candidate", async () => {
+    await expect(
+      svc.review(TENANT, "no_such", { action: "approved" }, "reviewer_1"),
+    ).rejects.toThrow("Candidate not found");
+  });
+});

--- a/packages/api/src/__tests__/pattern-extractor-service.test.ts
+++ b/packages/api/src/__tests__/pattern-extractor-service.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createMockD1 } from "./helpers/mock-d1.js";
+import { PatternExtractorService, wilsonScoreLowerBound } from "../services/pattern-extractor.js";
+
+const DERIVED_TABLES = `
+CREATE TABLE IF NOT EXISTS skill_executions (
+  id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, skill_id TEXT NOT NULL,
+  version INTEGER DEFAULT 1, biz_item_id TEXT, artifact_id TEXT,
+  model TEXT NOT NULL, status TEXT DEFAULT 'completed',
+  input_tokens INTEGER DEFAULT 0, output_tokens INTEGER DEFAULT 0,
+  cost_usd REAL DEFAULT 0, duration_ms INTEGER DEFAULT 0,
+  error_message TEXT, executed_by TEXT NOT NULL,
+  executed_at TEXT DEFAULT (datetime('now'))
+);
+CREATE TABLE IF NOT EXISTS derived_patterns (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  pipeline_stage TEXT NOT NULL,
+  discovery_stage TEXT,
+  pattern_type TEXT NOT NULL DEFAULT 'single',
+  skill_ids TEXT NOT NULL,
+  success_rate REAL NOT NULL,
+  sample_count INTEGER NOT NULL,
+  avg_cost_usd REAL DEFAULT 0,
+  avg_duration_ms INTEGER DEFAULT 0,
+  confidence REAL NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active',
+  extracted_at TEXT NOT NULL DEFAULT (datetime('now')),
+  expires_at TEXT
+);
+CREATE TABLE IF NOT EXISTS skill_registry (
+  id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, skill_id TEXT NOT NULL,
+  name TEXT NOT NULL, description TEXT, category TEXT DEFAULT 'general',
+  tags TEXT, status TEXT DEFAULT 'active',
+  safety_grade TEXT DEFAULT 'pending', safety_score INTEGER DEFAULT 0,
+  safety_checked_at TEXT, source_type TEXT DEFAULT 'marketplace',
+  source_ref TEXT, prompt_template TEXT, model_preference TEXT,
+  max_tokens INTEGER DEFAULT 4096, token_cost_avg REAL DEFAULT 0,
+  success_rate REAL DEFAULT 0, total_executions INTEGER DEFAULT 0,
+  current_version INTEGER DEFAULT 1, created_by TEXT NOT NULL,
+  updated_by TEXT, created_at TEXT DEFAULT (datetime('now')),
+  updated_at TEXT DEFAULT (datetime('now')), deleted_at TEXT,
+  UNIQUE(tenant_id, skill_id)
+);
+`;
+
+const TENANT = "org_test";
+
+function seedExecutions(db: D1Database, count: number, skillId: string, status = "completed", bizItemId = "discovery") {
+  for (let i = 0; i < count; i++) {
+    const id = `se_${skillId}_${status}_${i}`;
+    const executedAt = new Date(Date.now() - i * 60000).toISOString();
+    (db as unknown as { prepare: (q: string) => { bind: (...a: unknown[]) => { run: () => void } } })
+      .prepare(
+        `INSERT INTO skill_executions (id, tenant_id, skill_id, biz_item_id, model, status, cost_usd, duration_ms, executed_by, executed_at)
+         VALUES (?, ?, ?, ?, 'gpt-4', ?, 0.05, 1000, 'actor', ?)`,
+      )
+      .bind(id, TENANT, skillId, bizItemId, status, executedAt)
+      .run();
+  }
+}
+
+describe("PatternExtractorService (F276)", () => {
+  let db: D1Database;
+  let svc: PatternExtractorService;
+
+  beforeEach(() => {
+    const mockDb = createMockD1();
+    mockDb.exec(DERIVED_TABLES);
+    db = mockDb as unknown as D1Database;
+    svc = new PatternExtractorService(db);
+  });
+
+  it("extracts single skill pattern — 80% success rate, 10 samples", async () => {
+    seedExecutions(db, 8, "skill-a", "completed");
+    seedExecutions(db, 2, "skill-a", "failed");
+
+    const result = await svc.extract(TENANT, {
+      minSampleCount: 5, minSuccessRate: 0.7, includeChains: false,
+    });
+
+    expect(result.count).toBe(1);
+    expect(result.patterns[0]!.patternType).toBe("single");
+    expect(result.patterns[0]!.skillIds).toContain("skill-a");
+    expect(result.patterns[0]!.successRate).toBe(0.8);
+    expect(result.patterns[0]!.confidence).toBeGreaterThan(0);
+  });
+
+  it("filters out patterns below success rate threshold", async () => {
+    seedExecutions(db, 5, "skill-low", "completed");
+    seedExecutions(db, 5, "skill-low", "failed");
+
+    const result = await svc.extract(TENANT, {
+      minSampleCount: 5, minSuccessRate: 0.7, includeChains: false,
+    });
+
+    expect(result.count).toBe(0);
+  });
+
+  it("filters out patterns below sample count threshold", async () => {
+    seedExecutions(db, 3, "skill-few", "completed");
+
+    const result = await svc.extract(TENANT, {
+      minSampleCount: 5, minSuccessRate: 0.7, includeChains: false,
+    });
+
+    expect(result.count).toBe(0);
+  });
+
+  it("filters by pipeline stage", async () => {
+    seedExecutions(db, 10, "skill-disc", "completed", "discovery");
+    seedExecutions(db, 10, "skill-shap", "completed", "shaping");
+
+    const result = await svc.extract(TENANT, {
+      pipelineStage: "discovery",
+      minSampleCount: 5, minSuccessRate: 0.7, includeChains: false,
+    });
+
+    expect(result.count).toBe(1);
+    expect(result.patterns[0]!.pipelineStage).toBe("discovery");
+  });
+
+  it("extracts chain patterns — 2 skills in sequence", async () => {
+    // Seed sequential executions with same biz_item_id, 10min apart
+    for (let i = 0; i < 5; i++) {
+      const baseTime = new Date(2026, 0, 1, 10, 0, 0).getTime() + i * 3600000;
+      const time1 = new Date(baseTime).toISOString().replace("T", " ").replace("Z", "").slice(0, 19);
+      const time2 = new Date(baseTime + 600000).toISOString().replace("T", " ").replace("Z", "").slice(0, 19);
+
+      await db.prepare(
+        `INSERT INTO skill_executions (id, tenant_id, skill_id, biz_item_id, model, status, executed_by, executed_at)
+         VALUES (?, ?, 'chain-a', ?, 'gpt-4', 'completed', 'actor', ?)`,
+      ).bind(`cha_${i}`, TENANT, `biz_${i}`, time1).run();
+
+      await db.prepare(
+        `INSERT INTO skill_executions (id, tenant_id, skill_id, biz_item_id, model, status, executed_by, executed_at)
+         VALUES (?, ?, 'chain-b', ?, 'gpt-4', 'completed', 'actor', ?)`,
+      ).bind(`chb_${i}`, TENANT, `biz_${i}`, time2).run();
+    }
+
+    const result = await svc.extract(TENANT, {
+      minSampleCount: 2, minSuccessRate: 0.5, includeChains: true,
+    });
+
+    const chainPatterns = result.patterns.filter((p) => p.patternType === "chain");
+    expect(chainPatterns.length).toBeGreaterThanOrEqual(1);
+    expect(chainPatterns[0]!.skillIds).toHaveLength(2);
+  });
+
+  it("returns empty result for no data", async () => {
+    const result = await svc.extract(TENANT, {
+      minSampleCount: 5, minSuccessRate: 0.7, includeChains: true,
+    });
+
+    expect(result.count).toBe(0);
+    expect(result.patterns).toHaveLength(0);
+  });
+
+  it("lists patterns with pagination", async () => {
+    seedExecutions(db, 10, "skill-x", "completed", "discovery");
+    seedExecutions(db, 10, "skill-y", "completed", "shaping");
+    await svc.extract(TENANT, { minSampleCount: 5, minSuccessRate: 0.7, includeChains: false });
+
+    const result = await svc.getPatterns(TENANT, { limit: 1, offset: 0 });
+    expect(result.patterns).toHaveLength(1);
+    expect(result.total).toBe(2);
+  });
+
+  it("gets pattern detail with skills and sample executions", async () => {
+    // Register a skill
+    await db.prepare(
+      `INSERT INTO skill_registry (id, tenant_id, skill_id, name, category, created_by)
+       VALUES ('r1', ?, 'skill-detail', 'Detail Skill', 'analysis', 'actor')`,
+    ).bind(TENANT).run();
+
+    seedExecutions(db, 10, "skill-detail", "completed");
+    const { patterns } = await svc.extract(TENANT, {
+      minSampleCount: 5, minSuccessRate: 0.7, includeChains: false,
+    });
+
+    const detail = await svc.getPatternDetail(TENANT, patterns[0]!.id);
+    expect(detail).not.toBeNull();
+    expect(detail!.sampleExecutions.length).toBeGreaterThan(0);
+  });
+});
+
+describe("wilsonScoreLowerBound", () => {
+  it("returns 0 for n=0", () => {
+    expect(wilsonScoreLowerBound(0.5, 0)).toBe(0);
+  });
+
+  it("returns positive value for valid inputs", () => {
+    const score = wilsonScoreLowerBound(0.8, 10);
+    expect(score).toBeGreaterThan(0);
+    expect(score).toBeLessThan(0.8);
+  });
+
+  it("higher sample count gives higher confidence", () => {
+    const low = wilsonScoreLowerBound(0.8, 5);
+    const high = wilsonScoreLowerBound(0.8, 100);
+    expect(high).toBeGreaterThan(low);
+  });
+});

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -87,6 +87,8 @@ import { hitlReviewRoute } from "./routes/hitl-review.js";
 // Sprint 103: 스킬 실행 메트릭 (F274)
 import { skillMetricsRoute } from "./routes/skill-metrics.js";
 import { skillRegistryRoute } from "./routes/skill-registry.js";
+// Sprint 105: DERIVED 엔진 (F276)
+import { derivedEngineRoute } from "./routes/derived-engine.js";
 import { handleScheduled } from "./scheduled.js";
 import { authMiddleware } from "./middleware/auth.js";
 import { piiMaskerMiddleware } from "./middleware/pii-masker.middleware.js";
@@ -323,6 +325,8 @@ app.route("/api", hitlReviewRoute);
 app.route("/api", skillMetricsRoute);
 // Sprint 104: 스킬 레지스트리 (F275)
 app.route("/api", skillRegistryRoute);
+// Sprint 105: DERIVED 엔진 (F276)
+app.route("/api", derivedEngineRoute);
 
 // Sprint 47: PII masker middleware — AI API 경로에만 적용
 app.use("/api/agents/*", piiMaskerMiddleware);

--- a/packages/api/src/db/migrations/0082_derived_engine.sql
+++ b/packages/api/src/db/migrations/0082_derived_engine.sql
@@ -1,0 +1,71 @@
+-- F276: DERIVED 엔진 — 패턴 추출 + 스킬 후보 생성 + HITL 승인
+
+-- 1. derived_patterns — BD 단계별 반복 성공 패턴 저장소
+CREATE TABLE IF NOT EXISTS derived_patterns (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  tenant_id TEXT NOT NULL,
+  pipeline_stage TEXT NOT NULL
+    CHECK(pipeline_stage IN ('collection', 'discovery', 'shaping', 'validation', 'productization', 'gtm')),
+  discovery_stage TEXT
+    CHECK(discovery_stage IS NULL OR discovery_stage IN (
+      '2-0', '2-1', '2-2', '2-3', '2-4', '2-5', '2-6', '2-7', '2-8', '2-9', '2-10'
+    )),
+  pattern_type TEXT NOT NULL DEFAULT 'single'
+    CHECK(pattern_type IN ('single', 'chain')),
+  skill_ids TEXT NOT NULL,
+  success_rate REAL NOT NULL CHECK(success_rate >= 0 AND success_rate <= 1),
+  sample_count INTEGER NOT NULL CHECK(sample_count >= 1),
+  avg_cost_usd REAL DEFAULT 0,
+  avg_duration_ms INTEGER DEFAULT 0,
+  confidence REAL NOT NULL CHECK(confidence >= 0 AND confidence <= 1),
+  status TEXT NOT NULL DEFAULT 'active'
+    CHECK(status IN ('active', 'consumed', 'expired')),
+  extracted_at TEXT NOT NULL DEFAULT (datetime('now')),
+  expires_at TEXT
+);
+
+CREATE INDEX idx_dp_tenant_stage ON derived_patterns(tenant_id, pipeline_stage, status);
+CREATE INDEX idx_dp_confidence ON derived_patterns(confidence DESC);
+CREATE INDEX idx_dp_status ON derived_patterns(status, expires_at);
+
+-- 2. derived_candidates — 패턴에서 생성된 스킬 후보
+CREATE TABLE IF NOT EXISTS derived_candidates (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  tenant_id TEXT NOT NULL,
+  pattern_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  description TEXT,
+  category TEXT NOT NULL DEFAULT 'general'
+    CHECK(category IN ('general', 'bd-process', 'analysis', 'generation', 'validation', 'integration')),
+  prompt_template TEXT NOT NULL,
+  source_skills TEXT NOT NULL,
+  similarity_score REAL DEFAULT 0,
+  safety_grade TEXT DEFAULT 'pending'
+    CHECK(safety_grade IN ('A', 'B', 'C', 'D', 'F', 'pending')),
+  safety_score INTEGER DEFAULT 0,
+  review_status TEXT NOT NULL DEFAULT 'pending'
+    CHECK(review_status IN ('pending', 'approved', 'rejected', 'revision_requested')),
+  registered_skill_id TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  reviewed_at TEXT,
+  reviewed_by TEXT
+);
+
+CREATE INDEX idx_dc_tenant_status ON derived_candidates(tenant_id, review_status);
+CREATE INDEX idx_dc_pattern ON derived_candidates(pattern_id);
+
+-- 3. derived_reviews — HITL 리뷰 이력 (감사 추적)
+CREATE TABLE IF NOT EXISTS derived_reviews (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  tenant_id TEXT NOT NULL,
+  candidate_id TEXT NOT NULL,
+  action TEXT NOT NULL
+    CHECK(action IN ('approved', 'rejected', 'revision_requested')),
+  comment TEXT,
+  modified_prompt TEXT,
+  reviewer_id TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_dr_candidate ON derived_reviews(candidate_id);
+CREATE INDEX idx_dr_tenant ON derived_reviews(tenant_id, created_at);

--- a/packages/api/src/routes/derived-engine.ts
+++ b/packages/api/src/routes/derived-engine.ts
@@ -1,0 +1,118 @@
+/**
+ * F276: DERIVED 엔진 API 라우트 — 패턴 추출 + 스킬 후보 생성 + HITL 승인
+ */
+
+import { Hono } from "hono";
+import type { Env } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import { PatternExtractorService } from "../services/pattern-extractor.js";
+import { DerivedSkillGeneratorService } from "../services/derived-skill-generator.js";
+import { DerivedReviewService } from "../services/derived-review.js";
+import {
+  extractPatternsSchema,
+  listPatternsQuerySchema,
+  generateCandidateSchema,
+  listCandidatesQuerySchema,
+  reviewCandidateSchema,
+} from "../schemas/derived-engine.js";
+
+export const derivedEngineRoute = new Hono<{
+  Bindings: Env;
+  Variables: TenantVariables;
+}>();
+
+// 1) POST /skills/derived/extract — 패턴 추출
+derivedEngineRoute.post("/skills/derived/extract", async (c) => {
+  const body = await c.req.json();
+  const parsed = extractPatternsSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid input", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new PatternExtractorService(c.env.DB);
+  const result = await svc.extract(c.get("orgId"), parsed.data);
+  return c.json(result, 201);
+});
+
+// 2) GET /skills/derived/patterns — 패턴 목록
+derivedEngineRoute.get("/skills/derived/patterns", async (c) => {
+  const parsed = listPatternsQuerySchema.safeParse(c.req.query());
+  if (!parsed.success) {
+    return c.json({ error: "Invalid query", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new PatternExtractorService(c.env.DB);
+  const result = await svc.getPatterns(c.get("orgId"), parsed.data);
+  return c.json(result);
+});
+
+// 3) GET /skills/derived/patterns/:patternId — 패턴 상세
+derivedEngineRoute.get("/skills/derived/patterns/:patternId", async (c) => {
+  const svc = new PatternExtractorService(c.env.DB);
+  const detail = await svc.getPatternDetail(c.get("orgId"), c.req.param("patternId"));
+  if (!detail) return c.json({ error: "Pattern not found" }, 404);
+  return c.json(detail);
+});
+
+// 4) POST /skills/derived/generate — 스킬 후보 생성
+derivedEngineRoute.post("/skills/derived/generate", async (c) => {
+  const body = await c.req.json();
+  const parsed = generateCandidateSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid input", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new DerivedSkillGeneratorService(c.env.DB);
+  const result = await svc.generate(
+    c.get("orgId"),
+    parsed.data.patternId,
+    { nameOverride: parsed.data.nameOverride, categoryOverride: parsed.data.categoryOverride },
+    c.get("userId"),
+  );
+  return c.json(result, 201);
+});
+
+// 5) GET /skills/derived/candidates — 후보 목록
+derivedEngineRoute.get("/skills/derived/candidates", async (c) => {
+  const parsed = listCandidatesQuerySchema.safeParse(c.req.query());
+  if (!parsed.success) {
+    return c.json({ error: "Invalid query", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new DerivedSkillGeneratorService(c.env.DB);
+  const result = await svc.listCandidates(c.get("orgId"), parsed.data);
+  return c.json(result);
+});
+
+// 6) GET /skills/derived/candidates/:candidateId — 후보 상세
+derivedEngineRoute.get("/skills/derived/candidates/:candidateId", async (c) => {
+  const svc = new DerivedSkillGeneratorService(c.env.DB);
+  const detail = await svc.getCandidateDetail(c.get("orgId"), c.req.param("candidateId"));
+  if (!detail) return c.json({ error: "Candidate not found" }, 404);
+  return c.json(detail);
+});
+
+// 7) POST /skills/derived/candidates/:candidateId/review — HITL 리뷰
+derivedEngineRoute.post("/skills/derived/candidates/:candidateId/review", async (c) => {
+  const body = await c.req.json();
+  const parsed = reviewCandidateSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid input", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new DerivedReviewService(c.env.DB);
+  const result = await svc.review(
+    c.get("orgId"),
+    c.req.param("candidateId"),
+    parsed.data,
+    c.get("userId"),
+  );
+  return c.json(result, 201);
+});
+
+// 8) GET /skills/derived/stats — 엔진 통계
+derivedEngineRoute.get("/skills/derived/stats", async (c) => {
+  const svc = new DerivedReviewService(c.env.DB);
+  const stats = await svc.getStats(c.get("orgId"));
+  return c.json(stats);
+});

--- a/packages/api/src/schemas/derived-engine.ts
+++ b/packages/api/src/schemas/derived-engine.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+
+export const extractPatternsSchema = z.object({
+  pipelineStage: z
+    .enum(["collection", "discovery", "shaping", "validation", "productization", "gtm"])
+    .optional(),
+  discoveryStage: z.string().regex(/^2-\d{1,2}$/).optional(),
+  minSampleCount: z.number().int().min(1).max(100).optional().default(5),
+  minSuccessRate: z.number().min(0).max(1).optional().default(0.7),
+  includeChains: z.boolean().optional().default(true),
+});
+
+export const listPatternsQuerySchema = z.object({
+  pipelineStage: z
+    .enum(["collection", "discovery", "shaping", "validation", "productization", "gtm"])
+    .optional(),
+  status: z.enum(["active", "consumed", "expired"]).optional(),
+  minConfidence: z.coerce.number().min(0).max(1).optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional().default(50),
+  offset: z.coerce.number().int().min(0).optional().default(0),
+});
+
+export const generateCandidateSchema = z.object({
+  patternId: z.string().min(1),
+  nameOverride: z.string().max(200).optional(),
+  categoryOverride: z
+    .enum(["general", "bd-process", "analysis", "generation", "validation", "integration"])
+    .optional(),
+});
+
+export const listCandidatesQuerySchema = z.object({
+  reviewStatus: z.enum(["pending", "approved", "rejected", "revision_requested"]).optional(),
+  category: z
+    .enum(["general", "bd-process", "analysis", "generation", "validation", "integration"])
+    .optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional().default(50),
+  offset: z.coerce.number().int().min(0).optional().default(0),
+});
+
+export const reviewCandidateSchema = z.object({
+  action: z.enum(["approved", "rejected", "revision_requested"]),
+  comment: z.string().max(2000).optional(),
+  modifiedPrompt: z.string().max(50000).optional(),
+});
+
+export type ExtractPatternsInput = z.infer<typeof extractPatternsSchema>;
+export type ListPatternsQuery = z.infer<typeof listPatternsQuerySchema>;
+export type GenerateCandidateInput = z.infer<typeof generateCandidateSchema>;
+export type ListCandidatesQuery = z.infer<typeof listCandidatesQuerySchema>;
+export type ReviewCandidateInput = z.infer<typeof reviewCandidateSchema>;

--- a/packages/api/src/services/derived-review.ts
+++ b/packages/api/src/services/derived-review.ts
@@ -1,0 +1,308 @@
+/**
+ * F276: DerivedReviewService — HITL 승인 워크플로우 + skill_registry 등록 + 통계
+ */
+
+import type {
+  DerivedReview,
+  DerivedStats,
+  SkillSafetyGrade,
+} from "@foundry-x/shared";
+import type { ReviewCandidateInput } from "../schemas/derived-engine.js";
+import { SafetyChecker } from "./safety-checker.js";
+
+export class DerivedReviewService {
+  constructor(private db: D1Database) {}
+
+  async review(
+    tenantId: string,
+    candidateId: string,
+    params: ReviewCandidateInput,
+    reviewerId: string,
+  ): Promise<DerivedReview> {
+    // Verify candidate exists and is reviewable
+    const candidate = await this.db
+      .prepare("SELECT * FROM derived_candidates WHERE tenant_id = ? AND id = ?")
+      .bind(tenantId, candidateId)
+      .first<CandidateRow>();
+
+    if (!candidate) throw new Error("Candidate not found");
+
+    const reviewId = generateId("dr");
+    const now = new Date().toISOString();
+
+    // Insert review record
+    await this.db
+      .prepare(
+        `INSERT INTO derived_reviews (id, tenant_id, candidate_id, action, comment, modified_prompt, reviewer_id)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        reviewId, tenantId, candidateId,
+        params.action, params.comment ?? null, params.modifiedPrompt ?? null,
+        reviewerId,
+      )
+      .run();
+
+    if (params.action === "approved") {
+      await this.handleApproval(tenantId, candidate, params, reviewerId, now);
+    } else if (params.action === "rejected") {
+      await this.db
+        .prepare(
+          "UPDATE derived_candidates SET review_status = 'rejected', reviewed_at = ?, reviewed_by = ? WHERE id = ?",
+        )
+        .bind(now, reviewerId, candidateId)
+        .run();
+    } else if (params.action === "revision_requested") {
+      await this.handleRevision(tenantId, candidateId, params, reviewerId, now);
+    }
+
+    return {
+      id: reviewId,
+      tenantId,
+      candidateId,
+      action: params.action,
+      comment: params.comment ?? null,
+      modifiedPrompt: params.modifiedPrompt ?? null,
+      reviewerId,
+      createdAt: now,
+    };
+  }
+
+  private async handleApproval(
+    tenantId: string,
+    candidate: CandidateRow,
+    params: ReviewCandidateInput,
+    reviewerId: string,
+    now: string,
+  ): Promise<void> {
+    const newSkillId = `derived_${candidate.id}`;
+    const registryId = generateId("sr");
+    const promptTemplate = params.modifiedPrompt ?? candidate.prompt_template;
+
+    // 1. Register in skill_registry
+    await this.db
+      .prepare(
+        `INSERT INTO skill_registry
+          (id, tenant_id, skill_id, name, description, category,
+           source_type, source_ref, prompt_template, created_by)
+         VALUES (?, ?, ?, ?, ?, ?, 'derived', ?, ?, ?)`,
+      )
+      .bind(
+        registryId, tenantId, newSkillId,
+        candidate.name, candidate.description, candidate.category,
+        candidate.pattern_id, promptTemplate, reviewerId,
+      )
+      .run();
+
+    // 2. Record lineage for each source skill
+    const sourceSkills: { skillId: string; contribution: number }[] = parseJson(candidate.source_skills, []);
+    for (const ss of sourceSkills) {
+      const lineageId = generateId("sl");
+      await this.db
+        .prepare(
+          `INSERT INTO skill_lineage
+            (id, tenant_id, parent_skill_id, child_skill_id, derivation_type, created_by)
+           VALUES (?, ?, ?, ?, 'derived', ?)`,
+        )
+        .bind(lineageId, tenantId, ss.skillId, newSkillId, reviewerId)
+        .run();
+    }
+
+    // 3. Audit log
+    const auditId = generateId("sa");
+    await this.db
+      .prepare(
+        `INSERT INTO skill_audit_log
+          (id, tenant_id, entity_type, entity_id, action, actor_id, details)
+         VALUES (?, ?, 'skill', ?, 'created', ?, ?)`,
+      )
+      .bind(
+        auditId, tenantId, newSkillId, reviewerId,
+        JSON.stringify({ source: "DERIVED", patternId: candidate.pattern_id }),
+      )
+      .run();
+
+    // 4. Update candidate
+    await this.db
+      .prepare(
+        `UPDATE derived_candidates
+         SET review_status = 'approved', registered_skill_id = ?, reviewed_at = ?, reviewed_by = ?
+         WHERE id = ?`,
+      )
+      .bind(newSkillId, now, reviewerId, candidate.id)
+      .run();
+
+    // 5. Consume pattern
+    await this.db
+      .prepare("UPDATE derived_patterns SET status = 'consumed' WHERE id = ?")
+      .bind(candidate.pattern_id)
+      .run();
+  }
+
+  private async handleRevision(
+    tenantId: string,
+    candidateId: string,
+    params: ReviewCandidateInput,
+    reviewerId: string,
+    now: string,
+  ): Promise<void> {
+    if (params.modifiedPrompt) {
+      // Update prompt + re-check safety
+      const safetyResult = SafetyChecker.check(params.modifiedPrompt);
+      await this.db
+        .prepare(
+          `UPDATE derived_candidates
+           SET prompt_template = ?, safety_grade = ?, safety_score = ?,
+               review_status = 'pending', reviewed_at = ?, reviewed_by = ?
+           WHERE id = ?`,
+        )
+        .bind(
+          params.modifiedPrompt, safetyResult.grade, safetyResult.score,
+          now, reviewerId, candidateId,
+        )
+        .run();
+    } else {
+      await this.db
+        .prepare(
+          `UPDATE derived_candidates
+           SET review_status = 'revision_requested', reviewed_at = ?, reviewed_by = ?
+           WHERE id = ?`,
+        )
+        .bind(now, reviewerId, candidateId)
+        .run();
+    }
+  }
+
+  async getReviews(tenantId: string, candidateId: string): Promise<DerivedReview[]> {
+    const rows = await this.db
+      .prepare(
+        "SELECT * FROM derived_reviews WHERE tenant_id = ? AND candidate_id = ? ORDER BY created_at DESC",
+      )
+      .bind(tenantId, candidateId)
+      .all<ReviewRow>();
+
+    return (rows.results ?? []).map(mapReviewRow);
+  }
+
+  async getStats(tenantId: string): Promise<DerivedStats> {
+    const pRow = await this.db
+      .prepare(
+        `SELECT
+           COUNT(*) as total,
+           SUM(CASE WHEN status = 'active' THEN 1 ELSE 0 END) as active_cnt,
+           SUM(CASE WHEN status = 'consumed' THEN 1 ELSE 0 END) as consumed_cnt,
+           SUM(CASE WHEN status = 'expired' THEN 1 ELSE 0 END) as expired_cnt,
+           AVG(CASE WHEN status = 'active' THEN confidence ELSE NULL END) as avg_conf
+         FROM derived_patterns WHERE tenant_id = ?`,
+      )
+      .bind(tenantId)
+      .first<{
+        total: number; active_cnt: number; consumed_cnt: number;
+        expired_cnt: number; avg_conf: number | null;
+      }>();
+
+    const cRow = await this.db
+      .prepare(
+        `SELECT
+           COUNT(*) as total,
+           SUM(CASE WHEN review_status = 'pending' THEN 1 ELSE 0 END) as pending_cnt,
+           SUM(CASE WHEN review_status = 'approved' THEN 1 ELSE 0 END) as approved_cnt,
+           SUM(CASE WHEN review_status = 'rejected' THEN 1 ELSE 0 END) as rejected_cnt,
+           SUM(CASE WHEN registered_skill_id IS NOT NULL THEN 1 ELSE 0 END) as registered_cnt
+         FROM derived_candidates WHERE tenant_id = ?`,
+      )
+      .bind(tenantId)
+      .first<{
+        total: number; pending_cnt: number; approved_cnt: number;
+        rejected_cnt: number; registered_cnt: number;
+      }>();
+
+    const topStageRows = await this.db
+      .prepare(
+        `SELECT pipeline_stage as stage, COUNT(*) as cnt
+         FROM derived_patterns WHERE tenant_id = ?
+         GROUP BY pipeline_stage ORDER BY cnt DESC LIMIT 5`,
+      )
+      .bind(tenantId)
+      .all<{ stage: string; cnt: number }>();
+
+    const approved = cRow?.approved_cnt ?? 0;
+    const rejected = cRow?.rejected_cnt ?? 0;
+    const reviewedTotal = approved + rejected;
+
+    return {
+      totalPatterns: pRow?.total ?? 0,
+      activePatterns: pRow?.active_cnt ?? 0,
+      consumedPatterns: pRow?.consumed_cnt ?? 0,
+      expiredPatterns: pRow?.expired_cnt ?? 0,
+      totalCandidates: cRow?.total ?? 0,
+      pendingCandidates: cRow?.pending_cnt ?? 0,
+      approvedCandidates: approved,
+      rejectedCandidates: rejected,
+      approvalRate: reviewedTotal > 0 ? Math.round((approved / reviewedTotal) * 100) / 100 : 0,
+      registeredSkills: cRow?.registered_cnt ?? 0,
+      avgConfidence: Math.round((pRow?.avg_conf ?? 0) * 1000) / 1000,
+      topStages: (topStageRows.results ?? []).map((r) => ({
+        stage: r.stage,
+        patternCount: r.cnt,
+      })),
+    };
+  }
+}
+
+// ─── Helpers ───
+
+interface CandidateRow {
+  id: string;
+  tenant_id: string;
+  pattern_id: string;
+  name: string;
+  description: string | null;
+  category: string;
+  prompt_template: string;
+  source_skills: string;
+  similarity_score: number;
+  safety_grade: string;
+  safety_score: number;
+  review_status: string;
+  registered_skill_id: string | null;
+}
+
+interface ReviewRow {
+  id: string;
+  tenant_id: string;
+  candidate_id: string;
+  action: string;
+  comment: string | null;
+  modified_prompt: string | null;
+  reviewer_id: string;
+  created_at: string;
+}
+
+function mapReviewRow(r: ReviewRow): DerivedReview {
+  return {
+    id: r.id,
+    tenantId: r.tenant_id,
+    candidateId: r.candidate_id,
+    action: r.action as DerivedReview["action"],
+    comment: r.comment,
+    modifiedPrompt: r.modified_prompt,
+    reviewerId: r.reviewer_id,
+    createdAt: r.created_at,
+  };
+}
+
+function parseJson<T>(raw: string | null, fallback: T): T {
+  if (!raw) return fallback;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return fallback;
+  }
+}
+
+function generateId(prefix: string): string {
+  const t = Date.now().toString(36);
+  const r = Math.random().toString(36).substring(2, 10);
+  return `${prefix}_${t}${r}`;
+}

--- a/packages/api/src/services/derived-skill-generator.ts
+++ b/packages/api/src/services/derived-skill-generator.ts
@@ -1,0 +1,335 @@
+/**
+ * F276: DerivedSkillGeneratorService — 패턴 → 스킬 후보 생성 + 중복 감지 + 안전성 사전 검사
+ */
+
+import type {
+  DerivedCandidate,
+  DerivedCandidateDetail,
+  DerivedPattern,
+  DerivedReview,
+  SkillCategory,
+  SkillSafetyGrade,
+  SkillRegistryEntry,
+} from "@foundry-x/shared";
+import type { ListCandidatesQuery } from "../schemas/derived-engine.js";
+import { SafetyChecker } from "./safety-checker.js";
+
+export class DerivedSkillGeneratorService {
+  constructor(private db: D1Database) {}
+
+  async generate(
+    tenantId: string,
+    patternId: string,
+    overrides?: { nameOverride?: string; categoryOverride?: string },
+    actorId?: string,
+  ): Promise<DerivedCandidate> {
+    // 1. Fetch pattern
+    const pattern = await this.db
+      .prepare("SELECT * FROM derived_patterns WHERE tenant_id = ? AND id = ?")
+      .bind(tenantId, patternId)
+      .first<PatternRow>();
+
+    if (!pattern) throw new Error("Pattern not found");
+    if (pattern.status !== "active") throw new Error("Pattern is not active");
+
+    const skillIds: string[] = parseJson(pattern.skill_ids, []);
+
+    // 2. Fetch source skills from registry
+    const sourceSkills: SkillRegistryRow[] = [];
+    for (const sid of skillIds) {
+      const row = await this.db
+        .prepare("SELECT * FROM skill_registry WHERE tenant_id = ? AND skill_id = ? AND deleted_at IS NULL")
+        .bind(tenantId, sid)
+        .first<SkillRegistryRow>();
+      if (row) sourceSkills.push(row);
+    }
+
+    // 3. Build prompt template
+    const skillNames = sourceSkills.map((s) => s.name).join(" + ");
+    const stage = pattern.pipeline_stage;
+    const name = overrides?.nameOverride ?? `${stage} 최적화 — ${skillNames || skillIds.join("+")} 기반`;
+    const description = `${stage}에서 성공률 ${Math.round(pattern.success_rate * 100)}%로 검증된 패턴 기반 파생 스킬`;
+
+    const promptParts = sourceSkills
+      .filter((s) => s.prompt_template)
+      .map((s) => s.prompt_template!);
+    const promptTemplate = promptParts.length > 0
+      ? `# ${name}\n\n## 기반 패턴\n성공률: ${Math.round(pattern.success_rate * 100)}%, 샘플: ${pattern.sample_count}\n\n## 통합 프롬프트\n${promptParts.join("\n\n---\n\n")}`
+      : `# ${name}\n\n${description}\n\n성공률: ${Math.round(pattern.success_rate * 100)}%, 샘플: ${pattern.sample_count}`;
+
+    // 4. Determine category
+    const category: SkillCategory = (overrides?.categoryOverride as SkillCategory) ??
+      determineMajorCategory(sourceSkills) ??
+      "general";
+
+    // 5. Source skill contributions
+    const contribution = sourceSkills.length > 0 ? 1 / sourceSkills.length : 1;
+    const sourceSkillsJson = skillIds.map((sid) => ({
+      skillId: sid,
+      contribution: Math.round(contribution * 100) / 100,
+    }));
+
+    // 6. Duplicate detection via search index
+    const similarityScore = await this.checkSimilarity(tenantId, name, description);
+
+    // 7. Safety pre-check
+    const safetyResult = SafetyChecker.check(promptTemplate);
+
+    // 8. Insert candidate
+    const id = generateId("dc");
+    await this.db
+      .prepare(
+        `INSERT INTO derived_candidates
+          (id, tenant_id, pattern_id, name, description, category, prompt_template,
+           source_skills, similarity_score, safety_grade, safety_score, review_status)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending')`,
+      )
+      .bind(
+        id, tenantId, patternId, name, description, category, promptTemplate,
+        JSON.stringify(sourceSkillsJson), similarityScore,
+        safetyResult.grade, safetyResult.score,
+      )
+      .run();
+
+    return {
+      id,
+      tenantId,
+      patternId,
+      name,
+      description,
+      category,
+      promptTemplate,
+      sourceSkills: sourceSkillsJson,
+      similarityScore,
+      safetyGrade: safetyResult.grade as SkillSafetyGrade,
+      safetyScore: safetyResult.score,
+      reviewStatus: "pending",
+      registeredSkillId: null,
+      createdAt: new Date().toISOString(),
+      reviewedAt: null,
+      reviewedBy: null,
+    };
+  }
+
+  async listCandidates(
+    tenantId: string,
+    params: ListCandidatesQuery,
+  ): Promise<{ candidates: DerivedCandidate[]; total: number }> {
+    let countSql = "SELECT COUNT(*) as cnt FROM derived_candidates WHERE tenant_id = ?";
+    let sql = "SELECT * FROM derived_candidates WHERE tenant_id = ?";
+    const bindings: unknown[] = [tenantId];
+
+    if (params.reviewStatus) {
+      countSql += " AND review_status = ?";
+      sql += " AND review_status = ?";
+      bindings.push(params.reviewStatus);
+    }
+    if (params.category) {
+      countSql += " AND category = ?";
+      sql += " AND category = ?";
+      bindings.push(params.category);
+    }
+
+    const countBindings = [...bindings];
+    sql += " ORDER BY created_at DESC LIMIT ? OFFSET ?";
+    bindings.push(params.limit, params.offset);
+
+    const [countRow, rows] = await Promise.all([
+      this.db.prepare(countSql).bind(...countBindings).first<{ cnt: number }>(),
+      this.db.prepare(sql).bind(...bindings).all<CandidateRow>(),
+    ]);
+
+    return {
+      candidates: (rows.results ?? []).map(mapCandidateRow),
+      total: countRow?.cnt ?? 0,
+    };
+  }
+
+  async getCandidateById(tenantId: string, candidateId: string): Promise<DerivedCandidate | null> {
+    const row = await this.db
+      .prepare("SELECT * FROM derived_candidates WHERE tenant_id = ? AND id = ?")
+      .bind(tenantId, candidateId)
+      .first<CandidateRow>();
+
+    return row ? mapCandidateRow(row) : null;
+  }
+
+  async getCandidateDetail(tenantId: string, candidateId: string): Promise<DerivedCandidateDetail | null> {
+    const candidate = await this.getCandidateById(tenantId, candidateId);
+    if (!candidate) return null;
+
+    // Pattern
+    const patternRow = await this.db
+      .prepare("SELECT * FROM derived_patterns WHERE tenant_id = ? AND id = ?")
+      .bind(tenantId, candidate.patternId)
+      .first<Record<string, unknown>>();
+
+    // Reviews
+    const reviewRows = await this.db
+      .prepare("SELECT * FROM derived_reviews WHERE tenant_id = ? AND candidate_id = ? ORDER BY created_at DESC")
+      .bind(tenantId, candidateId)
+      .all<ReviewRow>();
+
+    // Source skill entries
+    const sourceSkillEntries: SkillRegistryEntry[] = [];
+    for (const ss of candidate.sourceSkills) {
+      const row = await this.db
+        .prepare("SELECT * FROM skill_registry WHERE tenant_id = ? AND skill_id = ? AND deleted_at IS NULL")
+        .bind(tenantId, ss.skillId)
+        .first<Record<string, unknown>>();
+      if (row) sourceSkillEntries.push(row as unknown as SkillRegistryEntry);
+    }
+
+    return {
+      ...candidate,
+      pattern: patternRow as unknown as DerivedPattern,
+      reviews: (reviewRows.results ?? []).map(mapReviewRow),
+      sourceSkillEntries,
+    };
+  }
+
+  private async checkSimilarity(tenantId: string, name: string, description: string): Promise<number> {
+    // Simple check: search the search index for similar tokens
+    const tokens = tokenize(`${name} ${description}`);
+    if (tokens.length === 0) return 0;
+
+    const placeholders = tokens.map(() => "?").join(",");
+    const row = await this.db
+      .prepare(
+        `SELECT COUNT(DISTINCT skill_id) as match_count
+         FROM skill_search_index
+         WHERE tenant_id = ? AND token IN (${placeholders})`,
+      )
+      .bind(tenantId, ...tokens)
+      .first<{ match_count: number }>();
+
+    const matchCount = row?.match_count ?? 0;
+    // Rough similarity: proportion of matching skills to total tokens
+    return Math.min(matchCount / Math.max(tokens.length, 1), 1);
+  }
+}
+
+// ─── Helpers ───
+
+interface PatternRow {
+  id: string;
+  tenant_id: string;
+  pipeline_stage: string;
+  discovery_stage: string | null;
+  pattern_type: string;
+  skill_ids: string;
+  success_rate: number;
+  sample_count: number;
+  status: string;
+  prompt_template?: string;
+}
+
+interface SkillRegistryRow {
+  id: string;
+  skill_id: string;
+  name: string;
+  description: string | null;
+  category: string;
+  prompt_template: string | null;
+}
+
+interface CandidateRow {
+  id: string;
+  tenant_id: string;
+  pattern_id: string;
+  name: string;
+  description: string | null;
+  category: string;
+  prompt_template: string;
+  source_skills: string;
+  similarity_score: number;
+  safety_grade: string;
+  safety_score: number;
+  review_status: string;
+  registered_skill_id: string | null;
+  created_at: string;
+  reviewed_at: string | null;
+  reviewed_by: string | null;
+}
+
+interface ReviewRow {
+  id: string;
+  tenant_id: string;
+  candidate_id: string;
+  action: string;
+  comment: string | null;
+  modified_prompt: string | null;
+  reviewer_id: string;
+  created_at: string;
+}
+
+function mapCandidateRow(r: CandidateRow): DerivedCandidate {
+  return {
+    id: r.id,
+    tenantId: r.tenant_id,
+    patternId: r.pattern_id,
+    name: r.name,
+    description: r.description,
+    category: r.category as SkillCategory,
+    promptTemplate: r.prompt_template,
+    sourceSkills: parseJson(r.source_skills, []),
+    similarityScore: r.similarity_score,
+    safetyGrade: r.safety_grade as SkillSafetyGrade,
+    safetyScore: r.safety_score,
+    reviewStatus: r.review_status as DerivedCandidate["reviewStatus"],
+    registeredSkillId: r.registered_skill_id,
+    createdAt: r.created_at,
+    reviewedAt: r.reviewed_at,
+    reviewedBy: r.reviewed_by,
+  };
+}
+
+function mapReviewRow(r: ReviewRow): DerivedReview {
+  return {
+    id: r.id,
+    tenantId: r.tenant_id,
+    candidateId: r.candidate_id,
+    action: r.action as DerivedReview["action"],
+    comment: r.comment,
+    modifiedPrompt: r.modified_prompt,
+    reviewerId: r.reviewer_id,
+    createdAt: r.created_at,
+  };
+}
+
+function parseJson<T>(raw: string | null, fallback: T): T {
+  if (!raw) return fallback;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return fallback;
+  }
+}
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9가-힣\s-]/g, " ")
+    .split(/\s+/)
+    .filter((t) => t.length >= 2);
+}
+
+function determineMajorCategory(skills: SkillRegistryRow[]): SkillCategory | null {
+  if (skills.length === 0) return null;
+  const counts: Record<string, number> = {};
+  for (const s of skills) {
+    counts[s.category] = (counts[s.category] ?? 0) + 1;
+  }
+  let max = 0;
+  let maxCat = "general";
+  for (const [cat, cnt] of Object.entries(counts)) {
+    if (cnt > max) { max = cnt; maxCat = cat; }
+  }
+  return maxCat as SkillCategory;
+}
+
+function generateId(prefix: string): string {
+  const t = Date.now().toString(36);
+  const r = Math.random().toString(36).substring(2, 10);
+  return `${prefix}_${t}${r}`;
+}

--- a/packages/api/src/services/pattern-extractor.ts
+++ b/packages/api/src/services/pattern-extractor.ts
@@ -1,0 +1,386 @@
+/**
+ * F276: PatternExtractorService — skill_executions 성공 패턴 자동 추출
+ */
+
+import type {
+  DerivedPattern,
+  DerivedPatternDetail,
+  DerivedPatternStatus,
+  PipelineStage,
+  SkillRegistryEntry,
+  SkillExecutionRecord,
+} from "@foundry-x/shared";
+import type { ExtractPatternsInput, ListPatternsQuery } from "../schemas/derived-engine.js";
+
+export class PatternExtractorService {
+  constructor(private db: D1Database) {}
+
+  async extract(
+    tenantId: string,
+    params: ExtractPatternsInput,
+  ): Promise<{ patterns: DerivedPattern[]; count: number }> {
+    const singlePatterns = await this.extractSinglePatterns(tenantId, params);
+
+    let chainPatterns: DerivedPattern[] = [];
+    if (params.includeChains) {
+      chainPatterns = await this.extractChainPatterns(tenantId, params);
+    }
+
+    const allPatterns = [...singlePatterns, ...chainPatterns];
+    return { patterns: allPatterns, count: allPatterns.length };
+  }
+
+  private async extractSinglePatterns(
+    tenantId: string,
+    params: ExtractPatternsInput,
+  ): Promise<DerivedPattern[]> {
+    let sql = `
+      SELECT
+        se.skill_id,
+        COALESCE(se.biz_item_id, 'unknown') AS pipeline_stage,
+        NULL AS discovery_stage,
+        COUNT(*) AS sample_count,
+        SUM(CASE WHEN se.status = 'completed' THEN 1 ELSE 0 END) * 1.0 / COUNT(*) AS success_rate,
+        AVG(se.cost_usd) AS avg_cost_usd,
+        AVG(se.duration_ms) AS avg_duration_ms
+      FROM skill_executions se
+      WHERE se.tenant_id = ?
+    `;
+    const bindings: unknown[] = [tenantId];
+
+    if (params.pipelineStage) {
+      sql += " AND se.biz_item_id = ?";
+      bindings.push(params.pipelineStage);
+    }
+
+    sql += `
+      GROUP BY se.skill_id, pipeline_stage
+      HAVING sample_count >= ? AND success_rate >= ?
+    `;
+    bindings.push(params.minSampleCount, params.minSuccessRate);
+
+    const rows = await this.db
+      .prepare(sql)
+      .bind(...bindings)
+      .all<{
+        skill_id: string;
+        pipeline_stage: string;
+        discovery_stage: string | null;
+        sample_count: number;
+        success_rate: number;
+        avg_cost_usd: number;
+        avg_duration_ms: number;
+      }>();
+
+    const patterns: DerivedPattern[] = [];
+    for (const r of rows.results ?? []) {
+      const confidence = wilsonScoreLowerBound(r.success_rate, r.sample_count);
+      const id = generateId("dp");
+      const expiresAt = new Date(Date.now() + 30 * 86400_000).toISOString();
+
+      const stage = isValidPipelineStage(r.pipeline_stage)
+        ? r.pipeline_stage
+        : "discovery";
+
+      await this.db
+        .prepare(
+          `INSERT INTO derived_patterns
+            (id, tenant_id, pipeline_stage, discovery_stage, pattern_type, skill_ids,
+             success_rate, sample_count, avg_cost_usd, avg_duration_ms, confidence, status, expires_at)
+           VALUES (?, ?, ?, ?, 'single', ?, ?, ?, ?, ?, ?, 'active', ?)`,
+        )
+        .bind(
+          id, tenantId, stage, r.discovery_stage,
+          JSON.stringify([r.skill_id]),
+          r.success_rate, r.sample_count,
+          r.avg_cost_usd ?? 0, Math.round(r.avg_duration_ms ?? 0),
+          confidence, expiresAt,
+        )
+        .run();
+
+      patterns.push({
+        id,
+        tenantId,
+        pipelineStage: stage as PipelineStage,
+        discoveryStage: r.discovery_stage,
+        patternType: "single",
+        skillIds: [r.skill_id],
+        successRate: r.success_rate,
+        sampleCount: r.sample_count,
+        avgCostUsd: r.avg_cost_usd ?? 0,
+        avgDurationMs: Math.round(r.avg_duration_ms ?? 0),
+        confidence,
+        status: "active",
+        extractedAt: new Date().toISOString(),
+        expiresAt,
+      });
+    }
+
+    return patterns;
+  }
+
+  private async extractChainPatterns(
+    tenantId: string,
+    params: ExtractPatternsInput,
+  ): Promise<DerivedPattern[]> {
+    const minChainSample = Math.max(Math.floor(params.minSampleCount / 2), 3);
+
+    let sql = `
+      SELECT
+        se1.skill_id AS skill_1,
+        se2.skill_id AS skill_2,
+        COUNT(*) AS chain_count,
+        SUM(CASE WHEN se1.status = 'completed' AND se2.status = 'completed' THEN 1 ELSE 0 END)
+          * 1.0 / COUNT(*) AS chain_success_rate
+      FROM skill_executions se1
+        JOIN skill_executions se2 ON se1.biz_item_id = se2.biz_item_id
+          AND se1.tenant_id = se2.tenant_id
+          AND se2.executed_at > se1.executed_at
+          AND julianday(se2.executed_at) - julianday(se1.executed_at) < 0.0208
+          AND se1.skill_id != se2.skill_id
+      WHERE se1.tenant_id = ?
+    `;
+    const bindings: unknown[] = [tenantId];
+
+    if (params.pipelineStage) {
+      sql += " AND se1.biz_item_id = ?";
+      bindings.push(params.pipelineStage);
+    }
+
+    sql += `
+      GROUP BY se1.skill_id, se2.skill_id
+      HAVING chain_count >= ? AND chain_success_rate >= 0.65
+    `;
+    bindings.push(minChainSample);
+
+    const rows = await this.db
+      .prepare(sql)
+      .bind(...bindings)
+      .all<{
+        skill_1: string;
+        skill_2: string;
+        chain_count: number;
+        chain_success_rate: number;
+      }>();
+
+    const patterns: DerivedPattern[] = [];
+    for (const r of rows.results ?? []) {
+      const confidence = wilsonScoreLowerBound(r.chain_success_rate, r.chain_count);
+      const id = generateId("dp");
+      const expiresAt = new Date(Date.now() + 30 * 86400_000).toISOString();
+
+      const stage = params.pipelineStage ?? "discovery";
+
+      await this.db
+        .prepare(
+          `INSERT INTO derived_patterns
+            (id, tenant_id, pipeline_stage, pattern_type, skill_ids,
+             success_rate, sample_count, avg_cost_usd, avg_duration_ms, confidence, status, expires_at)
+           VALUES (?, ?, ?, 'chain', ?, ?, ?, 0, 0, ?, 'active', ?)`,
+        )
+        .bind(
+          id, tenantId, stage,
+          JSON.stringify([r.skill_1, r.skill_2]),
+          r.chain_success_rate, r.chain_count,
+          confidence, expiresAt,
+        )
+        .run();
+
+      patterns.push({
+        id,
+        tenantId,
+        pipelineStage: stage as PipelineStage,
+        discoveryStage: null,
+        patternType: "chain",
+        skillIds: [r.skill_1, r.skill_2],
+        successRate: r.chain_success_rate,
+        sampleCount: r.chain_count,
+        avgCostUsd: 0,
+        avgDurationMs: 0,
+        confidence,
+        status: "active",
+        extractedAt: new Date().toISOString(),
+        expiresAt,
+      });
+    }
+
+    return patterns;
+  }
+
+  async getPatterns(
+    tenantId: string,
+    params: ListPatternsQuery,
+  ): Promise<{ patterns: DerivedPattern[]; total: number }> {
+    let countSql = "SELECT COUNT(*) as cnt FROM derived_patterns WHERE tenant_id = ?";
+    let sql = "SELECT * FROM derived_patterns WHERE tenant_id = ?";
+    const bindings: unknown[] = [tenantId];
+
+    if (params.pipelineStage) {
+      countSql += " AND pipeline_stage = ?";
+      sql += " AND pipeline_stage = ?";
+      bindings.push(params.pipelineStage);
+    }
+    if (params.status) {
+      countSql += " AND status = ?";
+      sql += " AND status = ?";
+      bindings.push(params.status);
+    }
+    if (params.minConfidence !== undefined) {
+      countSql += " AND confidence >= ?";
+      sql += " AND confidence >= ?";
+      bindings.push(params.minConfidence);
+    }
+
+    const countBindings = [...bindings];
+    sql += " ORDER BY confidence DESC LIMIT ? OFFSET ?";
+    bindings.push(params.limit, params.offset);
+
+    const [countRow, rows] = await Promise.all([
+      this.db.prepare(countSql).bind(...countBindings).first<{ cnt: number }>(),
+      this.db.prepare(sql).bind(...bindings).all<PatternRow>(),
+    ]);
+
+    return {
+      patterns: (rows.results ?? []).map(mapPatternRow),
+      total: countRow?.cnt ?? 0,
+    };
+  }
+
+  async getPatternById(tenantId: string, patternId: string): Promise<DerivedPattern | null> {
+    const row = await this.db
+      .prepare("SELECT * FROM derived_patterns WHERE tenant_id = ? AND id = ?")
+      .bind(tenantId, patternId)
+      .first<PatternRow>();
+
+    return row ? mapPatternRow(row) : null;
+  }
+
+  async getPatternDetail(tenantId: string, patternId: string): Promise<DerivedPatternDetail | null> {
+    const pattern = await this.getPatternById(tenantId, patternId);
+    if (!pattern) return null;
+
+    // Fetch related skills from skill_registry
+    const skillRows = await this.db
+      .prepare(
+        `SELECT * FROM skill_registry WHERE tenant_id = ? AND skill_id IN (${pattern.skillIds.map(() => "?").join(",")}) AND deleted_at IS NULL`,
+      )
+      .bind(tenantId, ...pattern.skillIds)
+      .all<Record<string, unknown>>();
+
+    // Fetch sample executions
+    const execRows = await this.db
+      .prepare(
+        `SELECT id, skill_id, version, model, status,
+                input_tokens + output_tokens as total_tokens,
+                cost_usd, duration_ms, executed_by, executed_at
+         FROM skill_executions
+         WHERE tenant_id = ? AND skill_id IN (${pattern.skillIds.map(() => "?").join(",")})
+         ORDER BY executed_at DESC LIMIT 10`,
+      )
+      .bind(tenantId, ...pattern.skillIds)
+      .all<{
+        id: string; skill_id: string; version: number; model: string;
+        status: string; total_tokens: number; cost_usd: number;
+        duration_ms: number; executed_by: string; executed_at: string;
+      }>();
+
+    const sampleExecutions: SkillExecutionRecord[] = (execRows.results ?? []).map((r) => ({
+      id: r.id,
+      skillId: r.skill_id,
+      version: r.version,
+      model: r.model,
+      status: r.status as SkillExecutionRecord["status"],
+      totalTokens: r.total_tokens,
+      costUsd: r.cost_usd,
+      durationMs: r.duration_ms,
+      executedBy: r.executed_by,
+      executedAt: r.executed_at,
+    }));
+
+    return {
+      ...pattern,
+      skills: (skillRows.results ?? []) as unknown as SkillRegistryEntry[],
+      sampleExecutions,
+    };
+  }
+
+  async expireStale(): Promise<number> {
+    const result = await this.db
+      .prepare(
+        `UPDATE derived_patterns SET status = 'expired'
+         WHERE status = 'active' AND expires_at IS NOT NULL AND expires_at < datetime('now')`,
+      )
+      .run();
+    return result.meta?.changes ?? 0;
+  }
+}
+
+// ─── Helpers ───
+
+interface PatternRow {
+  id: string;
+  tenant_id: string;
+  pipeline_stage: string;
+  discovery_stage: string | null;
+  pattern_type: string;
+  skill_ids: string;
+  success_rate: number;
+  sample_count: number;
+  avg_cost_usd: number;
+  avg_duration_ms: number;
+  confidence: number;
+  status: string;
+  extracted_at: string;
+  expires_at: string | null;
+}
+
+function mapPatternRow(r: PatternRow): DerivedPattern {
+  return {
+    id: r.id,
+    tenantId: r.tenant_id,
+    pipelineStage: r.pipeline_stage as PipelineStage,
+    discoveryStage: r.discovery_stage,
+    patternType: r.pattern_type as DerivedPattern["patternType"],
+    skillIds: parseJson<string[]>(r.skill_ids, []),
+    successRate: r.success_rate,
+    sampleCount: r.sample_count,
+    avgCostUsd: r.avg_cost_usd,
+    avgDurationMs: r.avg_duration_ms,
+    confidence: r.confidence,
+    status: r.status as DerivedPatternStatus,
+    extractedAt: r.extracted_at,
+    expiresAt: r.expires_at,
+  };
+}
+
+function parseJson<T>(raw: string | null, fallback: T): T {
+  if (!raw) return fallback;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return fallback;
+  }
+}
+
+const VALID_STAGES = new Set([
+  "collection", "discovery", "shaping", "validation", "productization", "gtm",
+]);
+
+function isValidPipelineStage(s: string): boolean {
+  return VALID_STAGES.has(s);
+}
+
+export function wilsonScoreLowerBound(successRate: number, n: number, z = 1.96): number {
+  if (n === 0) return 0;
+  const p = successRate;
+  const denominator = 1 + (z * z) / n;
+  const centre = p + (z * z) / (2 * n);
+  const adjust = z * Math.sqrt((p * (1 - p) + (z * z) / (4 * n)) / n);
+  return Math.max(0, (centre - adjust) / denominator);
+}
+
+function generateId(prefix: string): string {
+  const t = Date.now().toString(36);
+  const r = Math.random().toString(36).substring(2, 10);
+  return `${prefix}_${t}${r}`;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -56,6 +56,20 @@ export type {
   SkillEnrichedView,
 } from './types.js';
 
+// F276: DERIVED 엔진 타입 (Sprint 105)
+export type {
+  DerivedPatternType,
+  DerivedPatternStatus,
+  DerivedReviewStatus,
+  PipelineStage,
+  DerivedPattern,
+  DerivedPatternDetail,
+  DerivedCandidate,
+  DerivedCandidateDetail,
+  DerivedReview,
+  DerivedStats,
+} from './types.js';
+
 // Web Dashboard types (Sprint 5 Part A)
 export type {
   WikiPage,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -537,3 +537,83 @@ export interface SkillEnrichedView {
   versions: SkillVersionRecord[];
   lineage: SkillLineageNode | null;
 }
+
+// ─── F276: DERIVED 엔진 타입 ───
+
+export type DerivedPatternType = "single" | "chain";
+export type DerivedPatternStatus = "active" | "consumed" | "expired";
+export type DerivedReviewStatus = "pending" | "approved" | "rejected" | "revision_requested";
+export type PipelineStage = "collection" | "discovery" | "shaping" | "validation" | "productization" | "gtm";
+
+export interface DerivedPattern {
+  id: string;
+  tenantId: string;
+  pipelineStage: PipelineStage;
+  discoveryStage: string | null;
+  patternType: DerivedPatternType;
+  skillIds: string[];
+  successRate: number;
+  sampleCount: number;
+  avgCostUsd: number;
+  avgDurationMs: number;
+  confidence: number;
+  status: DerivedPatternStatus;
+  extractedAt: string;
+  expiresAt: string | null;
+}
+
+export interface DerivedPatternDetail extends DerivedPattern {
+  skills: SkillRegistryEntry[];
+  sampleExecutions: SkillExecutionRecord[];
+}
+
+export interface DerivedCandidate {
+  id: string;
+  tenantId: string;
+  patternId: string;
+  name: string;
+  description: string | null;
+  category: SkillCategory;
+  promptTemplate: string;
+  sourceSkills: { skillId: string; contribution: number }[];
+  similarityScore: number;
+  safetyGrade: SkillSafetyGrade;
+  safetyScore: number;
+  reviewStatus: DerivedReviewStatus;
+  registeredSkillId: string | null;
+  createdAt: string;
+  reviewedAt: string | null;
+  reviewedBy: string | null;
+}
+
+export interface DerivedCandidateDetail extends DerivedCandidate {
+  pattern: DerivedPattern;
+  reviews: DerivedReview[];
+  sourceSkillEntries: SkillRegistryEntry[];
+}
+
+export interface DerivedReview {
+  id: string;
+  tenantId: string;
+  candidateId: string;
+  action: "approved" | "rejected" | "revision_requested";
+  comment: string | null;
+  modifiedPrompt: string | null;
+  reviewerId: string;
+  createdAt: string;
+}
+
+export interface DerivedStats {
+  totalPatterns: number;
+  activePatterns: number;
+  consumedPatterns: number;
+  expiredPatterns: number;
+  totalCandidates: number;
+  pendingCandidates: number;
+  approvedCandidates: number;
+  rejectedCandidates: number;
+  approvalRate: number;
+  registeredSkills: number;
+  avgConfidence: number;
+  topStages: { stage: string; patternCount: number }[];
+}


### PR DESCRIPTION
## Summary
- F276: Track C DERIVED 엔진 — BD 7단계 반복 성공 패턴 자동 추출 + 새 스킬 생성 + HITL 승인
- D1 0082 (3테이블: derived_patterns, derived_candidates, derived_reviews)
- 3 서비스 + API 8 endpoints + Zod 5개 스키마 + Shared 11개 타입
- **40 tests** (전체 2311→2351), typecheck ✅, Match Rate **100%**

## Changes
- `PatternExtractorService`: Wilson score 기반 성공 패턴 자동 추출 (단일+체이닝)
- `DerivedSkillGeneratorService`: 패턴→스킬 후보 생성 + 중복 감지 + SafetyChecker 사전 검사
- `DerivedReviewService`: HITL 승인 워크플로우 (approve→registry+lineage+audit, reject, revision)

## Test plan
- [x] PatternExtractorService 11 tests (단일/체이닝 패턴, 임계값 필터, 페이지네이션)
- [x] DerivedSkillGeneratorService 6 tests (후보 생성, 에러 케이스, 필터)
- [x] DerivedReviewService 9 tests (승인→등록, 반려, 수정 요청, 통계)
- [x] Route 14 tests (8 endpoints × 정상/에러)
- [x] typecheck 전체 통과
- [x] 기존 2311 테스트 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)