### PR TITLE
feat: Sprint 113 F288+F289 — Role-based Sidebar + 리브랜딩

### DIFF
--- a/docs/03-analysis/features/sprint-113-ia-structure.analysis.md
+++ b/docs/03-analysis/features/sprint-113-ia-structure.analysis.md
@@ -1,0 +1,77 @@
+---
+code: FX-ANLS-113
+title: Sprint 113 Gap Analysis — Role-based Sidebar + 리브랜딩
+version: 1.0
+status: Active
+category: ANLS
+created: 2026-04-03
+updated: 2026-04-03
+author: Sinclair Seo
+sprint: 113
+f-items: F288, F289
+design-ref: FX-DSGN-113
+---
+
+# Sprint 113 Gap Analysis — Role-based Sidebar + 리브랜딩
+
+> Design 참조: [[FX-DSGN-113]] `docs/02-design/features/sprint-113-ia-structure.design.md`
+
+---
+
+## Executive Summary
+
+| 항목 | 내용 |
+|------|------|
+| **Feature** | F288 Role-based Sidebar + F289 리브랜딩 |
+| **Sprint** | 113 |
+| **분석일** | 2026-04-03 |
+| **Match Rate** | **92%** (11/12 항목 Pass) |
+
+| Perspective | Content |
+|-------------|---------|
+| **Problem** | BD 팀원에게 개발자 전용 메뉴 노출 + Figma v0.92 명칭 불일치 |
+| **Solution** | NavItem.visibility + useUserRole 필터링 + 리브랜딩 3건 |
+| **Function/UX Effect** | Member ~18메뉴, Admin ~29메뉴. Role 기반 네비게이션 |
+| **Core Value** | BD 팀원이 사업개발 워크플로에 집중할 수 있는 역할 기반 UX |
+
+---
+
+## 검증 결과
+
+| V# | 검증 항목 | 결과 | 근거 |
+|----|----------|:----:|------|
+| V-01 | NavItem에 visibility 속성 존재 | ✅ | sidebar.tsx L70-76 |
+| V-02 | isVisible 유틸 함수 존재 + 정상 동작 | ✅ | sidebar.tsx L88-96 + T-01~T-04 |
+| V-03 | Admin 전용 메뉴 9개 마킹 | ✅ | adminGroup, externalGroup, knowledge 3아이템 |
+| V-04 | Member 로그인 시 관리/외부서비스 미노출 | ✅ | T-05 통과 |
+| V-05 | Admin 로그인 시 전체 메뉴 노출 | ✅ | T-06 통과 |
+| V-06 | 리브랜딩 3건 반영 | ✅ | T-07 (Field 수집), T-08 (IDEA Portal), T-09 (PRD) |
+| V-07 | 지식 그룹 아이템 레벨 필터링 | ✅ | T-10 + isVisible 유닛테스트 |
+| V-08 | 시작하기 조건부 노출 | ✅ | topItems conditional visibility |
+| V-09 | Member 하단 도움말+설정 노출 | ✅ | memberBottomItems + !isAdmin 조건 |
+| V-10 | 기존 Web 테스트 전체 통과 | ✅ | 287/287 pass |
+| V-11 | TypeScript 에러 0건 | ✅ | tsc --noEmit 통과 |
+| V-12 | E2E 35 specs 통과 | ⏭️ | CI에서 확인 (로컬 Playwright 미설치) |
+
+---
+
+## 변경 파일 요약
+
+| 파일 | 변경 유형 | 변경 내용 |
+|------|:--------:|----------|
+| `packages/web/src/components/sidebar.tsx` | MODIFY | Visibility 타입 + isVisible + NavLinks 필터링 + 리브랜딩 |
+| `packages/web/src/__tests__/sidebar-visibility.test.tsx` | NEW | 14개 테스트 (유닛 5 + 통합 9) |
+
+---
+
+## 미해결 항목
+
+- V-12 E2E: CI/CD 파이프라인에서 자동 검증 예정 (PR merge 전 GitHub Actions)
+
+---
+
+## Version History
+
+| Version | Date | Changes | Author |
+|---------|------|---------|--------|
+| 1.0 | 2026-04-03 | Initial analysis — Match 92% | Sinclair Seo |

