### PR TITLE
feat: Sprint 127 F306 — DERIVED/CAPTURED → SKILL.md 자동 생성

### DIFF
--- a/packages/api/src/__tests__/captured-engine-routes.test.ts
+++ b/packages/api/src/__tests__/captured-engine-routes.test.ts
@@ -61,6 +61,7 @@ CREATE TABLE IF NOT EXISTS skill_registry (
   current_version INTEGER DEFAULT 1, created_by TEXT NOT NULL,
   updated_by TEXT, created_at TEXT DEFAULT (datetime('now')),
   updated_at TEXT DEFAULT (datetime('now')), deleted_at TEXT,
+  skill_md_content TEXT, skill_md_generated_at TEXT,
   UNIQUE(tenant_id, skill_id)
 );
 CREATE TABLE IF NOT EXISTS skill_search_index (

--- a/packages/api/src/__tests__/captured-review-service.test.ts
+++ b/packages/api/src/__tests__/captured-review-service.test.ts
@@ -40,6 +40,7 @@ CREATE TABLE IF NOT EXISTS skill_registry (
   current_version INTEGER DEFAULT 1, created_by TEXT NOT NULL,
   updated_by TEXT, created_at TEXT DEFAULT (datetime('now')),
   updated_at TEXT DEFAULT (datetime('now')), deleted_at TEXT,
+  skill_md_content TEXT, skill_md_generated_at TEXT,
   UNIQUE(tenant_id, skill_id)
 );
 CREATE TABLE IF NOT EXISTS skill_lineage (
@@ -106,9 +107,14 @@ describe("CapturedReviewService (F277)", () => {
     const skill = await db
       .prepare("SELECT * FROM skill_registry WHERE tenant_id = ? AND skill_id LIKE 'captured_%'")
       .bind(TENANT)
-      .first<{ skill_id: string; source_type: string }>();
+      .first<{ skill_id: string; source_type: string; skill_md_content: string | null; skill_md_generated_at: string | null }>();
     expect(skill).not.toBeNull();
     expect(skill!.source_type).toBe("captured");
+
+    // F306: SKILL.md 자동 생성 확인
+    expect(skill!.skill_md_content).not.toBeNull();
+    expect(skill!.skill_md_content).toContain("Test Captured Skill");
+    expect(skill!.skill_md_generated_at).not.toBeNull();
   });
 
   it("approves candidate → records lineage with derivation_type='captured'", async () => {

--- a/packages/api/src/__tests__/derived-engine-routes.test.ts
+++ b/packages/api/src/__tests__/derived-engine-routes.test.ts
@@ -68,6 +68,7 @@ CREATE TABLE IF NOT EXISTS skill_registry (
   current_version INTEGER DEFAULT 1, created_by TEXT NOT NULL,
   updated_by TEXT, created_at TEXT DEFAULT (datetime('now')),
   updated_at TEXT DEFAULT (datetime('now')), deleted_at TEXT,
+  skill_md_content TEXT, skill_md_generated_at TEXT,
   UNIQUE(tenant_id, skill_id)
 );
 CREATE TABLE IF NOT EXISTS skill_search_index (

--- a/packages/api/src/__tests__/derived-review-service.test.ts
+++ b/packages/api/src/__tests__/derived-review-service.test.ts
@@ -59,6 +59,7 @@ CREATE TABLE IF NOT EXISTS skill_registry (
   current_version INTEGER DEFAULT 1, created_by TEXT NOT NULL,
   updated_by TEXT, created_at TEXT DEFAULT (datetime('now')),
   updated_at TEXT DEFAULT (datetime('now')), deleted_at TEXT,
+  skill_md_content TEXT, skill_md_generated_at TEXT,
   UNIQUE(tenant_id, skill_id)
 );
 CREATE TABLE IF NOT EXISTS skill_lineage (
@@ -120,9 +121,14 @@ describe("DerivedReviewService (F276)", () => {
     const skill = await db
       .prepare("SELECT * FROM skill_registry WHERE tenant_id = ? AND skill_id LIKE 'derived_%'")
       .bind(TENANT)
-      .first<{ skill_id: string; source_type: string }>();
+      .first<{ skill_id: string; source_type: string; skill_md_content: string | null; skill_md_generated_at: string | null }>();
     expect(skill).not.toBeNull();
     expect(skill!.source_type).toBe("derived");
+
+    // F306: SKILL.md 자동 생성 확인
+    expect(skill!.skill_md_content).not.toBeNull();
+    expect(skill!.skill_md_content).toContain("Test Derived Skill");
+    expect(skill!.skill_md_generated_at).not.toBeNull();
   });
 
   it("approves candidate → records lineage", async () => {

--- a/packages/api/src/__tests__/skill-deploy.test.ts
+++ b/packages/api/src/__tests__/skill-deploy.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { app } from "../app.js";
+import { createTestEnv, createAuthHeaders } from "./helpers/test-app.js";
+
+const TABLES = `
+CREATE TABLE IF NOT EXISTS skill_registry (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  skill_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  description TEXT,
+  category TEXT NOT NULL DEFAULT 'general',
+  tags TEXT,
+  status TEXT NOT NULL DEFAULT 'active',
+  safety_grade TEXT DEFAULT 'pending',
+  safety_score INTEGER DEFAULT 0,
+  safety_checked_at TEXT,
+  source_type TEXT NOT NULL DEFAULT 'marketplace',
+  source_ref TEXT,
+  prompt_template TEXT,
+  model_preference TEXT,
+  max_tokens INTEGER DEFAULT 4096,
+  token_cost_avg REAL DEFAULT 0,
+  success_rate REAL DEFAULT 0,
+  total_executions INTEGER DEFAULT 0,
+  current_version INTEGER DEFAULT 1,
+  created_by TEXT NOT NULL,
+  updated_by TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  deleted_at TEXT,
+  skill_md_content TEXT,
+  skill_md_generated_at TEXT,
+  UNIQUE(tenant_id, skill_id)
+);
+CREATE TABLE IF NOT EXISTS skill_search_index (
+  id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, skill_id TEXT NOT NULL,
+  token TEXT NOT NULL, weight REAL NOT NULL DEFAULT 1.0,
+  field TEXT NOT NULL DEFAULT 'name',
+  UNIQUE(tenant_id, skill_id, token, field)
+);
+`;
+
+function seedSkill(env: ReturnType<typeof createTestEnv>) {
+  (env.DB as any).exec(`
+    INSERT INTO skill_registry (id, tenant_id, skill_id, name, description, category, tags, source_type, prompt_template, created_by)
+    VALUES ('sr_1', 'org_test', 'derived_abc', 'Cost Analysis', 'Analyzes costs', 'analysis', '["cost","finance"]', 'derived', 'Analyze cost for {{target}}', 'test-user')
+  `);
+}
+
+describe("POST /api/skills/registry/:skillId/deploy (F306)", () => {
+  let env: ReturnType<typeof createTestEnv>;
+  let headers: Record<string, string>;
+
+  beforeEach(async () => {
+    env = createTestEnv();
+    (env.DB as any).exec(TABLES);
+    seedSkill(env);
+    headers = await createAuthHeaders();
+  });
+
+  it("preview 모드 — SKILL.md 텍스트 반환", async () => {
+    const res = await app.request(
+      "/api/skills/registry/derived_abc/deploy",
+      {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({ format: "preview" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as any;
+    expect(data.skillId).toBe("derived_abc");
+    expect(data.skillMd).toContain('name: "Cost Analysis"');
+    expect(data.skillMd).toContain("## Steps");
+    expect(data.skillMd).toContain("Analyze cost for {{target}}");
+    expect(data.fileName).toBe("derived_abc/SKILL.md");
+    expect(data.generatedAt).toBeDefined();
+  });
+
+  it("download 모드 — text/markdown Content-Type", async () => {
+    const res = await app.request(
+      "/api/skills/registry/derived_abc/deploy",
+      {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({ format: "download" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("text/markdown");
+    expect(res.headers.get("Content-Disposition")).toContain("SKILL.md");
+    const text = await res.text();
+    expect(text).toContain("# Cost Analysis");
+  });
+
+  it("존재하지 않는 skillId — 404", async () => {
+    const res = await app.request(
+      "/api/skills/registry/nonexistent/deploy",
+      {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      },
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("비admin — 403", async () => {
+    // member user 등록 (org_members에 member role)
+    (env.DB as any).exec(
+      "INSERT OR IGNORE INTO org_members (org_id, user_id, role) VALUES ('org_test', 'member-user', 'member')"
+    );
+    const memberHeaders = await createAuthHeaders({ sub: "member-user", orgRole: "member" });
+    const res = await app.request(
+      "/api/skills/registry/derived_abc/deploy",
+      {
+        method: "POST",
+        headers: { ...memberHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      },
+      env,
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("D1에 skill_md_content 캐시 저장", async () => {
+    await app.request(
+      "/api/skills/registry/derived_abc/deploy",
+      {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      },
+      env,
+    );
+
+    const row = await env.DB.prepare(
+      "SELECT skill_md_content, skill_md_generated_at FROM skill_registry WHERE skill_id = ?"
+    ).bind("derived_abc").first<{ skill_md_content: string; skill_md_generated_at: string }>();
+
+    expect(row?.skill_md_content).toContain("Cost Analysis");
+    expect(row?.skill_md_generated_at).toBeDefined();
+  });
+});

--- a/packages/api/src/__tests__/skill-md-generator.test.ts
+++ b/packages/api/src/__tests__/skill-md-generator.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { SkillMdGeneratorService } from "../services/skill-md-generator.js";
+
+describe("SkillMdGeneratorService (F306)", () => {
+  const svc = new SkillMdGeneratorService();
+
+  it("기본 SKILL.md 생성 — frontmatter + body", () => {
+    const md = svc.generate({
+      skillId: "derived_abc",
+      name: "Cost Analysis",
+      description: "Analyzes project costs",
+      category: "analysis",
+      tags: ["cost", "finance"],
+      sourceType: "derived",
+    });
+
+    expect(md).toContain("---");
+    expect(md).toContain('name: "Cost Analysis"');
+    expect(md).toContain('category: "analysis"');
+    expect(md).toContain('source: "derived"');
+    expect(md).toContain('tags: ["cost", "finance"]');
+    expect(md).toContain('version: "1.0"');
+    expect(md).toContain("# Cost Analysis");
+    expect(md).toContain("Analyzes project costs");
+    expect(md).toContain("## Gotchas");
+    expect(md).toContain("derived 소스에서 자동 생성");
+  });
+
+  it("promptTemplate 포함 시 실행 프롬프트 섹션 생성", () => {
+    const md = svc.generate({
+      skillId: "derived_xyz",
+      name: "Quick Audit",
+      description: "Fast audit skill",
+      category: "validation",
+      tags: [],
+      sourceType: "derived",
+      promptTemplate: "Run audit on {{target}}",
+    });
+
+    expect(md).toContain("## Steps");
+    expect(md).toContain("### 실행 프롬프트");
+    expect(md).toContain("Run audit on {{target}}");
+  });
+
+  it("promptTemplate 없으면 Steps 섹션 없음", () => {
+    const md = svc.generate({
+      skillId: "captured_1",
+      name: "Workflow Skill",
+      description: "A captured workflow",
+      category: "general",
+      tags: ["workflow"],
+      sourceType: "captured",
+    });
+
+    expect(md).not.toContain("## Steps");
+    expect(md).not.toContain("### 실행 프롬프트");
+  });
+
+  it("빈 tags 배열 처리", () => {
+    const md = svc.generate({
+      skillId: "test_1",
+      name: "Empty Tags",
+      description: "No tags",
+      category: "general",
+      tags: [],
+      sourceType: "custom",
+    });
+
+    expect(md).toContain("tags: []");
+  });
+
+  it("version 지정 시 반영", () => {
+    const md = svc.generate({
+      skillId: "test_v3",
+      name: "Versioned Skill",
+      description: "Has version",
+      category: "bd-process",
+      tags: ["bd"],
+      sourceType: "derived",
+      version: 3,
+    });
+
+    expect(md).toContain('version: "3.0"');
+    expect(md).toContain("생성 버전: v3");
+  });
+
+  it("description에 쌍따옴표 포함 시 이스케이프", () => {
+    const md = svc.generate({
+      skillId: "test_esc",
+      name: 'Skill "Alpha"',
+      description: 'Uses "special" chars',
+      category: "general",
+      tags: [],
+      sourceType: "derived",
+    });
+
+    expect(md).toContain('name: "Skill \\"Alpha\\""');
+    expect(md).toContain('description: "Uses \\"special\\" chars"');
+  });
+});

--- a/packages/api/src/db/migrations/0089_skill_md_content.sql
+++ b/packages/api/src/db/migrations/0089_skill_md_content.sql
@@ -1,0 +1,3 @@
+-- F306: SKILL.md 콘텐츠 저장 컬럼
+ALTER TABLE skill_registry ADD COLUMN skill_md_content TEXT;
+ALTER TABLE skill_registry ADD COLUMN skill_md_generated_at TEXT;

--- a/packages/api/src/routes/skill-registry.ts
+++ b/packages/api/src/routes/skill-registry.ts
@@ -9,7 +9,9 @@ import {
   listSkillsQuerySchema,
   searchSkillsSchema,
   bulkRegisterSkillSchema,
+  deploySkillSchema,
 } from "../schemas/skill-registry.js";
+import { SkillMdGeneratorService } from "../services/skill-md-generator.js";
 
 export const skillRegistryRoute = new Hono<{
   Bindings: Env;
@@ -105,6 +107,60 @@ skillRegistryRoute.delete("/skills/registry/:skillId", async (c) => {
   const svc = new SkillRegistryService(c.env.DB);
   await svc.softDelete(c.get("orgId"), skillId, c.get("userId"));
   return c.json({ deleted: true });
+});
+
+// POST /skills/registry/:skillId/deploy — SKILL.md 생성 (F306, admin only)
+skillRegistryRoute.post("/skills/registry/:skillId/deploy", async (c) => {
+  const role = c.get("orgRole") as string;
+  if (role !== "admin" && role !== "owner") {
+    return c.json({ error: "Admin access required" }, 403);
+  }
+
+  const skillId = c.req.param("skillId");
+  const body = await c.req.json().catch(() => ({}));
+  const parsed = deploySkillSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid input", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new SkillRegistryService(c.env.DB);
+  const entry = await svc.getById(c.get("orgId"), skillId);
+  if (!entry) {
+    return c.json({ error: "Skill not found" }, 404);
+  }
+
+  const mdGenerator = new SkillMdGeneratorService();
+  const skillMd = mdGenerator.generate({
+    skillId: entry.skillId,
+    name: entry.name,
+    description: entry.description ?? "",
+    category: entry.category,
+    tags: entry.tags,
+    sourceType: entry.sourceType,
+    promptTemplate: entry.promptTemplate ?? undefined,
+    version: entry.currentVersion,
+  });
+
+  // D1에 SKILL.md 캐시 저장
+  await c.env.DB.prepare(
+    "UPDATE skill_registry SET skill_md_content = ?, skill_md_generated_at = datetime('now') WHERE tenant_id = ? AND skill_id = ?"
+  ).bind(skillMd, c.get("orgId"), skillId).run();
+
+  if (parsed.data.format === "download") {
+    return new Response(skillMd, {
+      headers: {
+        "Content-Type": "text/markdown",
+        "Content-Disposition": `attachment; filename="SKILL.md"`,
+      },
+    });
+  }
+
+  return c.json({
+    skillId,
+    skillMd,
+    fileName: `${skillId}/SKILL.md`,
+    generatedAt: new Date().toISOString(),
+  });
 });
 
 // POST /skills/registry/:skillId/safety-check — 안전성 검사

--- a/packages/api/src/schemas/skill-registry.ts
+++ b/packages/api/src/schemas/skill-registry.ts
@@ -66,4 +66,9 @@ export type RegisterSkillInput = z.infer<typeof registerSkillSchema>;
 export type UpdateSkillInput = z.infer<typeof updateSkillSchema>;
 export type ListSkillsQuery = z.infer<typeof listSkillsQuerySchema>;
 export type SearchSkillsQuery = z.infer<typeof searchSkillsSchema>;
+export const deploySkillSchema = z.object({
+  format: z.enum(["preview", "download"]).optional().default("preview"),
+});
+
 export type BulkRegisterSkillInput = z.infer<typeof bulkRegisterSkillSchema>;
+export type DeploySkillInput = z.infer<typeof deploySkillSchema>;

--- a/packages/api/src/services/captured-review.ts
+++ b/packages/api/src/services/captured-review.ts
@@ -8,6 +8,7 @@ import type {
 } from "@foundry-x/shared";
 import type { ReviewCapturedCandidateInput } from "../schemas/captured-engine.js";
 import { SafetyChecker } from "./safety-checker.js";
+import { SkillMdGeneratorService } from "./skill-md-generator.js";
 
 export class CapturedReviewService {
   constructor(private db: D1Database) {}
@@ -132,6 +133,28 @@ export class CapturedReviewService {
     await this.db
       .prepare("UPDATE captured_workflow_patterns SET status = 'consumed' WHERE id = ?")
       .bind(candidate.pattern_id)
+      .run();
+
+    // 6. F306: SKILL.md 자동 생성
+    const parsedTags: string[] = parseJson(candidate.source_skills, [])
+      .map((s: { skillId: string }) => s.skillId);
+    const mdGenerator = new SkillMdGeneratorService();
+    const skillMd = mdGenerator.generate({
+      skillId: newSkillId,
+      name: candidate.name,
+      description: candidate.description ?? "",
+      category: candidate.category,
+      tags: parsedTags,
+      sourceType: "captured",
+      promptTemplate: promptTemplate,
+      version: 1,
+    });
+
+    await this.db
+      .prepare(
+        "UPDATE skill_registry SET skill_md_content = ?, skill_md_generated_at = datetime('now') WHERE tenant_id = ? AND skill_id = ?"
+      )
+      .bind(skillMd, tenantId, newSkillId)
       .run();
   }
 

--- a/packages/api/src/services/derived-review.ts
+++ b/packages/api/src/services/derived-review.ts
@@ -9,6 +9,7 @@ import type {
 } from "@foundry-x/shared";
 import type { ReviewCandidateInput } from "../schemas/derived-engine.js";
 import { SafetyChecker } from "./safety-checker.js";
+import { SkillMdGeneratorService } from "./skill-md-generator.js";
 
 export class DerivedReviewService {
   constructor(private db: D1Database) {}
@@ -136,6 +137,28 @@ export class DerivedReviewService {
     await this.db
       .prepare("UPDATE derived_patterns SET status = 'consumed' WHERE id = ?")
       .bind(candidate.pattern_id)
+      .run();
+
+    // 6. F306: SKILL.md 자동 생성
+    const parsedTags: string[] = parseJson(candidate.source_skills, [])
+      .map((s: { skillId: string }) => s.skillId);
+    const mdGenerator = new SkillMdGeneratorService();
+    const skillMd = mdGenerator.generate({
+      skillId: newSkillId,
+      name: candidate.name,
+      description: candidate.description ?? "",
+      category: candidate.category,
+      tags: parsedTags,
+      sourceType: "derived",
+      promptTemplate: promptTemplate,
+      version: 1,
+    });
+
+    await this.db
+      .prepare(
+        "UPDATE skill_registry SET skill_md_content = ?, skill_md_generated_at = datetime('now') WHERE tenant_id = ? AND skill_id = ?"
+      )
+      .bind(skillMd, tenantId, newSkillId)
       .run();
   }
 

--- a/packages/api/src/services/skill-md-generator.ts
+++ b/packages/api/src/services/skill-md-generator.ts
@@ -1,0 +1,65 @@
+/**
+ * F306: SkillMdGeneratorService — 승인된 스킬을 SKILL.md 포맷으로 렌더링
+ * ax-marketplace SKILL.md 포맷 호환 (YAML frontmatter + Markdown body)
+ */
+
+export interface SkillMdParams {
+  skillId: string;
+  name: string;
+  description: string;
+  category: string;
+  tags: string[];
+  sourceType: string;
+  promptTemplate?: string;
+  version?: number;
+}
+
+export class SkillMdGeneratorService {
+  generate(params: SkillMdParams): string {
+    const version = params.version ?? 1;
+    const tagsStr = params.tags.length > 0
+      ? params.tags.map((t) => `"${t}"`).join(", ")
+      : "";
+
+    const lines: string[] = [
+      "---",
+      `name: "${escapeFrontmatter(params.name)}"`,
+      `description: "${escapeFrontmatter(params.description)}"`,
+      `version: "${version}.0"`,
+      `category: "${params.category}"`,
+      `source: "${params.sourceType}"`,
+      `tags: [${tagsStr}]`,
+      "---",
+      "",
+      `# ${params.name}`,
+      "",
+      params.description,
+      "",
+    ];
+
+    if (params.promptTemplate) {
+      lines.push(
+        "## Steps",
+        "",
+        "### 실행 프롬프트",
+        "",
+        params.promptTemplate,
+        "",
+      );
+    }
+
+    lines.push(
+      "## Gotchas",
+      "",
+      `- 이 스킬은 ${params.sourceType} 소스에서 자동 생성되었어요.`,
+      `- 생성 버전: v${version}`,
+      "",
+    );
+
+    return lines.join("\n");
+  }
+}
+
+function escapeFrontmatter(value: string): string {
+  return value.replace(/"/g, '\\"');
+}


### PR DESCRIPTION
## Summary
- **F306**: D3 단절 해소 — 승인된 DERIVED/CAPTURED 후보가 SKILL.md를 자동 생성하여 CC에서 즉시 실행 가능
- D1 migration 0089: skill_md_content + skill_md_generated_at 컬럼
- SkillMdGeneratorService + Deploy API + 리뷰→생성 자동 연동
- 30 tests 통과 (신규 11 + 기존 연동 19)

## Changes
| 파일 | 동작 |
|------|------|
| `0089_skill_md_content.sql` | D1 마이그레이��� — 2컬럼 추가 |
| `skill-md-generator.ts` | SKILL.md 렌더링 서비스 |
| `skill-registry.ts` (route) | POST /:skillId/deploy 엔드포인트 |
| `skill-registry.ts` (schema) | deploySkillSchema 추가 |
| `derived-review.ts` | 승인 시 SKILL.md 자동 생성 |
| `captured-review.ts` | 승인 시 SKILL.md 자동 생성 |
| 6 test files | 스키마 업데이트 + 새 테스트 |

## Match Rate
100% (9/9 Design 항목 구현 완료)

## Test plan
- [x] skill-md-generator: 6 tests (기본생성, promptTemplate, tags, version, escape)
- [x] skill-deploy: 5 tests (preview, download, 404, 403, D1 캐시)
- [x] derived-review: approve → skill_md_content 생성 확인
- [x] captured-review: approve → skill_md_content 생성 확인
- [x] typecheck 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)