### PR TITLE
feat: Sprint 116 F294+F295 — 2-tier 검증 + 인터뷰/미팅 관리

### DIFF
--- a/docs/02-design/features/sprint-116-validation-2tier.design.md
+++ b/docs/02-design/features/sprint-116-validation-2tier.design.md
@@ -1,0 +1,280 @@
+---
+code: FX-DSGN-116
+title: Sprint 116 Design — 2-tier 검증 + 인터뷰/미팅 관리 (F294+F295)
+version: 1.0
+status: Draft
+category: DSGN
+created: 2026-04-03
+updated: 2026-04-03
+author: Sinclair Seo
+sprint: 116
+f-items: F294, F295
+phase: "Phase 11-B"
+---
+
+# Sprint 116 Design — 2-tier 검증 + 인터뷰/미팅 관리 (F294+F295)
+
+> **Plan**: [[FX-PLAN-116]]  |  **Sprint**: 116  |  **Author**: Sinclair Seo  |  **Date**: 2026-04-03
+
+---
+
+## 1. Overview
+
+F294: 기존 단일 게이트 검증을 본부(division) → 전사(company) 2-tier 워크플로로 확장.
+F295: 전문가 인터뷰/미팅 기록을 시스템에서 관리하는 CRUD 기능 추가.
+
+---
+
+## 2. D1 Migration (0086_validation_2tier.sql)
+
+```sql
+-- F294: pipeline_stages에 validation_tier 컬럼 추가
+ALTER TABLE pipeline_stages ADD COLUMN validation_tier TEXT DEFAULT 'none';
+-- values: 'none' | 'division_pending' | 'division_approved' | 'company_pending' | 'company_approved'
+
+-- F295: expert_meetings 테이블
+CREATE TABLE IF NOT EXISTS expert_meetings (
+  id TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL,
+  biz_item_id TEXT NOT NULL,
+  type TEXT NOT NULL DEFAULT 'interview',
+  title TEXT NOT NULL,
+  scheduled_at TEXT NOT NULL,
+  attendees TEXT NOT NULL DEFAULT '[]',
+  location TEXT,
+  notes TEXT,
+  status TEXT NOT NULL DEFAULT 'scheduled',
+  created_by TEXT NOT NULL DEFAULT '',
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (org_id) REFERENCES organizations(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_expert_meetings_org ON expert_meetings(org_id, biz_item_id);
+CREATE INDEX IF NOT EXISTS idx_expert_meetings_status ON expert_meetings(org_id, status);
+```
+
+---
+
+## 3. API Schema (validation.schema.ts)
+
+```typescript
+// F294: Validation tier
+export const VALIDATION_TIERS = [
+  "none", "division_pending", "division_approved", "company_pending", "company_approved",
+] as const;
+export type ValidationTier = (typeof VALIDATION_TIERS)[number];
+export const ValidationTierEnum = z.enum(VALIDATION_TIERS);
+
+export const SubmitValidationSchema = z.object({
+  bizItemId: z.string().min(1),
+  decision: z.enum(["approve", "reject"]),
+  comment: z.string().max(2000).optional(),
+});
+
+export const ValidationFilterSchema = z.object({
+  tier: ValidationTierEnum.optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+// F295: Meeting
+export const MEETING_TYPES = ["interview", "meeting", "workshop", "review"] as const;
+export type MeetingType = (typeof MEETING_TYPES)[number];
+
+export const MEETING_STATUSES = ["scheduled", "completed", "cancelled"] as const;
+export type MeetingStatus = (typeof MEETING_STATUSES)[number];
+
+export const CreateMeetingSchema = z.object({
+  bizItemId: z.string().min(1),
+  type: z.enum(MEETING_TYPES).default("interview"),
+  title: z.string().min(1).max(200),
+  scheduledAt: z.string(), // ISO datetime
+  attendees: z.array(z.string()).default([]),
+  location: z.string().max(200).optional(),
+  notes: z.string().max(5000).optional(),
+});
+
+export const UpdateMeetingSchema = z.object({
+  title: z.string().min(1).max(200).optional(),
+  scheduledAt: z.string().optional(),
+  attendees: z.array(z.string()).optional(),
+  location: z.string().max(200).optional(),
+  notes: z.string().max(5000).optional(),
+  status: z.enum(MEETING_STATUSES).optional(),
+});
+```
+
+---
+
+## 4. Services
+
+### 4.1 ValidationService (validation-service.ts, 신규)
+
+```
+class ValidationService {
+  constructor(db: D1Database)
+
+  // F294: 2-tier validation
+  submitDivisionReview(bizItemId, orgId, decision, comment, userId) → result
+  submitCompanyReview(bizItemId, orgId, decision, comment, userId) → result
+  getDivisionItems(orgId, filters) → { items, total }
+  getCompanyItems(orgId, filters) → { items, total }
+  getValidationStatus(bizItemId, orgId) → { tier, history }
+}
+```
+
+**비즈니스 로직**:
+- `submitDivisionReview`: validation_tier = 'division_pending' → approve: 'division_approved', reject: 'none'
+- `submitCompanyReview`: tier가 'division_approved'일 때만 진행 가능. approve: 'company_approved', reject: 'division_approved' (본부 재검토)
+- division items: pipeline_stages에서 stage='REVIEW' AND validation_tier IN ('none', 'division_pending')
+- company items: validation_tier = 'division_approved'
+
+### 4.2 MeetingService (meeting-service.ts, 신규)
+
+```
+class MeetingService {
+  constructor(db: D1Database)
+
+  create(input, orgId, userId) → Meeting
+  list(orgId, bizItemId?, filters?) → { items, total }
+  getById(id, orgId) → Meeting | null
+  update(id, orgId, input) → Meeting | null
+  delete(id, orgId) → boolean
+}
+```
+
+---
+
+## 5. API Routes
+
+### 5.1 validation-tier.ts (신규, F294)
+
+| Method | Path | Handler | 설명 |
+|--------|------|---------|------|
+| POST | /validation/division/submit | submitDivisionReview | 본부 검증 제출 |
+| POST | /validation/company/submit | submitCompanyReview | 전사 검증 제출 |
+| GET | /validation/division/items | getDivisionItems | 본부 검증 대기 목록 |
+| GET | /validation/company/items | getCompanyItems | 전사 검증 대기 목록 |
+| GET | /validation/status/:bizItemId | getValidationStatus | 아이템별 검증 상태 |
+
+### 5.2 validation-meetings.ts (신규, F295)
+
+| Method | Path | Handler | 설명 |
+|--------|------|---------|------|
+| POST | /validation/meetings | create | 미팅 생성 |
+| GET | /validation/meetings | list | 미팅 목록 |
+| GET | /validation/meetings/:id | getById | 미팅 상세 |
+| PATCH | /validation/meetings/:id | update | 미팅 수정 |
+| DELETE | /validation/meetings/:id | delete | 미팅 삭제 |
+
+---
+
+## 6. Web Pages
+
+### 6.1 validation-division.tsx (F294)
+
+본부 검증 대기 아이템 목록 + 승인/반려 버튼. `GET /validation/division/items` 호출.
+
+### 6.2 validation-company.tsx (F294)
+
+전사 검증 대기 아이템 목록 + 승인/반려 버튼. `GET /validation/company/items` 호출. 본부 승인된 건만 표시.
+
+### 6.3 validation-meetings.tsx (F295)
+
+미팅 목록 (일정순) + 생성 다이얼로그 + 상세 보기. `GET /validation/meetings` 호출.
+
+### 6.4 Sidebar 변경
+
+```typescript
+// 4. 검증/공유 그룹에 3건 추가
+{
+  key: "validate",
+  items: [
+    { href: "/validation/pipeline", label: "파이프라인", icon: GitBranch },
+    { href: "/validation/division", label: "본부 검증", icon: Shield },
+    { href: "/validation/company", label: "전사 검증", icon: Building2 },
+    { href: "/validation/meetings", label: "미팅 관리", icon: CalendarDays },
+  ],
+}
+```
+
+### 6.5 Router 변경
+
+```typescript
+// validation routes 추가
+{ path: "validation/division", lazy: () => import("@/routes/validation-division") },
+{ path: "validation/company", lazy: () => import("@/routes/validation-company") },
+{ path: "validation/meetings", lazy: () => import("@/routes/validation-meetings") },
+```
+
+---
+
+## 7. Test Strategy
+
+### 7.1 API Tests (~30건 예상)
+
+- **validation-service.test.ts**: division/company submit, tier transition, guard (company before division → 400), filter queries
+- **meeting-service.test.ts**: CRUD 5 operations, validation (empty title, invalid type), list with filters
+- **validation-tier.test.ts**: route integration tests (5 endpoints)
+- **validation-meetings.test.ts**: route integration tests (5 endpoints)
+
+### 7.2 Web Tests (~8건 예상)
+
+- **validation-division.test.tsx**: 렌더링, 승인/반려 동작
+- **validation-company.test.tsx**: 렌더링, 본부 승인건만 표시
+- **validation-meetings.test.tsx**: 목록 렌더링, 생성 다이얼로그
+
+---
+
+## 8. File Map
+
+```
+packages/api/src/
+├── db/migrations/0086_validation_2tier.sql        ← D1 신규
+├── schemas/validation.schema.ts                    ← 신규
+├── services/validation-service.ts                  ← 신규
+├── services/meeting-service.ts                     ← 신규
+├── routes/validation-tier.ts                       ← 신규
+├── routes/validation-meetings.ts                   ← 신규
+└── routes/__tests__/
+    ├── validation-tier.test.ts                     ← 신규
+    ├── validation-meetings.test.ts                 ← 신규
+    ├── validation-service.test.ts                  ← 신규
+    └── meeting-service.test.ts                     ← 신규
+
+packages/web/src/
+├── routes/validation-division.tsx                  ← 신규
+├── routes/validation-company.tsx                   ← 신규
+├── routes/validation-meetings.tsx                  ← 신규
+├── components/sidebar.tsx                          ← 수정 (3 메뉴 추가)
+├── router.tsx                                      ← 수정 (3 라우트 추가)
+└── __tests__/
+    ├── validation-division.test.tsx                ← 신규
+    ├── validation-company.test.tsx                 ← 신규
+    └── validation-meetings.test.tsx                ← 신규
+
+packages/api/src/index.ts                           ← 수정 (2 라우트 등록)
+```
+
+---
+
+## 9. Implementation Order
+
+1. D1 migration `0086_validation_2tier.sql`
+2. Schema `validation.schema.ts`
+3. Services: `validation-service.ts` + `meeting-service.ts`
+4. Routes: `validation-tier.ts` + `validation-meetings.ts`
+5. Route registration in `index.ts`
+6. API tests (4 files)
+7. Web: sidebar + router + 3 pages
+8. Web tests (3 files)
+9. typecheck + lint
+
+---
+
+## Version History
+
+| Version | Date | Changes | Author |
+|---------|------|---------|--------|
+| 1.0 | 2026-04-03 | Initial design — F294 2-tier + F295 meetings | Sinclair Seo |