--- a/docs/04-report/features/sprint-113-ia-structure.report.md
+++ b/docs/04-report/features/sprint-113-ia-structure.report.md
@@ -1,0 +1,101 @@
+---
+code: FX-RPRT-113
+title: Sprint 113 Report — Role-based Sidebar + 리브랜딩
+version: 1.0
+status: Active
+category: RPRT
+created: 2026-04-03
+updated: 2026-04-03
+author: Sinclair Seo
+sprint: 113
+f-items: F288, F289
+plan-ref: FX-PLAN-113
+design-ref: FX-DSGN-113
+analysis-ref: FX-ANLS-113
+---
+
+# Sprint 113 Report — Role-based Sidebar + 리브랜딩
+
+---
+
+## Executive Summary
+
+| 항목 | 내용 |
+|------|------|
+| **Feature** | F288 Role-based Sidebar + F289 리브랜딩 |
+| **Sprint** | 113 |
+| **Phase** | Phase 11-A (IA 구조 기반) |
+| **완료일** | 2026-04-03 |
+| **Match Rate** | **92%** (11/12) |
+| **변경 파일** | 2개 (sidebar.tsx MODIFY + sidebar-visibility.test.tsx NEW) |
+| **테스트** | 287/287 pass (기존 273 + 신규 14) |
+
+| Perspective | Content |
+|-------------|---------|
+| **Problem** | BD 팀원에게 개발자 전용 메뉴(토큰/에이전트/아키텍처 등) 노출 → 혼란. Figma v0.92 명칭 불일치 |
+| **Solution** | NavItem.visibility 속성 + useUserRole 필터링 + 리브랜딩 3건 |
+| **Function/UX Effect** | Member ~18메뉴, Admin ~29메뉴. BD 프로세스 6단계에 집중 가능 |
+| **Core Value** | 역할 기반 네비게이션으로 BD 팀원의 플랫폼 진입 장벽 해소 |
+
+---
+
+## PDCA 참조 체인
+
+```
+FX-PLAN-113 → FX-DSGN-113 → (Implement) → FX-ANLS-113 → FX-RPRT-113
+```
+
+---
+
+## 구현 상세
+
+### F288: Role-based Sidebar Visibility
+
+1. **NavItem/NavGroup 인터페이스 확장**: `visibility` + `condition` 필드 추가
+2. **isVisible() 유틸 함수**: `all` / `admin` / `conditional` 3가지 가시성 모드
+3. **useUserRole() 연결**: JWT 기반 role → `isAdmin` 플래그 → useMemo 필터링
+4. **Admin 전용 마킹**: adminGroup(그룹 레벨), externalGroup(그룹 레벨), knowledgeGroup 3아이템(아이템 레벨)
+5. **Member 하단**: 도움말 + 설정 별도 제공 (admin 그룹 숨김 대체)
+6. **시작하기 조건부**: 온보딩 완료(localStorage) 시 상단에서 숨김
+
+### F289: 메뉴 리브랜딩
+
+| 변경 전 | 변경 후 | 위치 |
+|---------|---------|------|
+| 수집 채널 | Field 수집 | 1단계 수집 |
+| IR Bottom-up | IDEA Portal | 1단계 수집 |
+| Spec 생성 | PRD | 3단계 형상화 |
+
+---
+
+## 테스트 요약
+
+| 테스트 종류 | 수량 | 결과 |
+|------------|:----:|:----:|
+| isVisible 유닛테스트 | 5 | ✅ |
+| Sidebar 통합 테스트 | 9 | ✅ |
+| 기존 Web 테스트 | 273 | ✅ |
+| **합계** | **287** | **✅ all pass** |
+
+---
+
+## 학습 포인트
+
+1. **Sidebar mobile+desktop 듀얼 렌더링**: `getAllByText` 사용 필요 (중복 DOM)
+2. **CollapsibleGroup 닫힌 상태**: 내부 아이템 DOM 미존재 → 그룹 헤더로 존재 검증
+3. **isVisible을 순수 함수로 export**: 렌더링 없이 비즈니스 로직 단독 테스트 가능
+
+---
+
+## 다음 단계
+
+- [ ] Sprint 114: F290 Route namespace migration (URL 경로 변경)
+- [ ] Sprint 114 이후: Phase 11-B 기능 확장 (F291~F296)
+
+---
+
+## Version History
+
+| Version | Date | Changes | Author |
+|---------|------|---------|--------|
+| 1.0 | 2026-04-03 | Initial report — Sprint 113 완료 | Sinclair Seo |

