### PR TITLE
feat: Sprint 131 F311 — TinaCMS 인라인 에디팅 본구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,6 +108,7 @@ jobs:
       - run: pnpm --filter @foundry-x/web build
         env:
           VITE_MARKER_PROJECT_ID: ${{ secrets.VITE_MARKER_PROJECT_ID }}
+          VITE_TINA_CLIENT_ID: ${{ secrets.VITE_TINA_CLIENT_ID }}
       - uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/docs/03-analysis/features/sprint-131-tinacms-impl.analysis.md
+++ b/docs/03-analysis/features/sprint-131-tinacms-impl.analysis.md
@@ -1,0 +1,53 @@
+---
+code: FX-ANLS-S131
+title: "Sprint 131 — F311 TinaCMS 인라인 에디팅 본구현 Gap Analysis"
+version: "1.0"
+status: Active
+category: ANLS
+created: 2026-04-04
+updated: 2026-04-04
+author: Claude Opus 4.6
+sprint: 131
+f_items: [F311]
+---
+
+# FX-ANLS-S131 — Sprint 131 Gap Analysis
+
+## Executive Summary
+
+| 항목 | 내용 |
+|------|------|
+| Feature | F311 TinaCMS 인라인 에디팅 본구현 |
+| Sprint | 131 |
+| Match Rate | **100%** (10/10 PASS) |
+| 검증 일시 | 2026-04-04 |
+
+## 검증 결과
+
+| # | 항목 | Design 기준 | 구현 상태 | 결과 |
+|---|------|------------|----------|:----:|
+| G1 | tina/config.ts | landing+wiki 2 collections | ✅ 2 collections 정의 | PASS |
+| G2 | content/landing/hero.md | TinaCMS UI 편집 가능 콘텐츠 | ✅ frontmatter + body 존재 | PASS |
+| G3 | content/wiki/intro.md | TinaCMS UI 편집 가능 콘텐츠 | ✅ frontmatter + body 존재 | PASS |
+| G4 | content/sample/ | PoC 파일 삭제 | ✅ 삭제됨 | PASS |
+| G5 | landing.tsx fallback | TinaCMS 미기동 시 기존 렌더링 유지 | ✅ SITE_META_FALLBACK + null-coalescing | PASS |
+| G6 | _redirects | /admin 규칙 /* 보다 앞에 | ✅ /admin 2규칙이 최상단 | PASS |
+| G7 | deploy.yml | VITE_TINA_CLIENT_ID env | ✅ secrets 참조 추가 | PASS |
+| G8 | typecheck | 에러 0건 | ✅ tsc --noEmit 통과 | PASS |
+| G9 | build | 성공 | ✅ Vite 빌드 704ms, landing 26.58kB | PASS |
+| G10 | E2E | 전체 통과 (회귀 0건) | ✅ 170 passed / 4 failed(기존) / 5 skipped | PASS |
+
+## 추가 검증
+
+- **번들 영향**: landing chunk 26.58kB — TinaCMS 런타임이 메인 번들에 포함되지 않음 (admin은 별도 static)
+- **Vite ?raw import**: hero.md가 빌드타임에 문자열로 인라인됨 — 런타임 fetch 없음
+- **E2E 비교**: baseline 169 passed → 170 passed (회귀 0, 개선 +1)
+
+## 수동 작업 (Sprint 후)
+
+| # | 작업 | 설명 |
+|---|------|------|
+| 1 | TinaCloud 가입 | tina.io — ktds.axbd@gmail.com (Free Plan) |
+| 2 | GitHub App 설치 | KTDS-AXBD/Foundry-X 권한 부여 |
+| 3 | GitHub Secrets 등록 | VITE_TINA_CLIENT_ID, TINA_TOKEN |
+| 4 | Editor 초대 | 비개발자 이메일 → Editor 권한 |

--- a/docs/04-report/features/sprint-131-tinacms-impl.report.md
+++ b/docs/04-report/features/sprint-131-tinacms-impl.report.md
@@ -1,0 +1,98 @@
+---
+code: FX-RPRT-S131
+title: "Sprint 131 — F311 TinaCMS 인라인 에디팅 본구현 완료 보고서"
+version: "1.0"
+status: Active
+category: RPRT
+created: 2026-04-04
+updated: 2026-04-04
+author: Claude Opus 4.6
+sprint: 131
+f_items: [F311]
+---
+
+# FX-RPRT-S131 — Sprint 131 완료 보고서
+
+## Executive Summary
+
+| 항목 | 내용 |
+|------|------|
+| Feature | F311 TinaCMS 인라인 에디팅 본구현 |
+| Sprint | 131 |
+| 기간 | 2026-04-04 (1회 autopilot) |
+| Match Rate | **100%** (10/10 PASS) |
+
+### Results
+
+| 지표 | 값 |
+|------|-----|
+| Match Rate | 100% |
+| 검증 항목 | 10건 |
+| 변경 파일 | 7건 (수정 4 + 신규 3) |
+| 삭제 파일 | 1건 (PoC content/sample/) |
+
+### Value Delivered
+
+| 관점 | 내용 |
+|------|------|
+| Problem | 콘텐츠 수정이 개발자를 경유해야 함 |
+| Solution | TinaCMS 인라인 에디팅으로 브라우저에서 직접 수정 → GitHub PR 자동 생성 |
+| Function UX Effect | /admin에서 WYSIWYG 편집, 빌드타임 콘텐츠 로드 + fallback |
+| Core Value | 콘텐츠 관리 자율성 — 비개발자 병목 제거 |
+
+## 변경 사항
+
+### 신규 파일
+
+| 파일 | 용도 |
+|------|------|
+| `packages/web/content/landing/hero.md` | Landing Hero 콘텐츠 (tagline, phase, stats) |
+| `packages/web/content/wiki/intro.md` | Wiki 소개 콘텐츠 |
+| `packages/web/src/lib/content-loader.ts` | Markdown frontmatter 파서 유틸리티 |
+| `packages/web/src/vite-env.d.ts` | Vite ?raw import 타입 선언 |
+
+### 수정 파일
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `packages/web/tina/config.ts` | sample → landing+wiki 2 collections |
+| `packages/web/src/routes/landing.tsx` | SITE_META/stats를 hero.md에서 로드 + fallback |
+| `packages/web/public/_redirects` | /admin 리다이렉트 규칙 추가 |
+| `.github/workflows/deploy.yml` | VITE_TINA_CLIENT_ID secret env 주입 |
+
+### 삭제 파일
+
+| 파일 | 사유 |
+|------|------|
+| `packages/web/content/sample/hello.md` | PoC 샘플 정리 |
+
+## 기술 결정
+
+### Vite ?raw + parseFrontmatter vs TinaCMS Generated Client
+
+TinaCMS의 `__generated__/client`는 `npx tinacms build` 후에만 존재. TinaCloud 미설정 상태에서도 동작해야 하므로, Vite의 `?raw` import + 자체 frontmatter 파서로 **빌드타임 콘텐츠 로드**를 구현. TinaCloud 설정 후에도 이 패턴은 fallback으로 유지.
+
+### Fallback 패턴
+
+```tsx
+const SITE_META = {
+  phase: heroContent.data.phase ?? SITE_META_FALLBACK.phase,
+  // ...
+};
+```
+
+TinaCMS 콘텐츠 파싱 실패 시 기존 하드코딩 값으로 자동 fallback. 프로덕션 안정성 보장.
+
+## 검증 결과
+
+- **typecheck**: 에러 0건
+- **build**: 704ms, landing chunk 26.58kB (메인 번들 미영향)
+- **E2E**: 170 passed / 4 failed(기존) / 5 skipped — 회귀 0건
+
+## 수동 후속 작업
+
+1. TinaCloud 가입 (tina.io, Free Plan)
+2. GitHub App 설치 (KTDS-AXBD/Foundry-X)
+3. GitHub Secrets: VITE_TINA_CLIENT_ID, TINA_TOKEN
+4. Editor 초대 (비개발자 이메일)
+5. `gh workflow run deploy.yml` (수동 배포 트리거)

--- a/packages/web/content/landing/hero.md
+++ b/packages/web/content/landing/hero.md
@@ -1,0 +1,21 @@
+---
+title: "Foundry-X Hero"
+section: "hero"
+tagline: "AX 사업개발 AI 오케스트레이션 플랫폼"
+phase: "Phase 5f 완료"
+phaseTitle: "AX BD 사업개발 체계 수립"
+stats:
+  - value: "304"
+    label: "API Endpoints"
+  - value: "135"
+    label: "Services"
+  - value: "2,032+"
+    label: "Tests"
+  - value: "60"
+    label: "D1 Migrations"
+  - value: "71"
+    label: "Sprints"
+---
+
+AI 에이전트와 사람이 함께 만드는 조직 협업 플랫폼.
+Git이 진실, Foundry-X는 렌즈.

--- a/packages/web/content/sample/hello.md
+++ b/packages/web/content/sample/hello.md
@@ -1,5 +1,0 @@
----
-title: "PoC Test"
----
-
-TinaCMS 호환성 PoC 테스트 콘텐츠.

--- a/packages/web/content/wiki/intro.md
+++ b/packages/web/content/wiki/intro.md
@@ -1,0 +1,6 @@
+---
+title: "Foundry-X 소개"
+category: "getting-started"
+---
+
+Foundry-X는 AX 사업개발 업무의 전체 라이프사이클을 AI 에이전트로 자동화하는 오케스트레이션 플랫폼이에요.

--- a/packages/web/public/_redirects
+++ b/packages/web/public/_redirects
@@ -1,2 +1,4 @@
+/admin    /admin/index.html  200
+/admin/*  /admin/index.html  200
 /api/*  https://foundry-x-api.ktds-axbd.workers.dev/api/:splat  200
 /*      /index.html   200

--- a/packages/web/src/lib/content-loader.ts
+++ b/packages/web/src/lib/content-loader.ts
@@ -1,0 +1,81 @@
+/**
+ * Build-time content loader for TinaCMS-managed Markdown files.
+ * Parses YAML frontmatter from raw Markdown strings (imported via Vite ?raw).
+ * Falls back gracefully if parsing fails.
+ */
+
+/** Parse YAML frontmatter from a raw Markdown string. */
+export function parseFrontmatter<T>(
+  raw: string,
+): { data: Partial<T>; body: string } {
+  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
+  if (!match) return { data: {} as Partial<T>, body: raw.trim() };
+
+  const [, frontmatterStr, body] = match;
+  const data: Record<string, unknown> = {};
+
+  // Simple YAML parser — handles scalars, simple lists, and list-of-objects
+  let currentKey = "";
+  let currentList: Record<string, string>[] | null = null;
+  let currentObj: Record<string, string> | null = null;
+
+  for (const line of frontmatterStr.split("\n")) {
+    const trimmed = line.trimEnd();
+
+    // List-of-objects: "  - key: value" (start new object)
+    const listObjMatch = trimmed.match(/^\s{2}- (\w+):\s*"?(.*?)"?\s*$/);
+    if (listObjMatch && currentList !== null) {
+      if (currentObj) currentList.push(currentObj);
+      currentObj = { [listObjMatch[1]]: listObjMatch[2] };
+      continue;
+    }
+
+    // List-of-objects continuation: "    key: value"
+    const contMatch = trimmed.match(/^\s{4}(\w+):\s*"?(.*?)"?\s*$/);
+    if (contMatch && currentObj !== null) {
+      currentObj[contMatch[1]] = contMatch[2];
+      continue;
+    }
+
+    // Flush pending list object
+    if (currentObj && currentList) {
+      currentList.push(currentObj);
+      currentObj = null;
+    }
+
+    // Flush pending list
+    if (currentList && currentKey) {
+      data[currentKey] = currentList;
+      currentList = null;
+    }
+
+    // Top-level "key: value"
+    const kvMatch = trimmed.match(/^(\w+):\s*"?(.*?)"?\s*$/);
+    if (kvMatch) {
+      currentKey = kvMatch[1];
+      if (kvMatch[2] === "") {
+        // Could be start of a list
+        currentList = [];
+        currentObj = null;
+      } else {
+        data[currentKey] = kvMatch[2];
+      }
+    }
+  }
+
+  // Flush remaining
+  if (currentObj && currentList) currentList.push(currentObj);
+  if (currentList && currentKey) data[currentKey] = currentList;
+
+  return { data: data as Partial<T>, body: body.trim() };
+}
+
+/** Landing hero content shape */
+export interface HeroContent {
+  title: string;
+  section: string;
+  tagline: string;
+  phase: string;
+  phaseTitle: string;
+  stats: Array<{ value: string; label: string }>;
+}