--- a/docs/03-analysis/features/sprint-116.analysis.md
+++ b/docs/03-analysis/features/sprint-116.analysis.md
@@ -1,0 +1,115 @@
+---
+code: FX-ANLS-116
+title: Sprint 116 Gap Analysis — 2-tier 검증 + 미팅 관리 (F294+F295)
+version: 1.0
+status: Active
+category: ANLS
+created: 2026-04-03
+updated: 2026-04-03
+author: Sinclair Seo
+sprint: 116
+f-items: F294, F295
+match-rate: 95
+---
+
+# Sprint 116 Gap Analysis — F294+F295
+
+> **Design**: [[FX-DSGN-116]]  |  **Match Rate**: **95%**  |  **Date**: 2026-04-03
+
+---
+
+## Overall Scores
+
+| Category | Score | Status |
+|----------|:-----:|:------:|
+| D1 Migration (S2) | 100% | PASS |
+| API Schema (S3) | 100% | PASS |
+| Services (S4) | 100% | PASS |
+| API Routes (S5) | 100% | PASS |
+| Web Pages (S6) | 100% | PASS |
+| Test Strategy (S7) | 71% | WARN |
+| File Map (S8) | 88% | WARN |
+| **Overall** | **95%** | **PASS** |
+
+---
+
+## Section-by-Section
+
+### S2. D1 Migration — 100% + 3 Enhancements
+
+| Design Item | Implementation | Status |
+|-------------|---------------|:------:|
+| ALTER TABLE pipeline_stages ADD validation_tier | 0086 L4 | PASS |
+| CREATE TABLE expert_meetings | 0086 L7-22 | PASS |
+| idx_expert_meetings_org | 0086 L24 | PASS |
+| idx_expert_meetings_status | 0086 L25 | PASS |
+| *validation_history table (추가)* | 0086 L28-38 | ADDED |
+| *idx_validation_history_* (추가)* | 0086 L39-40 | ADDED |
+
+### S3. API Schema — 100% + 1 Enhancement
+
+| Design Item | Status |
+|-------------|:------:|
+| VALIDATION_TIERS, SubmitValidationSchema, ValidationFilterSchema | PASS |
+| MEETING_TYPES, MEETING_STATUSES, CreateMeetingSchema, UpdateMeetingSchema | PASS |
+| *MeetingFilterSchema (추가)* | ADDED |
+
+### S4. Services — 100%
+
+- ValidationService: 5 methods 전체 구현 (submitDivisionReview, submitCompanyReview, getDivisionItems, getCompanyItems, getValidationStatus)
+- MeetingService: 5 methods 전체 구현 (create, list, getById, update, delete)
+- 비즈니스 로직 검증: tier transition, guard, history tracking 모두 일치
+
+### S5. API Routes — 100% (10 endpoints)
+
+- validation-tier.ts: 5 endpoints (division submit/items, company submit/items, status)
+- validation-meetings.ts: 5 endpoints (CRUD + list)
+- app.ts 라우트 등록 완료
+
+### S6. Web Pages — 100%
+
+- 3 페이지 + sidebar 3 메뉴 + router 3 라우트 전체 구현
+
+### S7. Test Strategy — 71% (5/7 files)
+
+| Test File | Tests | Status |
+|-----------|:-----:|:------:|
+| validation-tier.test.ts | 11 | PASS |
+| validation-meetings.test.ts | 11 | PASS |
+| validation-service.test.ts | — | SKIP (route test 커버) |
+| meeting-service.test.ts | — | SKIP (route test 커버) |
+| validation-division.test.tsx | 3 | PASS |
+| validation-company.test.tsx | 4 | PASS |
+| validation-meetings.test.tsx | 4 | PASS |
+| **Total** | **33** | **33 PASS** |
+
+---
+
+## Missing Items (2건, Low Impact)
+
+| Item | Description | Impact |
+|------|-------------|--------|
+| validation-service.test.ts | 서비스 단위 테스트 | Low — route 통합 테스트가 동일 로직 커버 |
+| meeting-service.test.ts | 서비스 단위 테스트 | Low — route 통합 테스트가 동일 로직 커버 |
+
+## Added Items (4건, 합리적 보강)
+
+| Item | Description |
+|------|-------------|
+| validation_history DDL | Design S4 history 반환에 필수 — 설계 보완 |
+| idx_validation_history_* (2) | 이력 조회 성능 인덱스 |
+| MeetingFilterSchema | list endpoint query validation |
+
+## Changed Items (3건, None Impact)
+
+| Item | Design | Implementation | Impact |
+|------|--------|----------------|--------|
+| 테스트 파일 위치 | routes/__tests__/ | src/__tests__/ | None (프로젝트 관례) |
+| 라우트 등록 파일 | index.ts | app.ts | None (프로젝트 구조) |
+| division items stage | REVIEW only | REVIEW + DECISION | Low (범위 확장) |
+
+---
+
+## Conclusion
+
+핵심 기능(D1+Schema+Service+Route+Web) **100% Match**. 미구현 2건은 서비스 단위 테스트 파일로, route 통합 테스트가 동일 로직을 이미 검증하므로 실질적 영향 없음. **Match Rate 95% — PASS.**

--- a/docs/04-report/features/sprint-116.report.md
+++ b/docs/04-report/features/sprint-116.report.md
@@ -1,0 +1,97 @@
+---
+code: FX-RPRT-S116
+title: Sprint 116 완료 보고서 — 2-tier 검증 + 미팅 관리 (F294+F295)
+version: 1.0
+status: Active
+category: RPRT
+created: 2026-04-03
+updated: 2026-04-03
+author: Sinclair Seo
+sprint: 116
+f-items: F294, F295
+phase: "Phase 11-B"
+---
+
+# Sprint 116 완료 보고서
+
+## Executive Summary
+
+| Perspective | Content |
+|-------------|---------|
+| **Feature** | Sprint 116 — F294 (2-tier 검증) + F295 (인터뷰/미팅 관리) |
+| **Date** | 2026-04-03 |
+| **Match Rate** | 95% (43항목 중 41일치, 2건 Low-impact skip) |
+| **Tests** | 33 new (API 22 + Web 11), 전체 통과 |
+
+| Perspective | Content |
+|-------------|---------|
+| **Problem** | 단일 게이트 검증, 오프라인 인터뷰/미팅 기록 미관리 |
+| **Solution** | 본부→전사 2-tier 워크플로 + expert_meetings CRUD |
+| **Function/UX Effect** | 본부 승인 → 전사 검증 순차 진행, 미팅 일정/기록 시스템 관리 |
+| **Core Value** | BD 실제 워크플로와 시스템 1:1 매핑 |
+
+---
+
+## Deliverables
+
+### API (10 endpoints, 2 services, 1 schema, 1 migration)
+
+| Type | File | Description |
+|------|------|-------------|
+| Migration | 0086_validation_2tier.sql | ALTER pipeline_stages + CREATE expert_meetings + CREATE validation_history |
+| Schema | validation.schema.ts | 8 Zod schemas (tier, meeting, filter) |
+| Service | validation-service.ts | 5 methods — 2-tier submit, items, status |
+| Service | meeting-service.ts | 5 methods — CRUD + list |
+| Route | validation-tier.ts | 5 endpoints — division/company submit + items + status |
+| Route | validation-meetings.ts | 5 endpoints — meetings CRUD |
+| Registration | app.ts | 2 route imports + registration |
+
+### Web (3 pages, sidebar + router)
+
+| Type | File | Description |
+|------|------|-------------|
+| Page | validation-division.tsx | 본부 검증 목록 + 승인/반려 |
+| Page | validation-company.tsx | 전사 검증 목록 (본부 승인건만) |
+| Page | validation-meetings.tsx | 미팅 목록 + Sheet 생성 폼 |
+| Component | sidebar.tsx | 4단계 검증 메뉴 3건 추가 (Shield, Building2, CalendarDays) |
+| Router | router.tsx | 3 lazy routes 추가 |
+
+### Tests (33 tests, 5 files)
+
+| File | Tests | Scope |
+|------|:-----:|-------|
+| validation-tier.test.ts | 11 | division submit/reject, company submit/reject/guard, items filter, status |
+| validation-meetings.test.ts | 11 | CRUD, filter, validation, 404 |
+| validation-division.test.tsx | 3 | 렌더, empty state, approve/reject buttons |
+| validation-company.test.tsx | 4 | 렌더, guidance text, empty state, items |
+| validation-meetings.test.tsx | 4 | 렌더, add button, empty state, list |
+
+### Documents (4 files)
+
+| Type | File |
+|------|------|
+| Plan | sprint-116-validation-2tier.plan.md |
+| Design | sprint-116-validation-2tier.design.md |
+| Analysis | sprint-116.analysis.md (95%) |
+| Report | sprint-116.report.md |
+
+---
+
+## Metrics
+
+| Metric | Value |
+|--------|-------|
+| New endpoints | 10 |
+| New tests | 33 |
+| New files | 14 (API 7 + Web 5 + Tests 5 - shared) |
+| Modified files | 3 (app.ts, sidebar.tsx, router.tsx) |
+| D1 migration | 0086 (3 DDL statements) |
+| Match Rate | 95% |
+
+---
+
+## Version History
+
+| Version | Date | Changes | Author |
+|---------|------|---------|--------|
+| 1.0 | 2026-04-03 | Sprint 116 completion report | Sinclair Seo |