--- a/packages/web/src/__tests__/sidebar-visibility.test.tsx
+++ b/packages/web/src/__tests__/sidebar-visibility.test.tsx
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { isVisible } from "../components/sidebar";
+import type { Visibility, VisibilityContext } from "../components/sidebar";
+
+/* ------------------------------------------------------------------ */
+/*  T-01 ~ T-04: isVisible 유틸 함수 단위 테스트                        */
+/* ------------------------------------------------------------------ */
+
+describe("isVisible", () => {
+  const adminCtx: VisibilityContext = { isAdmin: true, onboardingComplete: false };
+  const memberCtx: VisibilityContext = { isAdmin: false, onboardingComplete: false };
+
+  it("T-01: visibility 'all'은 항상 true", () => {
+    expect(isVisible({ visibility: "all" }, memberCtx)).toBe(true);
+    expect(isVisible({ visibility: "all" }, adminCtx)).toBe(true);
+    expect(isVisible({}, memberCtx)).toBe(true); // default (undefined)
+  });
+
+  it("T-02: visibility 'admin' + isAdmin=false → false", () => {
+    expect(isVisible({ visibility: "admin" }, memberCtx)).toBe(false);
+  });
+
+  it("T-03: visibility 'admin' + isAdmin=true → true", () => {
+    expect(isVisible({ visibility: "admin" }, adminCtx)).toBe(true);
+  });
+
+  it("T-04: visibility 'conditional' + condition 결과", () => {
+    const entry = {
+      visibility: "conditional" as Visibility,
+      condition: (ctx: VisibilityContext) => !ctx.onboardingComplete,
+    };
+    expect(isVisible(entry, { isAdmin: false, onboardingComplete: false })).toBe(true);
+    expect(isVisible(entry, { isAdmin: false, onboardingComplete: true })).toBe(false);
+  });
+
+  it("conditional without condition function returns true", () => {
+    expect(isVisible({ visibility: "conditional" }, memberCtx)).toBe(true);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  T-05 ~ T-10: Sidebar 렌더링 통합 테스트                             */
+/* ------------------------------------------------------------------ */
+
+// Mock useUserRole
+vi.mock("@/hooks/useUserRole", () => ({
+  useUserRole: vi.fn(() => ({ role: "member", isAdmin: false })),
+}));
+
+// Mock auth-store
+vi.mock("@/lib/stores/auth-store", () => ({
+  useAuthStore: vi.fn(() => ({
+    user: null,
+    isAuthenticated: false,
+    logout: vi.fn(),
+    hydrate: vi.fn(),
+  })),
+}));
+
+// Mock OrgSwitcher
+vi.mock("@/components/feature/OrgSwitcher", () => ({
+  OrgSwitcher: () => <div data-testid="org-switcher" />,
+}));
+
+// Mock ThemeToggle
+vi.mock("@/components/theme-toggle", () => ({
+  ThemeToggle: () => <div data-testid="theme-toggle" />,
+}));
+
+// Mock Sheet components
+vi.mock("@/components/ui/sheet", () => ({
+  Sheet: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SheetTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SheetContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SheetHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SheetTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+// Mock button
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: React.ComponentProps<"button">) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+import { useUserRole } from "@/hooks/useUserRole";
+import { Sidebar } from "../components/sidebar";
+
+const mockedUseUserRole = vi.mocked(useUserRole);
+
+function renderSidebar() {
+  return render(
+    <MemoryRouter initialEntries={["/dashboard"]}>
+      <Sidebar />
+    </MemoryRouter>,
+  );
+}
+
+describe("Sidebar role-based visibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it("T-05: Member 로그인 시 관리 그룹 미노출", () => {
+    mockedUseUserRole.mockReturnValue({ role: "member", isAdmin: false });
+    renderSidebar();
+    expect(screen.queryByText("토큰 비용")).not.toBeInTheDocument();
+    expect(screen.queryByText("에이전트")).not.toBeInTheDocument();
+    expect(screen.queryByText("아키텍처")).not.toBeInTheDocument();
+  });
+
+  it("T-06: Admin 로그인 시 관리 그룹 헤더 노출", () => {
+    mockedUseUserRole.mockReturnValue({ role: "admin", isAdmin: true });
+    renderSidebar();
+    // CollapsibleGroup은 닫혀있으면 내부 아이템이 DOM에 없으므로, 그룹 헤더(label)로 검증
+    expect(screen.getAllByText("관리").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("외부 서비스").length).toBeGreaterThan(0);
+  });
+
+  it("T-07: 리브랜딩 — 'Field 수집' 존재", () => {
+    mockedUseUserRole.mockReturnValue({ role: "admin", isAdmin: true });
+    renderSidebar();
+    expect(screen.getAllByText("Field 수집").length).toBeGreaterThan(0);
+    expect(screen.queryByText("수집 채널")).not.toBeInTheDocument();
+  });
+
+  it("T-08: 리브랜딩 — 'IDEA Portal' 존재", () => {
+    mockedUseUserRole.mockReturnValue({ role: "admin", isAdmin: true });
+    renderSidebar();
+    expect(screen.getAllByText("IDEA Portal").length).toBeGreaterThan(0);
+    expect(screen.queryByText("IR Bottom-up")).not.toBeInTheDocument();
+  });
+
+  it("T-09: 리브랜딩 — 'PRD' 존재 (Spec 생성 대신)", () => {
+    mockedUseUserRole.mockReturnValue({ role: "admin", isAdmin: true });
+    renderSidebar();
+    expect(screen.getAllByText("PRD").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Spec 생성")).not.toBeInTheDocument();
+  });
+
+  it("T-10: Member: 지식 그룹 헤더 노출 (아이템 필터링은 isVisible 유닛테스트에서 검증)", () => {
+    mockedUseUserRole.mockReturnValue({ role: "member", isAdmin: false });
+    renderSidebar();
+    // 지식 그룹은 스킬 카탈로그(all) 1개가 남으므로 그룹 헤더는 표시
+    expect(screen.getAllByText("지식").length).toBeGreaterThan(0);
+    // Admin 전용 그룹은 미노출
+    expect(screen.queryByText("관리")).not.toBeInTheDocument();
+  });
+
+  it("Member: 외부 서비스 그룹 미노출", () => {
+    mockedUseUserRole.mockReturnValue({ role: "member", isAdmin: false });
+    renderSidebar();
+    expect(screen.queryByText("Discovery-X")).not.toBeInTheDocument();
+    expect(screen.queryByText("AI Foundry")).not.toBeInTheDocument();
+  });
+
+  it("Member: 하단에 도움말+설정 표시", () => {
+    mockedUseUserRole.mockReturnValue({ role: "member", isAdmin: false });
+    renderSidebar();
+    expect(screen.getAllByText("도움말").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("설정").length).toBeGreaterThan(0);
+  });
+
+  it("Admin: memberBottomItems 미렌더링", () => {
+    mockedUseUserRole.mockReturnValue({ role: "admin", isAdmin: true });
+    renderSidebar();
+    // Admin은 memberBottomItems가 렌더링되지 않으므로 "도움말" 미노출
+    expect(screen.queryByText("도움말")).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/sidebar.tsx
+++ b/packages/web/src/components/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { Link } from "react-router-dom";
 import { useLocation } from "react-router-dom";
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import {
   LayoutDashboard,
   BookOpen,
@@ -53,16 +53,26 @@ import {
 } from "@/components/ui/sheet";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { OrgSwitcher } from "@/components/feature/OrgSwitcher";
+import { useUserRole } from "@/hooks/useUserRole";
 import type { LucideIcon } from "lucide-react";
 
 /* ------------------------------------------------------------------ */
 /*  Navigation Structure — AX BD 프로세스 6단계 기반 그룹               */
 /* ------------------------------------------------------------------ */
 
+export type Visibility = "all" | "admin" | "conditional";
+
+export interface VisibilityContext {
+  isAdmin: boolean;
+  onboardingComplete: boolean;
+}
+
 interface NavItem {
   href: string;
   label: string;
   icon: LucideIcon;
+  visibility?: Visibility;
+  condition?: (ctx: VisibilityContext) => boolean;
 }
 
 interface NavGroup {
@@ -71,10 +81,28 @@ interface NavGroup {
   icon: LucideIcon;
   items: NavItem[];
   stageColor?: string; // 프로세스 단계 그룹에만 사용 — AXIS 색상 뱃지
+  visibility?: Visibility;
+  condition?: (ctx: VisibilityContext) => boolean;
+}
+
+export function isVisible(
+  entry: { visibility?: Visibility; condition?: (ctx: VisibilityContext) => boolean },
+  ctx: VisibilityContext,
+): boolean {
+  if (!entry.visibility || entry.visibility === "all") return true;
+  if (entry.visibility === "admin") return ctx.isAdmin;
+  if (entry.visibility === "conditional" && entry.condition) return entry.condition(ctx);
+  return true;
 }
 
 const topItems: NavItem[] = [
-  { href: "/getting-started", label: "시작하기", icon: Rocket },
+  {
+    href: "/getting-started",
+    label: "시작하기",
+    icon: Rocket,
+    visibility: "conditional",
+    condition: (ctx) => !ctx.onboardingComplete,
+  },
   { href: "/dashboard", label: "홈", icon: LayoutDashboard },
   { href: "/team-shared", label: "팀 공유", icon: Users },
   { href: "/ax-bd/demo", label: "데모 시나리오", icon: Presentation },
@@ -90,8 +118,8 @@ const processGroups: NavGroup[] = [
     stageColor: "bg-axis-blue",
     items: [
       { href: "/sr", label: "SR 목록", icon: ClipboardList },
-      { href: "/discovery/collection", label: "수집 채널", icon: Radio },
-      { href: "/ir-proposals", label: "IR Bottom-up", icon: ArrowUpFromLine },
+      { href: "/discovery/collection", label: "Field 수집", icon: Radio },
+      { href: "/ir-proposals", label: "IDEA Portal", icon: ArrowUpFromLine },
     ],
   },
   {
@@ -111,7 +139,7 @@ const processGroups: NavGroup[] = [
     icon: PenTool,
     stageColor: "bg-axis-warm",
     items: [
-      { href: "/spec-generator", label: "Spec 생성", icon: FileText },
+      { href: "/spec-generator", label: "PRD", icon: FileText },
       { href: "/ax-bd", label: "사업제안서", icon: FileSignature },
       { href: "/ax-bd/shaping", label: "형상화 리뷰", icon: ClipboardCheck },
       { href: "/offering-packs", label: "Offering Pack", icon: Package },
@@ -151,10 +179,10 @@ const knowledgeGroup: NavGroup = {
   label: "지식",
   icon: BookOpen,
   items: [
-    { href: "/wiki", label: "지식베이스", icon: BookOpen },
-    { href: "/methodologies", label: "방법론 관리", icon: Library },
+    { href: "/wiki", label: "지식베이스", icon: BookOpen, visibility: "admin" },
+    { href: "/methodologies", label: "방법론 관리", icon: Library, visibility: "admin" },
     { href: "/ax-bd/skill-catalog", label: "스킬 카탈로그", icon: Library },
-    { href: "/ax-bd/ontology", label: "Ontology", icon: Network },
+    { href: "/ax-bd/ontology", label: "Ontology", icon: Network, visibility: "admin" },
   ],
 };
 
@@ -162,6 +190,7 @@ const adminGroup: NavGroup = {
   key: "admin",
   label: "관리",
   icon: Settings,
+  visibility: "admin",
   items: [
     { href: "/analytics", label: "Analytics", icon: BarChart3 },
     { href: "/agents", label: "에이전트", icon: Bot },
@@ -172,10 +201,16 @@ const adminGroup: NavGroup = {
   ],
 };
 
+const memberBottomItems: NavItem[] = [
+  { href: "/getting-started", label: "도움말", icon: HelpCircle },
+  { href: "/settings/jira", label: "설정", icon: Settings },
+];
+
 const externalGroup: NavGroup = {
   key: "external",
   label: "외부 서비스",
   icon: Link2,
+  visibility: "admin",
   items: [
     { href: "/discovery", label: "Discovery-X", icon: Search },
     { href: "/foundry", label: "AI Foundry", icon: FlaskConical },
@@ -318,39 +353,83 @@ function CollapsibleGroup({
 function NavLinks({ onSelect }: { onSelect?: () => void }) {
   const { pathname } = useLocation();
   const { openGroups, toggle } = useGroupState();
+  const { isAdmin } = useUserRole();
 
-  const allGroups = [...processGroups, knowledgeGroup, adminGroup, externalGroup];
+  const onboardingComplete = useMemo(() => {
+    try {
+      return localStorage.getItem("onboarding_progress") === "100";
+    } catch {
+      return false;
+    }
+  }, []);
+
+  const ctx: VisibilityContext = useMemo(
+    () => ({ isAdmin, onboardingComplete }),
+    [isAdmin, onboardingComplete],
+  );
+
+  const filteredTopItems = useMemo(
+    () => topItems.filter((item) => isVisible(item, ctx)),
+    [ctx],
+  );
+
+  const filteredProcessGroups = useMemo(
+    () => processGroups
+      .filter((g) => isVisible(g, ctx))
+      .map((g) => ({ ...g, items: g.items.filter((item) => isVisible(item, ctx)) }))
+      .filter((g) => g.items.length > 0),
+    [ctx],
+  );
+
+  const filteredKnowledge = useMemo(() => {
+    if (!isVisible(knowledgeGroup, ctx)) return null;
+    const items = knowledgeGroup.items.filter((item) => isVisible(item, ctx));
+    return items.length > 0 ? { ...knowledgeGroup, items } : null;
+  }, [ctx]);
+
+  const filteredAdmin = useMemo(
+    () => (isVisible(adminGroup, ctx) ? adminGroup : null),
+    [ctx],
+  );
+
+  const filteredExternal = useMemo(
+    () => (isVisible(externalGroup, ctx) ? externalGroup : null),
+    [ctx],
+  );
+
+  const allVisibleGroups = useMemo(
+    () => [
+      ...filteredProcessGroups,
+      ...(filteredKnowledge ? [filteredKnowledge] : []),
+      ...(filteredAdmin ? [filteredAdmin] : []),
+      ...(filteredExternal ? [filteredExternal] : []),
+    ],
+    [filteredProcessGroups, filteredKnowledge, filteredAdmin, filteredExternal],
+  );
 
   // 활성 경로가 포함된 그룹은 자동 펼침
   useEffect(() => {
-    for (const group of allGroups) {
+    for (const group of allVisibleGroups) {
       if (group.items.some((item) => pathname === item.href || pathname.startsWith(item.href + "/"))) {
         if (!openGroups.has(group.key)) {
           toggle(group.key);
         }
       }
     }
-    // pathname 변경 시에만 실행
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pathname]);
 
   return (
     <nav className="flex flex-col gap-0.5">
-      {/* 시작하기 + 홈 */}
-      {topItems.map((item) => (
-        <NavLink
-          key={item.href}
-          item={item}
-          pathname={pathname}
-          onSelect={onSelect}
-        />
+      {/* 시작하기(조건부) + 홈 + 팀공유 + 데모 */}
+      {filteredTopItems.map((item) => (
+        <NavLink key={item.href} item={item} pathname={pathname} onSelect={onSelect} />
       ))}
 
-      {/* 구분선 */}
       <div className="my-2 border-t border-border/40" />
 
       {/* 프로세스 6단계 */}
-      {processGroups.map((group) => (
+      {filteredProcessGroups.map((group) => (
         <CollapsibleGroup
           key={group.key}
           group={group}
@@ -361,45 +440,52 @@ function NavLinks({ onSelect }: { onSelect?: () => void }) {
         />
       ))}
 
-      {/* 구분선 */}
       <div className="my-2 border-t border-border/40" />
 
-      {/* 지식 */}
-      <CollapsibleGroup
-        group={knowledgeGroup}
-        pathname={pathname}
-        isOpen={openGroups.has(knowledgeGroup.key)}
-        onToggle={() => toggle(knowledgeGroup.key)}
-        onSelect={onSelect}
-      />
+      {/* 지식 (필터링 후 아이템이 있을 때만) */}
+      {filteredKnowledge && (
+        <CollapsibleGroup
+          group={filteredKnowledge}
+          pathname={pathname}
+          isOpen={openGroups.has(filteredKnowledge.key)}
+          onToggle={() => toggle(filteredKnowledge.key)}
+          onSelect={onSelect}
+        />
+      )}
 
-      {/* 관리 */}
-      <CollapsibleGroup
-        group={adminGroup}
-        pathname={pathname}
-        isOpen={openGroups.has(adminGroup.key)}
-        onToggle={() => toggle(adminGroup.key)}
-        onSelect={onSelect}
-      />
+      {/* 관리 (Admin 전용) */}
+      {filteredAdmin && (
+        <CollapsibleGroup
+          group={filteredAdmin}
+          pathname={pathname}
+          isOpen={openGroups.has(filteredAdmin.key)}
+          onToggle={() => toggle(filteredAdmin.key)}
+          onSelect={onSelect}
+        />
+      )}
 
-      {/* 구분선 */}
-      <div className="my-2 border-t border-border/40" />
+      {filteredExternal && (
+        <>
+          <div className="my-2 border-t border-border/40" />
+          <CollapsibleGroup
+            group={filteredExternal}
+            pathname={pathname}
+            isOpen={openGroups.has(filteredExternal.key)}
+            onToggle={() => toggle(filteredExternal.key)}
+            onSelect={onSelect}
+          />
+        </>
+      )}
 
-      {/* 외부 서비스 */}
-      <CollapsibleGroup
-        group={externalGroup}
-        pathname={pathname}
-        isOpen={openGroups.has(externalGroup.key)}
-        onToggle={() => toggle(externalGroup.key)}
-        onSelect={onSelect}
-      />
-
-      {/* 도움말 — 시작하기 페이지로 이동 */}
-      <NavLink
-        item={{ href: "/getting-started", label: "도움말", icon: HelpCircle }}
-        pathname={pathname}
-        onSelect={onSelect}
-      />
+      {/* Member 하단: 도움말 + 설정 */}
+      {!isAdmin && (
+        <>
+          <div className="my-2 border-t border-border/40" />
+          {memberBottomItems.map((item) => (
+            <NavLink key={item.href} item={item} pathname={pathname} onSelect={onSelect} />
+          ))}
+        </>
+      )}
     </nav>
   );
 }


### PR DESCRIPTION
## Summary
- **F288**: NavItem.visibility 속성 기반 Role 필터링 (admin/member/conditional)
- **F289**: 메뉴 리브랜딩 3건 (수집 채널→Field 수집, IR Bottom-up→IDEA Portal, Spec 생성→PRD)
- Member ~18메뉴, Admin ~29메뉴 — BD 팀원 UX 대폭 개선

## Changes
- `sidebar.tsx`: Visibility 타입 + isVisible() + NavLinks useMemo 필터링 + memberBottomItems
- `sidebar-visibility.test.tsx`: 14개 테스트 (유닛 5 + 통합 9)
- PDCA 문서: Analysis + Report

## Test plan
- [x] isVisible 유닛테스트 5개 통과
- [x] Sidebar 통합 테스트 9개 통과
- [x] Web 전체 287/287 pass
- [x] TypeScript 에러 0건
- [ ] E2E 35 specs (CI에서 확인)

## Match Rate
92% (11/12 — E2E는 CI 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)