### PR TITLE
feat: Sprint 129 — F309 Marker.io 비주얼 피드백 통합

### DIFF
--- a/packages/web/.env.example
+++ b/packages/web/.env.example
@@ -1,0 +1,4 @@
+VITE_API_URL=https://foundry-x-api.ktds-axbd.workers.dev/api
+
+# Marker.io 비주얼 피드백 (계정 생성 후 프로젝트 ID 설정)
+# VITE_MARKER_PROJECT_ID=

--- a/packages/web/src/components/MarkerWidget.tsx
+++ b/packages/web/src/components/MarkerWidget.tsx
@@ -1,0 +1,28 @@
+import { useEffect } from "react";
+
+declare global {
+  interface Window {
+    markerConfig?: { project: string; source: string };
+  }
+}
+
+export function MarkerWidget() {
+  useEffect(() => {
+    const projectId = import.meta.env.VITE_MARKER_PROJECT_ID;
+    if (!projectId) return;
+
+    window.markerConfig = { project: projectId, source: "snippet" };
+
+    const script = document.createElement("script");
+    script.src = "https://edge.marker.io/latest/shim.js";
+    script.async = true;
+    document.head.appendChild(script);
+
+    return () => {
+      script.remove();
+      delete window.markerConfig;
+    };
+  }, []);
+
+  return null;
+}

--- a/packages/web/src/layouts/AppLayout.tsx
+++ b/packages/web/src/layouts/AppLayout.tsx
@@ -5,6 +5,7 @@ import { FeedbackWidget } from "@/components/feature/FeedbackWidget";
 import { ProcessStageGuide } from "@/components/feature/ProcessStageGuide";
 import { NpsSurveyTrigger } from "@/components/feature/NpsSurveyTrigger";
 import { HelpAgentPanel } from "@/components/feature/HelpAgentPanel";
+import { MarkerWidget } from "@/components/MarkerWidget";
 import { useCallback, useState } from "react";
 
 export function AppLayout() {
@@ -25,6 +26,7 @@ export function AppLayout() {
       <FeedbackWidget surveyId={npsSurveyId} />
       <NpsSurveyTrigger onTrigger={handleNpsTrigger} />
       <HelpAgentPanel />
+      <MarkerWidget />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Marker.io shim.js 동적 로드 위젯(`MarkerWidget.tsx`) 신규 생성
- `AppLayout`에 삽입 — 로그인 후 대시보드에서만 활성화
- 환경변수(`VITE_MARKER_PROJECT_ID`) 미설정 시 graceful skip

## Changes
| 파일 | 변경 |
|------|------|
| `packages/web/src/components/MarkerWidget.tsx` | 신규 — Marker.io 위젯 컴포넌트 |
| `packages/web/src/layouts/AppLayout.tsx` | import + JSX 삽입 (2줄) |
| `packages/web/.env.example` | `VITE_MARKER_PROJECT_ID` 환경변수 템플릿 |

## Match Rate
100% (6/6 Design 항목 PASS)

## Test plan
- [x] `pnpm typecheck` 통과
- [x] `pnpm build` 통과
- [ ] Marker.io 계정 생성 후 Pages 환경변수 설정 → 위젯 표시 확인
- [ ] 기존 E2E 회귀 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)