--- a/packages/web/src/routes/landing.tsx
+++ b/packages/web/src/routes/landing.tsx
@@ -24,25 +24,42 @@ import {
   TestTube,
   Timer,
 } from "lucide-react";
+import { parseFrontmatter, type HeroContent } from "@/lib/content-loader";
+import heroRaw from "../../content/landing/hero.md?raw";
 
 /* ═══════════════════════════════════════════════
-   DATA — PRD v8 기반
+   DATA — PRD v8 기반 (TinaCMS content with fallback)
    ═══════════════════════════════════════════════ */
 
-const SITE_META = {
+const SITE_META_FALLBACK = {
   sprint: "Sprint 71",
   phase: "Phase 5f 완료",
   phaseTitle: "AX BD 사업개발 체계 수립",
   tagline: "AX 사업개발 AI 오케스트레이션 플랫폼",
 } as const;
 
-const stats = [
+const STATS_FALLBACK = [
   { value: "304", label: "API Endpoints" },
   { value: "135", label: "Services" },
   { value: "2,032+", label: "Tests" },
   { value: "60", label: "D1 Migrations" },
   { value: "71", label: "Sprints" },
 ];
+
+// Build-time content from TinaCMS-managed Markdown
+const heroContent = parseFrontmatter<HeroContent>(heroRaw);
+
+const SITE_META = {
+  sprint: SITE_META_FALLBACK.sprint,
+  phase: heroContent.data.phase ?? SITE_META_FALLBACK.phase,
+  phaseTitle: heroContent.data.phaseTitle ?? SITE_META_FALLBACK.phaseTitle,
+  tagline: heroContent.data.tagline ?? SITE_META_FALLBACK.tagline,
+} as const;
+
+const stats =
+  heroContent.data.stats && heroContent.data.stats.length > 0
+    ? heroContent.data.stats
+    : STATS_FALLBACK;
 
 const pillars = [
   {

--- a/packages/web/src/vite-env.d.ts
+++ b/packages/web/src/vite-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="vite/client" />
+
+declare module "*.md?raw" {
+  const content: string;
+  export default content;
+}

--- a/packages/web/tina/config.ts
+++ b/packages/web/tina/config.ts
@@ -11,9 +11,9 @@ export default defineConfig({
   schema: {
     collections: [
       {
-        name: "sample",
-        label: "Sample",
-        path: "content/sample",
+        name: "landing",
+        label: "Landing Pages",
+        path: "content/landing",
         format: "md",
         fields: [
           {
@@ -23,6 +23,42 @@ export default defineConfig({
             isTitle: true,
             required: true,
           },
+          { type: "string", name: "section", label: "Section" },
+          { type: "string", name: "tagline", label: "Tagline" },
+          { type: "string", name: "phase", label: "Current Phase" },
+          { type: "string", name: "phaseTitle", label: "Phase Title" },
+          {
+            type: "object",
+            name: "stats",
+            label: "Stats",
+            list: true,
+            fields: [
+              { type: "string", name: "value", label: "Value" },
+              { type: "string", name: "label", label: "Label" },
+            ],
+          },
+          {
+            type: "rich-text",
+            name: "body",
+            label: "Body",
+            isBody: true,
+          },
+        ],
+      },
+      {
+        name: "wiki",
+        label: "Wiki Pages",
+        path: "content/wiki",
+        format: "md",
+        fields: [
+          {
+            type: "string",
+            name: "title",
+            label: "Title",
+            isTitle: true,
+            required: true,
+          },
+          { type: "string", name: "category", label: "Category" },
           {
             type: "rich-text",
             name: "body",


### PR DESCRIPTION
## Summary
- TinaCMS 인라인 에디팅 본구현 (F310 PoC → 본구현)
- landing+wiki 2 collections, Vite ?raw import + fallback 패턴
- /admin 라우팅 + CI/CD 환경변수 주입

## Changes
- `tina/config.ts`: sample → landing+wiki 2 collections
- `content/landing/hero.md` + `content/wiki/intro.md`: TinaCMS 관리 콘텐츠
- `landing.tsx`: SITE_META/stats를 hero.md에서 빌드타임 로드 + fallback
- `_redirects`: /admin 규칙 추가
- `deploy.yml`: VITE_TINA_CLIENT_ID secret env
- `content-loader.ts`: Markdown frontmatter 파서 유틸
- `content/sample/`: PoC 정리 삭제

## Verification
- Match Rate: **100%** (10/10 PASS)
- typecheck: 0 errors
- build: 704ms
- E2E: 170 passed / 4 failed(기존) / 5 skipped — **회귀 0건**

## Post-merge Manual Steps
1. TinaCloud 가입 (tina.io, Free Plan)
2. GitHub App 설치 (KTDS-AXBD/Foundry-X)
3. GitHub Secrets: `VITE_TINA_CLIENT_ID`, `TINA_TOKEN`
4. Editor 초대 (비개발자)

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)