### PR TITLE
feat: Sprint 141 — F323 대시보드 ToDo + F324 발굴 탭 통합

### DIFF
--- a/packages/web/src/components/feature/TodoSection.tsx
+++ b/packages/web/src/components/feature/TodoSection.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+/**
+ * F323 — 대시보드 ToDo List
+ * 아이템별 현재 6단계 위치 + 다음 할 일 + 의사결정 대기
+ */
+import { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
+import { fetchApi } from "@/lib/api-client";
+import { STAGES } from "@/components/feature/ProcessStageGuide";
+import { cn } from "@/lib/utils";
+import {
+  AlertCircle,
+  ArrowRight,
+  CheckCircle2,
+  Circle,
+  Loader2,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+
+/* ------------------------------------------------------------------ */
+/*  Stage → nextAction 매핑                                            */
+/* ------------------------------------------------------------------ */
+
+const NEXT_ACTIONS: Record<number, { label: string; href: string }> = {
+  1: { label: "아이디어 등록", href: "/discovery" },
+  2: { label: "평가 실행", href: "/discovery?tab=process" },
+  3: { label: "사업기획서 작성", href: "/shaping/business-plan" },
+  4: { label: "검증 기록", href: "/validation" },
+  5: { label: "MVP/PoC 추적", href: "/product" },
+  6: { label: "선제안 작성", href: "/gtm/outreach" },
+};
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
+
+interface BizItemSummary {
+  bizItemId: string;
+  title: string;
+  currentStage: number;
+  pendingDecision?: boolean;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Stage Indicator                                                    */
+/* ------------------------------------------------------------------ */
+
+const stageColors = [
+  "bg-blue-500",
+  "bg-violet-500",
+  "bg-amber-500",
+  "bg-green-500",
+  "bg-indigo-500",
+  "bg-rose-500",
+];
+
+function StageIndicator({ current }: { current: number }) {
+  return (
+    <div className="flex items-center gap-1">
+      {STAGES.map((stage, i) => {
+        const stageNum = stage.stage;
+        const isCompleted = stageNum < current;
+        const isCurrent = stageNum === current;
+
+        return (
+          <div key={stageNum} className="flex items-center">
+            <div className="flex flex-col items-center">
+              <div
+                className={cn(
+                  "flex items-center justify-center rounded-full transition-all",
+                  isCurrent
+                    ? cn("size-7 text-white text-xs font-bold", stageColors[i])
+                    : isCompleted
+                      ? "size-5 bg-green-500 text-white"
+                      : "size-5 bg-muted text-muted-foreground",
+                )}
+              >
+                {isCompleted ? (
+                  <CheckCircle2 className="size-3" />
+                ) : isCurrent ? (
+                  stageNum
+                ) : (
+                  <Circle className="size-2.5" />
+                )}
+              </div>
+              {isCurrent && (
+                <span className="mt-0.5 text-[10px] font-medium text-muted-foreground">
+                  {stage.label}
+                </span>
+              )}
+            </div>
+            {i < STAGES.length - 1 && (
+              <div
+                className={cn(
+                  "mx-0.5 h-px w-3",
+                  stageNum < current ? "bg-green-500" : "bg-muted",
+                )}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  TodoSection                                                        */
+/* ------------------------------------------------------------------ */
+
+export function TodoSection() {
+  const [items, setItems] = useState<BizItemSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchApi<{ items: BizItemSummary[] }>("/biz-items/summary")
+      .then((data) => {
+        if (!cancelled) {
+          setItems(data.items ?? []);
+          setLoading(false);
+        }
+      })
+      .catch((err: Error) => {
+        if (!cancelled) {
+          setError(err.message);
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <div className="rounded-lg border bg-card p-5">
+      <h2 className="mb-4 text-sm font-semibold text-muted-foreground">
+        📋 ToDo List
+      </h2>
+
+      {loading && (
+        <div className="flex items-center justify-center py-8 text-muted-foreground">
+          <Loader2 className="mr-2 size-4 animate-spin" />
+          <span className="text-sm">불러오는 중...</span>
+        </div>
+      )}
+
+      {error && (
+        <div className="flex items-center gap-2 rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          <AlertCircle className="size-4 shrink-0" />
+          {error}
+        </div>
+      )}
+
+      {!loading && !error && items.length === 0 && (
+        <div className="py-8 text-center text-sm text-muted-foreground">
+          진행 중인 사업 아이템이 없어요.{" "}
+          <Link to="/collection/sr" className="text-primary underline">
+            SR 등록
+          </Link>
+          으로 시작해 보세요.
+        </div>
+      )}
+
+      {!loading && !error && items.length > 0 && (
+        <div className="space-y-3">
+          {items.map((item) => {
+            const next = NEXT_ACTIONS[item.currentStage] ?? NEXT_ACTIONS[1]!;
+            return (
+              <div
+                key={item.bizItemId}
+                className="flex items-center gap-4 rounded-lg border px-4 py-3 transition-colors hover:bg-muted/50"
+              >
+                {/* 아이템 제목 + 의사결정 뱃지 */}
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate text-sm font-medium">
+                      {item.title}
+                    </span>
+                    {item.pendingDecision && (
+                      <Badge variant="outline" className="shrink-0 border-amber-300 text-amber-600 text-[10px]">
+                        의사결정 대기
+                      </Badge>
+                    )}
+                  </div>
+                  <StageIndicator current={item.currentStage} />
+                </div>
+
+                {/* 다음 할 일 */}
+                <Link
+                  to={next.href}
+                  className="flex shrink-0 items-center gap-1 rounded-md bg-primary/10 px-3 py-1.5 text-xs font-medium text-primary transition-colors hover:bg-primary/20"
+                >
+                  {next.label}
+                  <ArrowRight className="size-3" />
+                </Link>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/feature/WorkGuideSection.tsx
+++ b/packages/web/src/components/feature/WorkGuideSection.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+/**
+ * F323 — 업무 가이드
+ * 검증 흐름 / 제품화 / 개발 파이프라인 / 오프라인 활동 안내
+ * 정적 콘텐츠 — API 호출 없음
+ */
+import { Link } from "react-router-dom";
+import { Accordion } from "@/components/ui/accordion";
+import type { AccordionItemData } from "@/components/ui/accordion";
+import {
+  CheckCircle,
+  Rocket,
+  GitBranch,
+  CalendarDays,
+  ArrowRight,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+/* ------------------------------------------------------------------ */
+/*  가이드 데이터                                                       */
+/* ------------------------------------------------------------------ */
+
+interface GuideItem {
+  id: string;
+  title: string;
+  description: string;
+  detail: string;
+  icon: LucideIcon;
+  href: string;
+}
+
+const GUIDES: GuideItem[] = [
+  {
+    id: "verification",
+    title: "4단계 검증 흐름",
+    description: "본부 → 전사 → Pre-PRB → 임원 보고 → 최종 의사결정",
+    detail:
+      "각 단계에서 사업성, 기술 타당성, 투자 규모를 검증해요. 본부 검증이 통과되면 전사 검증으로 자동 이관되며, Pre-PRB에서 비용 투자 심의를 거쳐 임원 보고까지 이어져요.",
+    icon: CheckCircle,
+    href: "/validation",
+  },
+  {
+    id: "product",
+    title: "5단계 제품화",
+    description: "MVP와 PoC 병렬 진행 → Offering Pack 패키징",
+    detail:
+      "MVP(최소 기능 제품)와 PoC(기술 검증)를 병렬로 진행할 수 있어요. 완성되면 Offering Pack으로 패키징하여 고객에게 제안해요.",
+    icon: Rocket,
+    href: "/product",
+  },
+  {
+    id: "pipeline",
+    title: "개발 파이프라인",
+    description: "PRD → 요구사항 인터뷰 → PDCA → Sprint → 배포",
+    detail:
+      "AI 에이전트가 PRD 초안을 자동 생성하고, 인터뷰를 통해 요구사항을 구체화해요. PDCA(Plan→Do→Check→Act) 사이클을 Sprint 단위로 반복하며 점진적으로 완성해요.",
+    icon: GitBranch,
+    href: "/shaping/prd",
+  },
+  {
+    id: "offline",
+    title: "오프라인 활동",
+    description: "전문가 인터뷰, 유관부서 미팅, 고객사 방문",
+    detail:
+      "온라인 분석만으로는 한계가 있어요. 도메인 전문가 인터뷰, 유관부서 협의, 고객사 현장 방문 일정을 관리하고 결과를 기록해요.",
+    icon: CalendarDays,
+    href: "/validation?tab=meetings",
+  },
+];
+
+/* ------------------------------------------------------------------ */
+/*  WorkGuideSection                                                   */
+/* ------------------------------------------------------------------ */
+
+export function WorkGuideSection() {
+  const items: AccordionItemData[] = GUIDES.map((guide) => ({
+    value: guide.id,
+    trigger: (
+      <div className="flex items-center gap-3">
+        <guide.icon className="size-4 shrink-0 text-primary" />
+        <div className="text-left">
+          <div className="font-medium">{guide.title}</div>
+          <div className="text-xs text-muted-foreground">
+            {guide.description}
+          </div>
+        </div>
+      </div>
+    ),
+    content: (
+      <div className="space-y-2 pl-7">
+        <p>{guide.detail}</p>
+        <Link
+          to={guide.href}
+          className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+        >
+          이동하기 <ArrowRight className="size-3" />
+        </Link>
+      </div>
+    ),
+  }));
+
+  return (
+    <div className="rounded-lg border bg-card p-5">
+      <h2 className="mb-4 text-sm font-semibold text-muted-foreground">
+        📖 업무 가이드
+      </h2>
+      <Accordion items={items} type="multiple" />
+    </div>
+  );
+}

--- a/packages/web/src/router.tsx
+++ b/packages/web/src/router.tsx
@@ -24,7 +24,7 @@ export const router = createBrowserRouter([
       { path: "ax-bd/demo", lazy: () => import("@/routes/ax-bd/demo-scenario") },
 
       // ── Phase 13 v1.3 신규 경로 ──
-      { path: "discovery", lazy: () => import("@/routes/ax-bd/discover-dashboard") },
+      { path: "discovery", lazy: () => import("@/routes/discovery-unified") },
       { path: "validation", lazy: () => import("@/routes/validation-division") },
       { path: "product", lazy: () => import("@/routes/mvp-tracking") },
       { path: "shaping/business-plan", lazy: () => import("@/routes/ax-bd/index") },

--- a/packages/web/src/routes/dashboard.tsx
+++ b/packages/web/src/routes/dashboard.tsx
@@ -21,6 +21,8 @@ import {
   GitBranch,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { TodoSection } from "@/components/feature/TodoSection";
+import { WorkGuideSection } from "@/components/feature/WorkGuideSection";
 
 /* ------------------------------------------------------------------ */
 /*  Hooks                                                              */
@@ -309,6 +311,12 @@ export function Component() {
           )}
         </DashboardCard>
       </div>
+
+      {/* F323: ToDo List + 업무 가이드 */}
+      <section className="mt-8 space-y-6">
+        <TodoSection />
+        <WorkGuideSection />
+      </section>
     </div>
   );
 }

--- a/packages/web/src/routes/discovery-unified.tsx
+++ b/packages/web/src/routes/discovery-unified.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+/**
+ * F324 — 발굴 통합 페이지
+ * 3탭: 대시보드 / 프로세스 / BMC
+ * URL: /discovery?tab=dashboard|process|bmc
+ */
+import { useSearchParams } from "react-router-dom";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { BarChart3, Map, Lightbulb } from "lucide-react";
+
+// 기존 라우트 컴포넌트를 탭 콘텐츠로 재사용
+import { Component as DiscoverDashboard } from "@/routes/ax-bd/discover-dashboard";
+import { Component as DiscoveryProcess } from "@/routes/ax-bd/discovery";
+import { Component as IdeasBmc } from "@/routes/ax-bd/ideas-bmc";
+
+export function Component() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tab = searchParams.get("tab") ?? "dashboard";
+
+  return (
+    <div className="space-y-6 p-6">
+      <div>
+        <h1 className="text-2xl font-bold">발굴</h1>
+        <p className="text-muted-foreground">
+          사업 아이템 발굴 · 분석 · 평가
+        </p>
+      </div>
+
+      <Tabs
+        value={tab}
+        onValueChange={(v) => setSearchParams({ tab: v }, { replace: true })}
+      >
+        <TabsList>
+          <TabsTrigger value="dashboard">
+            <BarChart3 className="mr-2 size-4" /> 대시보드
+          </TabsTrigger>
+          <TabsTrigger value="process">
+            <Map className="mr-2 size-4" /> 프로세스
+          </TabsTrigger>
+          <TabsTrigger value="bmc">
+            <Lightbulb className="mr-2 size-4" /> BMC
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="dashboard">
+          <DiscoverDashboard />
+        </TabsContent>
+
+        <TabsContent value="process">
+          <DiscoveryProcess />
+        </TabsContent>
+
+        <TabsContent value="bmc">
+          <IdeasBmc />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **F323**: 대시보드에 TodoSection (아이템별 6단계 Stage Indicator + nextAction 계산 + 의사결정 대기 뱃지) + WorkGuideSection (4개 업무 가이드 Accordion) 추가
- **F324**: `/discovery` → 3탭 통합 페이지(대시보드/프로세스/BMC) + URL searchParams 연동
- **Gap 100%** (V1~V10 전항 PASS)

## Changed Files (5)
| 파일 | 변경 |
|------|------|
| `TodoSection.tsx` | 신규 — Stage Indicator + nextAction |
| `WorkGuideSection.tsx` | 신규 — 4개 가이드 Accordion |
| `dashboard.tsx` | 수정 — 하단에 두 섹션 추가 |
| `discovery-unified.tsx` | 신규 — 3탭 래퍼 |
| `router.tsx` | 수정 — /discovery 라우트 교체 |

## Test plan
- [x] typecheck 통과
- [x] build 통과
- [ ] /dashboard 에서 TodoSection + WorkGuideSection 렌더 확인
- [ ] /discovery → 대시보드 탭 기본 랜딩
- [ ] /discovery?tab=process → 프로세스 탭
- [ ] /discovery?tab=bmc → BMC 탭

🤖 Generated with [Claude Code](https://claude.com/claude-code)