--- a/packages/api/src/__tests__/validation-meetings.test.ts
+++ b/packages/api/src/__tests__/validation-meetings.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createMockD1 } from "./helpers/mock-d1.js";
+import { validationMeetingsRoute } from "../routes/validation-meetings.js";
+import { Hono } from "hono";
+import type { Env } from "../env.js";
+
+const DDL = `
+  CREATE TABLE IF NOT EXISTS expert_meetings (
+    id TEXT PRIMARY KEY,
+    org_id TEXT NOT NULL,
+    biz_item_id TEXT NOT NULL,
+    type TEXT NOT NULL DEFAULT 'interview',
+    title TEXT NOT NULL,
+    scheduled_at TEXT NOT NULL,
+    attendees TEXT NOT NULL DEFAULT '[]',
+    location TEXT,
+    notes TEXT,
+    status TEXT NOT NULL DEFAULT 'scheduled',
+    created_by TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE INDEX IF NOT EXISTS idx_expert_meetings_org ON expert_meetings(org_id, biz_item_id);
+`;
+
+function createApp(db: D1Database) {
+  const app = new Hono<{ Bindings: Env }>();
+  app.use("*", async (c, next) => {
+    c.set("orgId" as never, "org_test");
+    c.set("jwtPayload" as never, { sub: "test-user" });
+    await next();
+  });
+  app.route("/api", validationMeetingsRoute);
+  return {
+    request: (path: string, init?: RequestInit) =>
+      app.request(path, init, { DB: db } as unknown as Env),
+  };
+}
+
+describe("Validation Meetings Routes (F295)", () => {
+  let db: D1Database;
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(async () => {
+    const mockDb = createMockD1();
+    await mockDb.exec(DDL);
+    db = mockDb as unknown as D1Database;
+    app = createApp(db);
+  });
+
+  describe("POST /api/validation/meetings", () => {
+    it("creates a meeting", async () => {
+      const res = await app.request("/api/validation/meetings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          bizItemId: "item-1",
+          title: "Expert Interview",
+          scheduledAt: "2026-04-10T10:00:00Z",
+          attendees: ["user-1", "user-2"],
+          location: "회의실 A",
+        }),
+      });
+      expect(res.status).toBe(201);
+      const body = await res.json() as Record<string, unknown>;
+      expect(body.title).toBe("Expert Interview");
+      expect(body.type).toBe("interview");
+      expect(body.status).toBe("scheduled");
+      expect(body.attendees).toEqual(["user-1", "user-2"]);
+    });
+
+    it("creates with minimal fields", async () => {
+      const res = await app.request("/api/validation/meetings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          bizItemId: "item-1",
+          title: "Quick Chat",
+          scheduledAt: "2026-04-11T14:00:00Z",
+        }),
+      });
+      expect(res.status).toBe(201);
+      const body = await res.json() as Record<string, unknown>;
+      expect(body.attendees).toEqual([]);
+    });
+
+    it("returns 400 for missing title", async () => {
+      const res = await app.request("/api/validation/meetings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ bizItemId: "item-1", scheduledAt: "2026-04-10T10:00:00Z" }),
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("GET /api/validation/meetings", () => {
+    it("lists meetings", async () => {
+      // Create 2 meetings
+      await app.request("/api/validation/meetings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ bizItemId: "item-1", title: "Meeting 1", scheduledAt: "2026-04-10T10:00:00Z" }),
+      });
+      await app.request("/api/validation/meetings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ bizItemId: "item-1", title: "Meeting 2", scheduledAt: "2026-04-11T10:00:00Z" }),
+      });
+
+      const res = await app.request("/api/validation/meetings");
+      expect(res.status).toBe(200);
+      const body = await res.json() as { items: unknown[]; total: number };
+      expect(body.items).toHaveLength(2);
+      expect(body.total).toBe(2);
+    });
+
+    it("filters by bizItemId", async () => {
+      await app.request("/api/validation/meetings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ bizItemId: "item-1", title: "M1", scheduledAt: "2026-04-10T10:00:00Z" }),
+      });
+      await app.request("/api/validation/meetings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ bizItemId: "item-2", title: "M2", scheduledAt: "2026-04-11T10:00:00Z" }),
+      });
+
+      const res = await app.request("/api/validation/meetings?bizItemId=item-1");
+      expect(res.status).toBe(200);
+      const body = await res.json() as { items: unknown[]; total: number };
+      expect(body.items).toHaveLength(1);
+    });
+  });
+
+  describe("GET /api/validation/meetings/:id", () => {
+    it("returns meeting by id", async () => {
+      const createRes = await app.request("/api/validation/meetings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ bizItemId: "item-1", title: "Test", scheduledAt: "2026-04-10T10:00:00Z" }),
+      });
+      const created = await createRes.json() as { id: string };
+
+      const res = await app.request(`/api/validation/meetings/${created.id}`);
+      expect(res.status).toBe(200);
+      const body = await res.json() as { title: string };
+      expect(body.title).toBe("Test");
+    });
+
+    it("returns 404 for non-existent", async () => {
+      const res = await app.request("/api/validation/meetings/nonexistent");
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("PATCH /api/validation/meetings/:id", () => {
+    it("updates meeting fields", async () => {
+      const createRes = await app.request("/api/validation/meetings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ bizItemId: "item-1", title: "Original", scheduledAt: "2026-04-10T10:00:00Z" }),
+      });
+      const created = await createRes.json() as { id: string };
+
+      const res = await app.request(`/api/validation/meetings/${created.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: "Updated", status: "completed", notes: "Great discussion" }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json() as { title: string; status: string; notes: string };
+      expect(body.title).toBe("Updated");
+      expect(body.status).toBe("completed");
+      expect(body.notes).toBe("Great discussion");
+    });
+
+    it("returns 404 for non-existent", async () => {
+      const res = await app.request("/api/validation/meetings/nonexistent", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: "test" }),
+      });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("DELETE /api/validation/meetings/:id", () => {
+    it("deletes meeting", async () => {
+      const createRes = await app.request("/api/validation/meetings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ bizItemId: "item-1", title: "ToDelete", scheduledAt: "2026-04-10T10:00:00Z" }),
+      });
+      const created = await createRes.json() as { id: string };
+
+      const res = await app.request(`/api/validation/meetings/${created.id}`, { method: "DELETE" });
+      expect(res.status).toBe(200);
+
+      // Verify deleted
+      const getRes = await app.request(`/api/validation/meetings/${created.id}`);
+      expect(getRes.status).toBe(404);
+    });
+
+    it("returns 404 for non-existent", async () => {
+      const res = await app.request("/api/validation/meetings/nonexistent", { method: "DELETE" });
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/packages/api/src/__tests__/validation-tier.test.ts
+++ b/packages/api/src/__tests__/validation-tier.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createMockD1 } from "./helpers/mock-d1.js";
+import { validationTierRoute } from "../routes/validation-tier.js";
+import { Hono } from "hono";
+import type { Env } from "../env.js";
+
+const DDL = `
+  CREATE TABLE IF NOT EXISTS biz_items (
+    id TEXT PRIMARY KEY,
+    org_id TEXT NOT NULL DEFAULT '',
+    title TEXT NOT NULL,
+    description TEXT,
+    source TEXT NOT NULL DEFAULT 'manual',
+    status TEXT NOT NULL DEFAULT 'active',
+    created_by TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE TABLE IF NOT EXISTS pipeline_stages (
+    id TEXT PRIMARY KEY,
+    biz_item_id TEXT NOT NULL,
+    org_id TEXT NOT NULL,
+    stage TEXT NOT NULL DEFAULT 'REGISTERED',
+    entered_at TEXT NOT NULL DEFAULT (datetime('now')),
+    exited_at TEXT,
+    entered_by TEXT NOT NULL,
+    notes TEXT,
+    validation_tier TEXT DEFAULT 'none'
+  );
+  CREATE INDEX IF NOT EXISTS idx_pipeline_stages_item ON pipeline_stages(biz_item_id, entered_at DESC);
+  CREATE INDEX IF NOT EXISTS idx_pipeline_stages_org ON pipeline_stages(org_id, stage);
+  CREATE TABLE IF NOT EXISTS validation_history (
+    id TEXT PRIMARY KEY,
+    biz_item_id TEXT NOT NULL,
+    org_id TEXT NOT NULL,
+    tier TEXT NOT NULL,
+    decision TEXT NOT NULL,
+    comment TEXT NOT NULL DEFAULT '',
+    decided_by TEXT NOT NULL,
+    decided_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE INDEX IF NOT EXISTS idx_validation_history_item ON validation_history(biz_item_id, decided_at DESC);
+`;
+
+function createApp(db: D1Database) {
+  const app = new Hono<{ Bindings: Env }>();
+  app.use("*", async (c, next) => {
+    c.set("orgId" as never, "org_test");
+    c.set("jwtPayload" as never, { sub: "test-user" });
+    await next();
+  });
+  app.route("/api", validationTierRoute);
+  return {
+    request: (path: string, init?: RequestInit) =>
+      app.request(path, init, { DB: db } as unknown as Env),
+  };
+}
+
+async function seedItemWithStage(db: D1Database, id: string, stage: string = "REVIEW", tier: string = "none") {
+  await (db as unknown as { exec: (q: string) => Promise<void> }).exec(
+    `INSERT INTO biz_items (id, org_id, title, created_by) VALUES ('${id}', 'org_test', 'Test Item ${id}', 'other-user')`,
+  );
+  await (db as unknown as { exec: (q: string) => Promise<void> }).exec(
+    `INSERT INTO pipeline_stages (id, biz_item_id, org_id, stage, entered_by, validation_tier) VALUES ('ps-${id}', '${id}', 'org_test', '${stage}', 'test-user', '${tier}')`,
+  );
+}
+
+describe("Validation Tier Routes (F294)", () => {
+  let db: D1Database;
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(async () => {
+    const mockDb = createMockD1();
+    await mockDb.exec(DDL);
+    db = mockDb as unknown as D1Database;
+    app = createApp(db);
+  });
+
+  describe("POST /api/validation/division/submit", () => {
+    it("approves division review", async () => {
+      await seedItemWithStage(db, "item-1", "REVIEW", "none");
+
+      const res = await app.request("/api/validation/division/submit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ bizItemId: "item-1", decision: "approve", comment: "Good to go" }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json() as Record<string, unknown>;
+      expect(body.currentTier).toBe("division_approved");
+      expect(body.decision).toBe("approve");
+    });
+
+    it("rejects division review — resets to none", async () => {
+      await seedItemWithStage(db, "item-2", "REVIEW", "division_pending");
+
+      const res = await app.request("/api/validation/division/submit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ bizItemId: "item-2", decision: "reject", comment: "Needs work" }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json() as Record<string, unknown>;
+      expect(body.currentTier).toBe("none");
+    });
+
+    it("returns 400 for invalid body", async () => {
+      const res = await app.request("/api/validation/division/submit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ decision: "approve" }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when tier is already division_approved", async () => {
+      await seedItemWithStage(db, "item-3", "REVIEW", "division_approved");
+
+      const res = await app.request("/api/validation/division/submit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ bizItemId: "item-3", decision: "approve", comment: "test" }),
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("POST /api/validation/company/submit", () => {
+    it("approves company review after division approved", async () => {
+      await seedItemWithStage(db, "item-4", "REVIEW", "division_approved");
+
+      const res = await app.request("/api/validation/company/submit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ bizItemId: "item-4", decision: "approve", comment: "Company approved" }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json() as Record<string, unknown>;
+      expect(body.currentTier).toBe("company_approved");
+    });
+
+    it("returns 400 when division not yet approved", async () => {
+      await seedItemWithStage(db, "item-5", "REVIEW", "none");
+
+      const res = await app.request("/api/validation/company/submit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ bizItemId: "item-5", decision: "approve", comment: "test" }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects company review — stays at division_approved", async () => {
+      await seedItemWithStage(db, "item-6", "REVIEW", "division_approved");
+
+      const res = await app.request("/api/validation/company/submit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ bizItemId: "item-6", decision: "reject", comment: "Needs revision" }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json() as Record<string, unknown>;
+      expect(body.currentTier).toBe("division_approved");
+    });
+  });
+
+  describe("GET /api/validation/division/items", () => {
+    it("returns division pending items", async () => {
+      await seedItemWithStage(db, "item-a", "REVIEW", "none");
+      await seedItemWithStage(db, "item-b", "REVIEW", "division_approved");
+
+      const res = await app.request("/api/validation/division/items");
+      expect(res.status).toBe(200);
+      const body = await res.json() as { items: unknown[]; total: number };
+      expect(body.items).toHaveLength(1);
+      expect(body.total).toBe(1);
+    });
+  });
+
+  describe("GET /api/validation/company/items", () => {
+    it("returns only division_approved items", async () => {
+      await seedItemWithStage(db, "item-c", "REVIEW", "none");
+      await seedItemWithStage(db, "item-d", "REVIEW", "division_approved");
+      await seedItemWithStage(db, "item-e", "REVIEW", "company_approved");
+
+      const res = await app.request("/api/validation/company/items");
+      expect(res.status).toBe(200);
+      const body = await res.json() as { items: unknown[]; total: number };
+      expect(body.items).toHaveLength(1);
+      expect(body.total).toBe(1);
+    });
+  });
+
+  describe("GET /api/validation/status/:bizItemId", () => {
+    it("returns validation status with history", async () => {
+      await seedItemWithStage(db, "item-f", "REVIEW", "division_approved");
+
+      // First submit to generate history
+      await app.request("/api/validation/company/submit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ bizItemId: "item-f", decision: "approve", comment: "LGTM" }),
+      });
+
+      const res = await app.request("/api/validation/status/item-f");
+      expect(res.status).toBe(200);
+      const body = await res.json() as { bizItemId: string; tier: string; history: unknown[] };
+      expect(body.bizItemId).toBe("item-f");
+      expect(body.tier).toBe("company_approved");
+      expect(body.history.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("returns 404 for non-existent item", async () => {
+      const res = await app.request("/api/validation/status/nonexistent");
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -95,6 +95,9 @@ import { capturedEngineRoute } from "./routes/captured-engine.js";
 import { roiBenchmarkRoute } from "./routes/roi-benchmark.js";
 // Sprint 112: BD 형상화 Phase F (F286, F287)
 import { shapingRoute } from "./routes/shaping.js";
+// Sprint 116: 2-tier 검증 + 미팅 관리 (F294, F295)
+import { validationTierRoute } from "./routes/validation-tier.js";
+import { validationMeetingsRoute } from "./routes/validation-meetings.js";
 // Sprint 117: 통합 평가 결과서 (F296)
 import { evaluationReportRoute } from "./routes/evaluation-report.js";
 import { handleScheduled } from "./scheduled.js";
@@ -341,6 +344,9 @@ app.route("/api", capturedEngineRoute);
 app.route("/api", roiBenchmarkRoute);
 // Sprint 112: BD 형상화 Phase F (F286, F287)
 app.route("/api", shapingRoute);
+// Sprint 116: 2-tier 검증 + 미팅 관리 (F294, F295)
+app.route("/api", validationTierRoute);
+app.route("/api", validationMeetingsRoute);
 // Sprint 117: 통합 평가 결과서 (F296)
 app.route("/api", evaluationReportRoute);
 

--- a/packages/api/src/db/migrations/0086_validation_2tier.sql
+++ b/packages/api/src/db/migrations/0086_validation_2tier.sql
@@ -1,0 +1,40 @@
+-- Sprint 116: F294 2-tier 검증 + F295 미팅 관리
+
+-- F294: pipeline_stages에 validation_tier 컬럼 추가
+ALTER TABLE pipeline_stages ADD COLUMN validation_tier TEXT DEFAULT 'none';
+
+-- F295: expert_meetings 테이블
+CREATE TABLE IF NOT EXISTS expert_meetings (
+  id TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL,
+  biz_item_id TEXT NOT NULL,
+  type TEXT NOT NULL DEFAULT 'interview',
+  title TEXT NOT NULL,
+  scheduled_at TEXT NOT NULL,
+  attendees TEXT NOT NULL DEFAULT '[]',
+  location TEXT,
+  notes TEXT,
+  status TEXT NOT NULL DEFAULT 'scheduled',
+  created_by TEXT NOT NULL DEFAULT '',
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (org_id) REFERENCES organizations(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_expert_meetings_org ON expert_meetings(org_id, biz_item_id);
+CREATE INDEX IF NOT EXISTS idx_expert_meetings_status ON expert_meetings(org_id, status);
+
+-- F294: validation_history 테이블 (검증 이력 추적)
+CREATE TABLE IF NOT EXISTS validation_history (
+  id TEXT PRIMARY KEY,
+  biz_item_id TEXT NOT NULL,
+  org_id TEXT NOT NULL,
+  tier TEXT NOT NULL,
+  decision TEXT NOT NULL,
+  comment TEXT NOT NULL DEFAULT '',
+  decided_by TEXT NOT NULL,
+  decided_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_validation_history_item ON validation_history(biz_item_id, decided_at DESC);
+CREATE INDEX IF NOT EXISTS idx_validation_history_org ON validation_history(org_id, decided_at DESC);

--- a/packages/api/src/routes/validation-meetings.ts
+++ b/packages/api/src/routes/validation-meetings.ts
@@ -1,0 +1,91 @@
+/**
+ * Sprint 116: Validation Meetings Routes — 인터뷰/미팅 관리 CRUD (F295)
+ */
+import { Hono } from "hono";
+import type { Env } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import { MeetingService } from "../services/meeting-service.js";
+import { CreateMeetingSchema, UpdateMeetingSchema, MeetingFilterSchema } from "../schemas/validation.schema.js";
+
+export const validationMeetingsRoute = new Hono<{ Bindings: Env; Variables: TenantVariables }>();
+
+// POST /validation/meetings — 미팅 생성
+validationMeetingsRoute.post("/validation/meetings", async (c) => {
+  const orgId = c.get("orgId");
+  const userId = (c.get("jwtPayload") as Record<string, string> | undefined)?.sub ?? "";
+
+  const body = await c.req.json();
+  const parsed = CreateMeetingSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new MeetingService(c.env.DB);
+  const meeting = await svc.create(parsed.data, orgId, userId);
+  return c.json(meeting, 201);
+});
+
+// GET /validation/meetings — 미팅 목록
+validationMeetingsRoute.get("/validation/meetings", async (c) => {
+  const orgId = c.get("orgId");
+  const query = c.req.query();
+  const parsed = MeetingFilterSchema.safeParse(query);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid filters", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new MeetingService(c.env.DB);
+  const result = await svc.list(orgId, parsed.data);
+  return c.json(result);
+});
+
+// GET /validation/meetings/:id — 미팅 상세
+validationMeetingsRoute.get("/validation/meetings/:id", async (c) => {
+  const orgId = c.get("orgId");
+  const id = c.req.param("id");
+
+  const svc = new MeetingService(c.env.DB);
+  const meeting = await svc.getById(id, orgId);
+
+  if (!meeting) {
+    return c.json({ error: "Meeting not found" }, 404);
+  }
+
+  return c.json(meeting);
+});
+
+// PATCH /validation/meetings/:id — 미팅 수정
+validationMeetingsRoute.patch("/validation/meetings/:id", async (c) => {
+  const orgId = c.get("orgId");
+  const id = c.req.param("id");
+
+  const body = await c.req.json();
+  const parsed = UpdateMeetingSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new MeetingService(c.env.DB);
+  const updated = await svc.update(id, orgId, parsed.data);
+
+  if (!updated) {
+    return c.json({ error: "Meeting not found" }, 404);
+  }
+
+  return c.json(updated);
+});
+
+// DELETE /validation/meetings/:id — 미팅 삭제
+validationMeetingsRoute.delete("/validation/meetings/:id", async (c) => {
+  const orgId = c.get("orgId");
+  const id = c.req.param("id");
+
+  const svc = new MeetingService(c.env.DB);
+  const deleted = await svc.delete(id, orgId);
+
+  if (!deleted) {
+    return c.json({ error: "Meeting not found" }, 404);
+  }
+
+  return c.json({ success: true });
+});

--- a/packages/api/src/routes/validation-tier.ts
+++ b/packages/api/src/routes/validation-tier.ts
@@ -1,0 +1,103 @@
+/**
+ * Sprint 116: Validation 2-tier Routes — 본부/전사 검증 워크플로 (F294)
+ */
+import { Hono } from "hono";
+import type { Env } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import { ValidationService, ValidationTierError } from "../services/validation-service.js";
+import { SubmitValidationSchema, ValidationFilterSchema } from "../schemas/validation.schema.js";
+
+export const validationTierRoute = new Hono<{ Bindings: Env; Variables: TenantVariables }>();
+
+// POST /validation/division/submit — 본부 검증 제출
+validationTierRoute.post("/validation/division/submit", async (c) => {
+  const orgId = c.get("orgId");
+  const userId = (c.get("jwtPayload") as Record<string, string> | undefined)?.sub ?? "";
+
+  const body = await c.req.json();
+  const parsed = SubmitValidationSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new ValidationService(c.env.DB);
+  try {
+    const result = await svc.submitDivisionReview(
+      parsed.data.bizItemId, orgId, parsed.data.decision, parsed.data.comment ?? "", userId,
+    );
+    return c.json(result, 200);
+  } catch (e) {
+    if (e instanceof ValidationTierError) {
+      return c.json({ error: e.message }, 400);
+    }
+    throw e;
+  }
+});
+
+// POST /validation/company/submit — 전사 검증 제출
+validationTierRoute.post("/validation/company/submit", async (c) => {
+  const orgId = c.get("orgId");
+  const userId = (c.get("jwtPayload") as Record<string, string> | undefined)?.sub ?? "";
+
+  const body = await c.req.json();
+  const parsed = SubmitValidationSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new ValidationService(c.env.DB);
+  try {
+    const result = await svc.submitCompanyReview(
+      parsed.data.bizItemId, orgId, parsed.data.decision, parsed.data.comment ?? "", userId,
+    );
+    return c.json(result, 200);
+  } catch (e) {
+    if (e instanceof ValidationTierError) {
+      return c.json({ error: e.message }, 400);
+    }
+    throw e;
+  }
+});
+
+// GET /validation/division/items — 본부 검증 대기 목록
+validationTierRoute.get("/validation/division/items", async (c) => {
+  const orgId = c.get("orgId");
+  const query = c.req.query();
+  const parsed = ValidationFilterSchema.safeParse(query);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid filters", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new ValidationService(c.env.DB);
+  const result = await svc.getDivisionItems(orgId, parsed.data);
+  return c.json(result);
+});
+
+// GET /validation/company/items — 전사 검증 대기 목록
+validationTierRoute.get("/validation/company/items", async (c) => {
+  const orgId = c.get("orgId");
+  const query = c.req.query();
+  const parsed = ValidationFilterSchema.safeParse(query);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid filters", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new ValidationService(c.env.DB);
+  const result = await svc.getCompanyItems(orgId, parsed.data);
+  return c.json(result);
+});
+
+// GET /validation/status/:bizItemId — 아이템별 검증 상태
+validationTierRoute.get("/validation/status/:bizItemId", async (c) => {
+  const orgId = c.get("orgId");
+  const bizItemId = c.req.param("bizItemId");
+
+  const svc = new ValidationService(c.env.DB);
+  const status = await svc.getValidationStatus(bizItemId, orgId);
+
+  if (!status) {
+    return c.json({ error: "Item not found" }, 404);
+  }
+
+  return c.json(status);
+});

--- a/packages/api/src/schemas/validation.schema.ts
+++ b/packages/api/src/schemas/validation.schema.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+// F294: Validation tier
+export const VALIDATION_TIERS = [
+  "none", "division_pending", "division_approved", "company_pending", "company_approved",
+] as const;
+export type ValidationTier = (typeof VALIDATION_TIERS)[number];
+export const ValidationTierEnum = z.enum(VALIDATION_TIERS);
+
+export const SubmitValidationSchema = z.object({
+  bizItemId: z.string().min(1),
+  decision: z.enum(["approve", "reject"]),
+  comment: z.string().max(2000).optional(),
+});
+
+export const ValidationFilterSchema = z.object({
+  tier: ValidationTierEnum.optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+// F295: Meeting
+export const MEETING_TYPES = ["interview", "meeting", "workshop", "review"] as const;
+export type MeetingType = (typeof MEETING_TYPES)[number];
+
+export const MEETING_STATUSES = ["scheduled", "completed", "cancelled"] as const;
+export type MeetingStatus = (typeof MEETING_STATUSES)[number];
+
+export const CreateMeetingSchema = z.object({
+  bizItemId: z.string().min(1),
+  type: z.enum(MEETING_TYPES).default("interview"),
+  title: z.string().min(1).max(200),
+  scheduledAt: z.string(),
+  attendees: z.array(z.string()).default([]),
+  location: z.string().max(200).optional(),
+  notes: z.string().max(5000).optional(),
+});
+
+export const UpdateMeetingSchema = z.object({
+  title: z.string().min(1).max(200).optional(),
+  scheduledAt: z.string().optional(),
+  attendees: z.array(z.string()).optional(),
+  location: z.string().max(200).optional(),
+  notes: z.string().max(5000).optional(),
+  status: z.enum(MEETING_STATUSES).optional(),
+});
+
+export const MeetingFilterSchema = z.object({
+  bizItemId: z.string().optional(),
+  status: z.enum(MEETING_STATUSES).optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+});

--- a/packages/api/src/services/meeting-service.ts
+++ b/packages/api/src/services/meeting-service.ts
@@ -1,0 +1,191 @@
+/**
+ * MeetingService — 전문가 인터뷰/미팅 관리 CRUD (F295)
+ */
+import type { MeetingType, MeetingStatus } from "../schemas/validation.schema.js";
+
+export interface Meeting {
+  id: string;
+  orgId: string;
+  bizItemId: string;
+  type: MeetingType;
+  title: string;
+  scheduledAt: string;
+  attendees: string[];
+  location: string | null;
+  notes: string | null;
+  status: MeetingStatus;
+  createdBy: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateMeetingInput {
+  bizItemId: string;
+  type?: MeetingType;
+  title: string;
+  scheduledAt: string;
+  attendees?: string[];
+  location?: string;
+  notes?: string;
+}
+
+export interface UpdateMeetingInput {
+  title?: string;
+  scheduledAt?: string;
+  attendees?: string[];
+  location?: string;
+  notes?: string;
+  status?: MeetingStatus;
+}
+
+export interface MeetingFilters {
+  bizItemId?: string;
+  status?: MeetingStatus;
+  limit?: number;
+  offset?: number;
+}
+
+export class MeetingService {
+  constructor(private db: D1Database) {}
+
+  async create(input: CreateMeetingInput, orgId: string, userId: string): Promise<Meeting> {
+    const id = crypto.randomUUID();
+    const type = input.type ?? "interview";
+    const attendees = JSON.stringify(input.attendees ?? []);
+
+    await this.db
+      .prepare(
+        `INSERT INTO expert_meetings (id, org_id, biz_item_id, type, title, scheduled_at, attendees, location, notes, created_by)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(id, orgId, input.bizItemId, type, input.title, input.scheduledAt, attendees, input.location ?? null, input.notes ?? null, userId)
+      .run();
+
+    return {
+      id,
+      orgId,
+      bizItemId: input.bizItemId,
+      type,
+      title: input.title,
+      scheduledAt: input.scheduledAt,
+      attendees: input.attendees ?? [],
+      location: input.location ?? null,
+      notes: input.notes ?? null,
+      status: "scheduled",
+      createdBy: userId,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+  }
+
+  async list(orgId: string, filters?: MeetingFilters): Promise<{ items: Meeting[]; total: number }> {
+    const limit = filters?.limit ?? 20;
+    const offset = filters?.offset ?? 0;
+    const conditions: string[] = ["org_id = ?"];
+    const params: unknown[] = [orgId];
+
+    if (filters?.bizItemId) {
+      conditions.push("biz_item_id = ?");
+      params.push(filters.bizItemId);
+    }
+    if (filters?.status) {
+      conditions.push("status = ?");
+      params.push(filters.status);
+    }
+
+    const where = conditions.join(" AND ");
+
+    const countResult = await this.db
+      .prepare(`SELECT COUNT(*) as cnt FROM expert_meetings WHERE ${where}`)
+      .bind(...params)
+      .first<{ cnt: number }>();
+
+    const { results } = await this.db
+      .prepare(
+        `SELECT id, org_id, biz_item_id, type, title, scheduled_at, attendees, location, notes, status, created_by, created_at, updated_at
+         FROM expert_meetings WHERE ${where}
+         ORDER BY scheduled_at DESC
+         LIMIT ? OFFSET ?`,
+      )
+      .bind(...params, limit, offset)
+      .all<Record<string, unknown>>();
+
+    return {
+      items: results.map((r) => this.mapRow(r)),
+      total: countResult?.cnt ?? 0,
+    };
+  }
+
+  async getById(id: string, orgId: string): Promise<Meeting | null> {
+    const row = await this.db
+      .prepare(
+        `SELECT id, org_id, biz_item_id, type, title, scheduled_at, attendees, location, notes, status, created_by, created_at, updated_at
+         FROM expert_meetings WHERE id = ? AND org_id = ?`,
+      )
+      .bind(id, orgId)
+      .first<Record<string, unknown>>();
+
+    return row ? this.mapRow(row) : null;
+  }
+
+  async update(id: string, orgId: string, input: UpdateMeetingInput): Promise<Meeting | null> {
+    const existing = await this.getById(id, orgId);
+    if (!existing) return null;
+
+    const sets: string[] = ["updated_at = datetime('now')"];
+    const params: unknown[] = [];
+
+    if (input.title !== undefined) { sets.push("title = ?"); params.push(input.title); }
+    if (input.scheduledAt !== undefined) { sets.push("scheduled_at = ?"); params.push(input.scheduledAt); }
+    if (input.attendees !== undefined) { sets.push("attendees = ?"); params.push(JSON.stringify(input.attendees)); }
+    if (input.location !== undefined) { sets.push("location = ?"); params.push(input.location); }
+    if (input.notes !== undefined) { sets.push("notes = ?"); params.push(input.notes); }
+    if (input.status !== undefined) { sets.push("status = ?"); params.push(input.status); }
+
+    params.push(id, orgId);
+
+    await this.db
+      .prepare(`UPDATE expert_meetings SET ${sets.join(", ")} WHERE id = ? AND org_id = ?`)
+      .bind(...params)
+      .run();
+
+    return this.getById(id, orgId);
+  }
+
+  async delete(id: string, orgId: string): Promise<boolean> {
+    const existing = await this.getById(id, orgId);
+    if (!existing) return false;
+
+    await this.db
+      .prepare(`DELETE FROM expert_meetings WHERE id = ? AND org_id = ?`)
+      .bind(id, orgId)
+      .run();
+
+    return true;
+  }
+
+  private mapRow(r: Record<string, unknown>): Meeting {
+    let attendees: string[] = [];
+    try {
+      attendees = JSON.parse(r.attendees as string) as string[];
+    } catch {
+      attendees = [];
+    }
+
+    return {
+      id: r.id as string,
+      orgId: r.org_id as string,
+      bizItemId: r.biz_item_id as string,
+      type: r.type as MeetingType,
+      title: r.title as string,
+      scheduledAt: r.scheduled_at as string,
+      attendees,
+      location: (r.location as string) || null,
+      notes: (r.notes as string) || null,
+      status: r.status as MeetingStatus,
+      createdBy: r.created_by as string,
+      createdAt: r.created_at as string,
+      updatedAt: r.updated_at as string,
+    };
+  }
+}

--- a/packages/api/src/services/validation-service.ts
+++ b/packages/api/src/services/validation-service.ts
@@ -1,0 +1,263 @@
+/**
+ * ValidationService — 본부/전사 2-tier 검증 워크플로 (F294)
+ */
+import type { ValidationTier } from "../schemas/validation.schema.js";
+
+export interface ValidationResult {
+  bizItemId: string;
+  previousTier: ValidationTier;
+  currentTier: ValidationTier;
+  decision: "approve" | "reject";
+  comment: string;
+  decidedBy: string;
+  decidedAt: string;
+}
+
+export interface ValidationItem {
+  bizItemId: string;
+  title: string;
+  currentStage: string;
+  validationTier: ValidationTier;
+  stageEnteredAt: string;
+  createdBy: string;
+}
+
+export interface ValidationStatus {
+  bizItemId: string;
+  tier: ValidationTier;
+  history: Array<{
+    tier: ValidationTier;
+    decision: string;
+    decidedBy: string;
+    decidedAt: string;
+    comment: string;
+  }>;
+}
+
+export class ValidationService {
+  constructor(private db: D1Database) {}
+
+  async submitDivisionReview(
+    bizItemId: string,
+    orgId: string,
+    decision: "approve" | "reject",
+    comment: string,
+    userId: string,
+  ): Promise<ValidationResult> {
+    // Get current tier
+    const current = await this.getCurrentTier(bizItemId, orgId);
+    if (current !== "none" && current !== "division_pending") {
+      throw new ValidationTierError(`Cannot submit division review: current tier is '${current}'`);
+    }
+
+    const newTier: ValidationTier = decision === "approve" ? "division_approved" : "none";
+
+    await this.db
+      .prepare(
+        `UPDATE pipeline_stages SET validation_tier = ?
+         WHERE biz_item_id = ? AND org_id = ? AND exited_at IS NULL`,
+      )
+      .bind(newTier, bizItemId, orgId)
+      .run();
+
+    // Record history
+    await this.recordHistory(bizItemId, orgId, newTier, decision, comment, userId);
+
+    return {
+      bizItemId,
+      previousTier: current,
+      currentTier: newTier,
+      decision,
+      comment,
+      decidedBy: userId,
+      decidedAt: new Date().toISOString(),
+    };
+  }
+
+  async submitCompanyReview(
+    bizItemId: string,
+    orgId: string,
+    decision: "approve" | "reject",
+    comment: string,
+    userId: string,
+  ): Promise<ValidationResult> {
+    const current = await this.getCurrentTier(bizItemId, orgId);
+    if (current !== "division_approved" && current !== "company_pending") {
+      throw new ValidationTierError(`Cannot submit company review: current tier is '${current}', need 'division_approved'`);
+    }
+
+    const newTier: ValidationTier = decision === "approve" ? "company_approved" : "division_approved";
+
+    await this.db
+      .prepare(
+        `UPDATE pipeline_stages SET validation_tier = ?
+         WHERE biz_item_id = ? AND org_id = ? AND exited_at IS NULL`,
+      )
+      .bind(newTier, bizItemId, orgId)
+      .run();
+
+    await this.recordHistory(bizItemId, orgId, newTier, decision, comment, userId);
+
+    return {
+      bizItemId,
+      previousTier: current,
+      currentTier: newTier,
+      decision,
+      comment,
+      decidedBy: userId,
+      decidedAt: new Date().toISOString(),
+    };
+  }
+
+  async getDivisionItems(orgId: string, filters?: { limit?: number; offset?: number }): Promise<{ items: ValidationItem[]; total: number }> {
+    const limit = filters?.limit ?? 20;
+    const offset = filters?.offset ?? 0;
+
+    const countResult = await this.db
+      .prepare(
+        `SELECT COUNT(*) as cnt FROM pipeline_stages ps
+         JOIN biz_items bi ON bi.id = ps.biz_item_id
+         WHERE ps.org_id = ? AND ps.exited_at IS NULL
+           AND ps.stage IN ('REVIEW', 'DECISION')
+           AND (ps.validation_tier IS NULL OR ps.validation_tier IN ('none', 'division_pending'))`,
+      )
+      .bind(orgId)
+      .first<{ cnt: number }>();
+
+    const { results } = await this.db
+      .prepare(
+        `SELECT ps.biz_item_id, bi.title, ps.stage, ps.validation_tier, ps.entered_at, bi.created_by
+         FROM pipeline_stages ps
+         JOIN biz_items bi ON bi.id = ps.biz_item_id
+         WHERE ps.org_id = ? AND ps.exited_at IS NULL
+           AND ps.stage IN ('REVIEW', 'DECISION')
+           AND (ps.validation_tier IS NULL OR ps.validation_tier IN ('none', 'division_pending'))
+         ORDER BY ps.entered_at ASC
+         LIMIT ? OFFSET ?`,
+      )
+      .bind(orgId, limit, offset)
+      .all<Record<string, unknown>>();
+
+    return {
+      items: results.map((r) => this.mapValidationItem(r)),
+      total: countResult?.cnt ?? 0,
+    };
+  }
+
+  async getCompanyItems(orgId: string, filters?: { limit?: number; offset?: number }): Promise<{ items: ValidationItem[]; total: number }> {
+    const limit = filters?.limit ?? 20;
+    const offset = filters?.offset ?? 0;
+
+    const countResult = await this.db
+      .prepare(
+        `SELECT COUNT(*) as cnt FROM pipeline_stages ps
+         JOIN biz_items bi ON bi.id = ps.biz_item_id
+         WHERE ps.org_id = ? AND ps.exited_at IS NULL
+           AND ps.validation_tier = 'division_approved'`,
+      )
+      .bind(orgId)
+      .first<{ cnt: number }>();
+
+    const { results } = await this.db
+      .prepare(
+        `SELECT ps.biz_item_id, bi.title, ps.stage, ps.validation_tier, ps.entered_at, bi.created_by
+         FROM pipeline_stages ps
+         JOIN biz_items bi ON bi.id = ps.biz_item_id
+         WHERE ps.org_id = ? AND ps.exited_at IS NULL
+           AND ps.validation_tier = 'division_approved'
+         ORDER BY ps.entered_at ASC
+         LIMIT ? OFFSET ?`,
+      )
+      .bind(orgId, limit, offset)
+      .all<Record<string, unknown>>();
+
+    return {
+      items: results.map((r) => this.mapValidationItem(r)),
+      total: countResult?.cnt ?? 0,
+    };
+  }
+
+  async getValidationStatus(bizItemId: string, orgId: string): Promise<ValidationStatus | null> {
+    const current = await this.db
+      .prepare(
+        `SELECT validation_tier FROM pipeline_stages
+         WHERE biz_item_id = ? AND org_id = ? AND exited_at IS NULL
+         ORDER BY entered_at DESC LIMIT 1`,
+      )
+      .bind(bizItemId, orgId)
+      .first<{ validation_tier: string }>();
+
+    if (!current) return null;
+
+    const { results } = await this.db
+      .prepare(
+        `SELECT tier, decision, decided_by, decided_at, comment
+         FROM validation_history
+         WHERE biz_item_id = ? AND org_id = ?
+         ORDER BY decided_at DESC`,
+      )
+      .bind(bizItemId, orgId)
+      .all<Record<string, unknown>>();
+
+    return {
+      bizItemId,
+      tier: (current.validation_tier || "none") as ValidationTier,
+      history: results.map((r) => ({
+        tier: r.tier as ValidationTier,
+        decision: r.decision as string,
+        decidedBy: r.decided_by as string,
+        decidedAt: r.decided_at as string,
+        comment: r.comment as string,
+      })),
+    };
+  }
+
+  private async getCurrentTier(bizItemId: string, orgId: string): Promise<ValidationTier> {
+    const row = await this.db
+      .prepare(
+        `SELECT validation_tier FROM pipeline_stages
+         WHERE biz_item_id = ? AND org_id = ? AND exited_at IS NULL
+         ORDER BY entered_at DESC LIMIT 1`,
+      )
+      .bind(bizItemId, orgId)
+      .first<{ validation_tier: string }>();
+
+    return (row?.validation_tier || "none") as ValidationTier;
+  }
+
+  private async recordHistory(
+    bizItemId: string,
+    orgId: string,
+    tier: ValidationTier,
+    decision: string,
+    comment: string,
+    userId: string,
+  ): Promise<void> {
+    const id = crypto.randomUUID();
+    await this.db
+      .prepare(
+        `INSERT INTO validation_history (id, biz_item_id, org_id, tier, decision, comment, decided_by, decided_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
+      )
+      .bind(id, bizItemId, orgId, tier, decision, comment, userId)
+      .run();
+  }
+
+  private mapValidationItem(r: Record<string, unknown>): ValidationItem {
+    return {
+      bizItemId: r.biz_item_id as string,
+      title: r.title as string,
+      currentStage: r.stage as string,
+      validationTier: (r.validation_tier || "none") as ValidationTier,
+      stageEnteredAt: r.entered_at as string,
+      createdBy: r.created_by as string,
+    };
+  }
+}
+
+export class ValidationTierError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ValidationTierError";
+  }
+}

--- a/packages/web/src/__tests__/validation-company.test.tsx
+++ b/packages/web/src/__tests__/validation-company.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import { Component as ValidationCompanyPage } from "@/routes/validation-company";
+
+vi.mock("../lib/api-client", () => ({
+  fetchApi: vi.fn().mockResolvedValue({ items: [], total: 0 }),
+}));
+
+import { fetchApi } from "../lib/api-client";
+
+const mockItems = [
+  {
+    bizItemId: "item-2",
+    title: "공급망 인과 분석",
+    currentStage: "REVIEW",
+    validationTier: "division_approved",
+    stageEnteredAt: "2026-04-01T10:00:00Z",
+    createdBy: "user-1",
+  },
+];
+
+describe("ValidationCompanyPage (F294)", () => {
+  beforeEach(() => {
+    vi.mocked(fetchApi).mockResolvedValue({ items: [], total: 0 });
+  });
+
+  it("renders page title", async () => {
+    const { findByText } = render(<ValidationCompanyPage />);
+    expect(await findByText("전사 검증")).toBeDefined();
+  });
+
+  it("shows guidance text", async () => {
+    const { findByText } = render(<ValidationCompanyPage />);
+    expect(await findByText("본부 검증이 승인된 항목만 전사 검증에 표시돼요.")).toBeDefined();
+  });
+
+  it("shows empty state when no items", async () => {
+    const { findByText } = render(<ValidationCompanyPage />);
+    expect(await findByText("전사 검증 대기 중인 항목이 없어요.")).toBeDefined();
+  });
+
+  it("displays division-approved items", async () => {
+    vi.mocked(fetchApi).mockResolvedValueOnce({ items: mockItems, total: 1 });
+    const { findByText } = render(<ValidationCompanyPage />);
+    expect(await findByText("공급망 인과 분석")).toBeDefined();
+  });
+});

--- a/packages/web/src/__tests__/validation-division.test.tsx
+++ b/packages/web/src/__tests__/validation-division.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import { Component as ValidationDivisionPage } from "@/routes/validation-division";
+
+vi.mock("../lib/api-client", () => ({
+  fetchApi: vi.fn().mockResolvedValue({ items: [], total: 0 }),
+}));
+
+import { fetchApi } from "../lib/api-client";
+
+const mockItems = [
+  {
+    bizItemId: "item-1",
+    title: "AI 품질 예측",
+    currentStage: "REVIEW",
+    validationTier: "none",
+    stageEnteredAt: "2026-04-01T09:00:00Z",
+    createdBy: "user-1",
+  },
+];
+
+describe("ValidationDivisionPage (F294)", () => {
+  beforeEach(() => {
+    vi.mocked(fetchApi).mockResolvedValue({ items: [], total: 0 });
+  });
+
+  it("renders page title", async () => {
+    const { findByText } = render(<ValidationDivisionPage />);
+    expect(await findByText("본부 검증")).toBeDefined();
+  });
+
+  it("shows empty state when no items", async () => {
+    const { findByText } = render(<ValidationDivisionPage />);
+    expect(await findByText("검증 대기 중인 항목이 없어요.")).toBeDefined();
+  });
+
+  it("displays items with approve/reject buttons", async () => {
+    vi.mocked(fetchApi).mockResolvedValueOnce({ items: mockItems, total: 1 });
+    const { findByText } = render(<ValidationDivisionPage />);
+    expect(await findByText("AI 품질 예측")).toBeDefined();
+    expect(await findByText("승인")).toBeDefined();
+    expect(await findByText("반려")).toBeDefined();
+  });
+});

--- a/packages/web/src/__tests__/validation-meetings.test.tsx
+++ b/packages/web/src/__tests__/validation-meetings.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import { Component as ValidationMeetingsPage } from "@/routes/validation-meetings";
+
+vi.mock("../lib/api-client", () => ({
+  fetchApi: vi.fn().mockResolvedValue({ items: [], total: 0 }),
+}));
+
+import { fetchApi } from "../lib/api-client";
+
+const mockMeetings = [
+  {
+    id: "m-1",
+    bizItemId: "item-1",
+    type: "interview",
+    title: "AI 전문가 인터뷰",
+    scheduledAt: "2026-04-10T10:00:00Z",
+    attendees: ["user-1", "user-2"],
+    location: "회의실 A",
+    notes: "핵심 질문 3건 준비",
+    status: "scheduled",
+  },
+];
+
+describe("ValidationMeetingsPage (F295)", () => {
+  beforeEach(() => {
+    vi.mocked(fetchApi).mockResolvedValue({ items: [], total: 0 });
+  });
+
+  it("renders page title", async () => {
+    const { findByText } = render(<ValidationMeetingsPage />);
+    expect(await findByText("미팅 관리")).toBeDefined();
+  });
+
+  it("renders add button", async () => {
+    const { findByText } = render(<ValidationMeetingsPage />);
+    expect(await findByText("미팅 추가")).toBeDefined();
+  });
+
+  it("shows empty state when no meetings", async () => {
+    const { findByText } = render(<ValidationMeetingsPage />);
+    expect(await findByText("등록된 미팅이 없어요.")).toBeDefined();
+  });
+
+  it("displays meeting list", async () => {
+    vi.mocked(fetchApi).mockResolvedValueOnce({ items: mockMeetings, total: 1 });
+    const { findByText } = render(<ValidationMeetingsPage />);
+    expect(await findByText("AI 전문가 인터뷰")).toBeDefined();
+    expect(await findByText("핵심 질문 3건 준비")).toBeDefined();
+  });
+});

--- a/packages/web/src/components/sidebar.tsx
+++ b/packages/web/src/components/sidebar.tsx
@@ -34,6 +34,9 @@ import {
   Package,
   CheckCircle,
   GitBranch,
+  Shield,
+  Building2,
+  CalendarDays,
   Target,
   Library,
   Users,
@@ -154,6 +157,9 @@ const processGroups: NavGroup[] = [
     stageColor: "bg-axis-green",
     items: [
       { href: "/validation/pipeline", label: "파이프라인", icon: GitBranch },
+      { href: "/validation/division", label: "본부 검증", icon: Shield },
+      { href: "/validation/company", label: "전사 검증", icon: Building2 },
+      { href: "/validation/meetings", label: "미팅 관리", icon: CalendarDays },
     ],
   },
   {

--- a/packages/web/src/router.tsx
+++ b/packages/web/src/router.tsx
@@ -49,6 +49,9 @@ export const router = createBrowserRouter([
 
       // ── 4단계 검증/공유 (validation) ──
       { path: "validation/pipeline", lazy: () => import("@/routes/pipeline") },
+      { path: "validation/division", lazy: () => import("@/routes/validation-division") },
+      { path: "validation/company", lazy: () => import("@/routes/validation-company") },
+      { path: "validation/meetings", lazy: () => import("@/routes/validation-meetings") },
 
       // ── 5단계 제품화 (product) ──
       { path: "product/mvp", lazy: () => import("@/routes/mvp-tracking") },

--- a/packages/web/src/routes/validation-company.tsx
+++ b/packages/web/src/routes/validation-company.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { fetchApi } from "@/lib/api-client";
+import { Building2, Check, X } from "lucide-react";
+
+interface ValidationItem {
+  bizItemId: string;
+  title: string;
+  currentStage: string;
+  validationTier: string;
+  stageEnteredAt: string;
+  createdBy: string;
+}
+
+export function Component() {
+  const [items, setItems] = useState<ValidationItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+
+  const loadItems = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await fetchApi<{ items: ValidationItem[]; total: number }>("/validation/company/items");
+      setItems(data.items);
+      setTotal(data.total);
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { loadItems(); }, [loadItems]);
+
+  const handleSubmit = async (bizItemId: string, decision: "approve" | "reject") => {
+    try {
+      await fetchApi("/validation/company/submit", {
+        method: "POST",
+        body: JSON.stringify({ bizItemId, decision, comment: "" }),
+      });
+      await loadItems();
+    } catch {
+      // ignore
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="p-6 space-y-4">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-32 w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center gap-2">
+        <Building2 className="h-6 w-6 text-indigo-600" />
+        <h1 className="text-2xl font-bold">전사 검증</h1>
+        <span className="text-sm text-muted-foreground">({total}건)</span>
+      </div>
+
+      <p className="text-sm text-muted-foreground">
+        본부 검증이 승인된 항목만 전사 검증에 표시돼요.
+      </p>
+
+      {items.length === 0 ? (
+        <p className="text-muted-foreground">전사 검증 대기 중인 항목이 없어요.</p>
+      ) : (
+        <div className="space-y-3">
+          {items.map((item) => (
+            <div key={item.bizItemId} className="border rounded-lg p-4 flex items-center justify-between">
+              <div>
+                <h3 className="font-medium">{item.title}</h3>
+                <p className="text-sm text-muted-foreground">
+                  단계: {item.currentStage} · 등록일: {new Date(item.stageEnteredAt).toLocaleDateString("ko-KR")}
+                </p>
+              </div>
+              <div className="flex gap-2">
+                <Button size="sm" variant="default" onClick={() => handleSubmit(item.bizItemId, "approve")}>
+                  <Check className="h-4 w-4 mr-1" /> 승인
+                </Button>
+                <Button size="sm" variant="destructive" onClick={() => handleSubmit(item.bizItemId, "reject")}>
+                  <X className="h-4 w-4 mr-1" /> 반려
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/routes/validation-division.tsx
+++ b/packages/web/src/routes/validation-division.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { fetchApi } from "@/lib/api-client";
+import { Shield, Check, X } from "lucide-react";
+
+interface ValidationItem {
+  bizItemId: string;
+  title: string;
+  currentStage: string;
+  validationTier: string;
+  stageEnteredAt: string;
+  createdBy: string;
+}
+
+export function Component() {
+  const [items, setItems] = useState<ValidationItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+
+  const loadItems = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await fetchApi<{ items: ValidationItem[]; total: number }>("/validation/division/items");
+      setItems(data.items);
+      setTotal(data.total);
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { loadItems(); }, [loadItems]);
+
+  const handleSubmit = async (bizItemId: string, decision: "approve" | "reject") => {
+    try {
+      await fetchApi("/validation/division/submit", {
+        method: "POST",
+        body: JSON.stringify({ bizItemId, decision, comment: "" }),
+      });
+      await loadItems();
+    } catch {
+      // ignore
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="p-6 space-y-4">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-32 w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center gap-2">
+        <Shield className="h-6 w-6 text-green-600" />
+        <h1 className="text-2xl font-bold">본부 검증</h1>
+        <span className="text-sm text-muted-foreground">({total}건)</span>
+      </div>
+
+      {items.length === 0 ? (
+        <p className="text-muted-foreground">검증 대기 중인 항목이 없어요.</p>
+      ) : (
+        <div className="space-y-3">
+          {items.map((item) => (
+            <div key={item.bizItemId} className="border rounded-lg p-4 flex items-center justify-between">
+              <div>
+                <h3 className="font-medium">{item.title}</h3>
+                <p className="text-sm text-muted-foreground">
+                  단계: {item.currentStage} · 등록일: {new Date(item.stageEnteredAt).toLocaleDateString("ko-KR")}
+                </p>
+              </div>
+              <div className="flex gap-2">
+                <Button size="sm" variant="default" onClick={() => handleSubmit(item.bizItemId, "approve")}>
+                  <Check className="h-4 w-4 mr-1" /> 승인
+                </Button>
+                <Button size="sm" variant="destructive" onClick={() => handleSubmit(item.bizItemId, "reject")}>
+                  <X className="h-4 w-4 mr-1" /> 반려
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/routes/validation-meetings.tsx
+++ b/packages/web/src/routes/validation-meetings.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { fetchApi } from "@/lib/api-client";
+import { CalendarDays, Plus } from "lucide-react";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface Meeting {
+  id: string;
+  bizItemId: string;
+  type: string;
+  title: string;
+  scheduledAt: string;
+  attendees: string[];
+  location: string | null;
+  notes: string | null;
+  status: string;
+}
+
+export function Component() {
+  const [meetings, setMeetings] = useState<Meeting[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [sheetOpen, setSheetOpen] = useState(false);
+
+  // Form state
+  const [title, setTitle] = useState("");
+  const [bizItemId, setBizItemId] = useState("");
+  const [scheduledAt, setScheduledAt] = useState("");
+  const [location, setLocation] = useState("");
+
+  const loadMeetings = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await fetchApi<{ items: Meeting[]; total: number }>("/validation/meetings");
+      setMeetings(data.items);
+      setTotal(data.total);
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { loadMeetings(); }, [loadMeetings]);
+
+  const handleCreate = async () => {
+    if (!title || !bizItemId || !scheduledAt) return;
+    try {
+      await fetchApi("/validation/meetings", {
+        method: "POST",
+        body: JSON.stringify({ bizItemId, title, scheduledAt, location: location || undefined }),
+      });
+      setSheetOpen(false);
+      setTitle("");
+      setBizItemId("");
+      setScheduledAt("");
+      setLocation("");
+      await loadMeetings();
+    } catch {
+      // ignore
+    }
+  };
+
+  const statusBadge = (status: string) => {
+    const colors: Record<string, string> = {
+      scheduled: "bg-blue-100 text-blue-800",
+      completed: "bg-green-100 text-green-800",
+      cancelled: "bg-gray-100 text-gray-500",
+    };
+    return (
+      <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${colors[status] ?? "bg-gray-100"}`}>
+        {status}
+      </span>
+    );
+  };
+
+  if (loading) {
+    return (
+      <div className="p-6 space-y-4">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-32 w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <CalendarDays className="h-6 w-6 text-orange-600" />
+          <h1 className="text-2xl font-bold">미팅 관리</h1>
+          <span className="text-sm text-muted-foreground">({total}건)</span>
+        </div>
+
+        <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
+          <SheetTrigger asChild>
+            <Button size="sm">
+              <Plus className="h-4 w-4 mr-1" /> 미팅 추가
+            </Button>
+          </SheetTrigger>
+          <SheetContent>
+            <SheetHeader>
+              <SheetTitle>새 미팅 추가</SheetTitle>
+            </SheetHeader>
+            <div className="space-y-4 pt-4">
+              <div>
+                <Label htmlFor="title">제목</Label>
+                <Input id="title" value={title} onChange={(e) => setTitle(e.target.value)} placeholder="인터뷰 제목" />
+              </div>
+              <div>
+                <Label htmlFor="bizItemId">사업 아이템 ID</Label>
+                <Input id="bizItemId" value={bizItemId} onChange={(e) => setBizItemId(e.target.value)} placeholder="item-xxx" />
+              </div>
+              <div>
+                <Label htmlFor="scheduledAt">일정</Label>
+                <Input id="scheduledAt" type="datetime-local" value={scheduledAt} onChange={(e) => setScheduledAt(e.target.value)} />
+              </div>
+              <div>
+                <Label htmlFor="location">장소 (선택)</Label>
+                <Input id="location" value={location} onChange={(e) => setLocation(e.target.value)} placeholder="회의실 A" />
+              </div>
+              <Button onClick={handleCreate} className="w-full">생성</Button>
+            </div>
+          </SheetContent>
+        </Sheet>
+      </div>
+
+      {meetings.length === 0 ? (
+        <p className="text-muted-foreground">등록된 미팅이 없어요.</p>
+      ) : (
+        <div className="space-y-3">
+          {meetings.map((m) => (
+            <div key={m.id} className="border rounded-lg p-4">
+              <div className="flex items-center justify-between">
+                <h3 className="font-medium">{m.title}</h3>
+                {statusBadge(m.status)}
+              </div>
+              <p className="text-sm text-muted-foreground mt-1">
+                {new Date(m.scheduledAt).toLocaleString("ko-KR")}
+                {m.location && ` · ${m.location}`}
+                {m.attendees.length > 0 && ` · 참석자 ${m.attendees.length}명`}
+              </p>
+              {m.notes && (
+                <p className="text-sm mt-2 text-gray-600">{m.notes}</p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **F294**: 본부→전사 2-tier 검증 워크플로 (5 API endpoints)
- **F295**: expert_meetings CRUD + 인터뷰/미팅 관리 (5 API endpoints)
- D1 migration 0086: 3 DDL statements (ALTER + CREATE 2)
- Web: 3 pages (본부/전사 검증, 미팅 관리) + sidebar 3 메뉴

## Metrics
- New endpoints: 10
- New tests: 33 (API 22 + Web 11)
- New files: 17 + 3 modified
- Match Rate: 95%

## Test plan
- [x] API 22 tests 통과 (validation-tier 11 + validation-meetings 11)
- [x] Web 11 tests 통과 (division 3 + company 4 + meetings 4)
- [x] typecheck 통과 (신규 파일 에러 없음)
- [ ] D1 migration 0086 remote 적용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)