### PR TITLE
feat: Sprint 146 — F330 rules/ 5종 + F331 git guard

### DIFF
--- a/.claude/hooks/pre-bash-guard.sh
+++ b/.claude/hooks/pre-bash-guard.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# PreToolUse hook: git 위험 명령 차단
+# 차단 대상: --no-verify, git add ., git push --force, git reset --hard
+
+INPUT="$CLAUDE_TOOL_INPUT"
+
+# --no-verify 차단 (git commit, git push 등 어디에서든)
+if echo "$INPUT" | grep -qE -- '--no-verify'; then
+  echo "BLOCKED: --no-verify는 프로젝트 정책으로 차단됨 — hook 실패 시 원인을 해결하세요"
+  exit 2
+fi
+
+# git add . 차단 (git add 뒤에 . 또는 -A 또는 --all)
+if echo "$INPUT" | grep -qE 'git\s+add\s+(-A|--all|\.(\s|"|$))'; then
+  echo "BLOCKED: 'git add .'은 금지 — 파일을 개별 지정하세요 (멀티 pane 사고 방지)"
+  exit 2
+fi
+
+# git push --force 차단 (--force-with-lease 포함)
+if echo "$INPUT" | grep -qE 'git\s+push\s+.*--force'; then
+  echo "BLOCKED: force push는 프로젝트 정책으로 차단됨 — Linear history 보호"
+  exit 2
+fi
+
+# git reset --hard 차단
+if echo "$INPUT" | grep -qE 'git\s+reset\s+--hard'; then
+  echo "BLOCKED: git reset --hard는 프로젝트 정책으로 차단됨 — 데이터 손실 위험"
+  exit 2
+fi
+
+exit 0

--- a/.claude/rules/coding-style.md
+++ b/.claude/rules/coding-style.md
@@ -1,0 +1,22 @@
+# Foundry-X Coding Style
+
+## TypeScript 공통
+- 패키지 매니저: pnpm (npm/yarn 금지)
+- 빌드: Turborepo (`turbo build/test/lint/typecheck`)
+- Node.js 20, TypeScript strict mode
+
+## API (Hono + Cloudflare Workers)
+- 라우트: Zod 스키마 필수 — ESLint `require-zod-schema` 룰 적용
+- DB 접근: 서비스 레이어 경유 — ESLint `no-direct-db-in-route` 룰 적용
+- Plumb import: 패키지 내부만 — ESLint `no-orphan-plumb-import` 룰 적용
+- D1 바인딩: `env.DB`로 접근, raw SQL 대신 prepared statement 사용
+
+## Web (Vite 8 + React 18 + React Router 7)
+- 상태관리: Zustand (전역), useState (로컬)
+- 라우팅: React Router 7 파일 기반 (`src/routes/`)
+- 스타일: CSS Modules 또는 인라인 — Tailwind 미사용
+
+## CLI (Commander + Ink 5)
+- TUI: Ink 5 (React 18 기반), render.tsx 4-branch dispatcher
+- 컴포넌트: 순수 UI(components/) + 로직(views/) 분리
+- 출력: json/short/non-TTY/TTY 4가지 모드 지원

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,0 +1,17 @@
+# Foundry-X Git Workflow
+
+## Branch & Merge
+- Branch Protection: master에 직접 push 불가 — PR 필수 + 1명 Approve
+- Merge 전략: Squash merge + Linear history + Auto-delete branches
+- Remote: HTTPS + PAT 인증 (SSH 아님)
+
+## Sprint Worktree
+- WT 생성: `bash -i -c "sprint N"` 함수만 사용 (wt.exe/git worktree 직접 호출 금지)
+- WT에서 작업 → Master에서 `/ax:sprint merge N`으로 통합
+
+## 필수 금지 사항
+- `git add .` 절대 금지 — 파일을 개별 지정 (멀티 pane 사고 방지)
+- `git add -A` / `git add --all` 금지 — 동일 이유
+- `--no-verify` 금지 — hook 실패 시 원인 해결 후 재시도
+- `git push --force` 금지 — Linear history 파괴
+- 자동 커밋 절대 금지 — NL→Spec 변환 결과는 사람 확인 후 커밋

--- a/.claude/rules/sdd-triangle.md
+++ b/.claude/rules/sdd-triangle.md
@@ -1,0 +1,20 @@
+# Foundry-X SDD Triangle
+
+> Spec(명세) ↔ Code ↔ Test 상시 동기화 — Foundry-X 핵심 철학
+
+## SPEC.md = 권위 소스(SSOT)
+- SPEC.md가 권위 소스, MEMORY.md는 캐시 — 불일치 시 SPEC 기준 보정
+- 수치(routes/services/schemas/tests/D1) 하드코딩 금지 — `/ax:daily-check`가 실측
+
+## F-item 등록 선행 원칙
+- Plan/Design 작성 전 반드시 SPEC.md에 F-item + REQ코드 먼저 등록
+- SPEC 등록 → 커밋 → push → WT 생성 순서 (S149 교훈)
+
+## Gap Analysis
+- Design ↔ Implementation 일치율 90% 이상 목표
+- Gap < 90%: pdca-iterator 자동 개선
+- Gap ≥ 90%: 완료 보고서 작성
+
+## 동기화 주기
+- 5세션마다 1회 또는 수동 운영(벌크 승인, DB 직접 조작) 후 즉시 점검
+- 수치/상태/리스크/Phase 명칭/REQ 완전성 확인

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -1,0 +1,16 @@
+# Foundry-X Security Rules
+
+## 인증
+- JWT + PBKDF2 + RBAC + SSO Hub Token + Google OAuth
+- Secrets: `wrangler secret put`으로만 등록 — 코드에 하드코딩 절대 금지
+- 등록된 Secrets: JWT_SECRET, GITHUB_TOKEN, WEBHOOK_SECRET, ANTHROPIC_API_KEY, GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, OPENROUTER_API_KEY
+
+## CORS
+- Pages(fx.minu.best) → Workers(foundry-x-api) 크로스오리진
+- `packages/api/src/app.ts` CORS 미들웨어 필수
+- `VITE_API_URL`에 `/api` 경로 포함 필수 (빠뜨리면 404)
+
+## Cloudflare Workers
+- D1 migrations: CI/CD 자동 적용, 수동 시 `--remote` 필수 (누락 = 프로덕션 500)
+- 보호 파일: `.env`, `credentials`, `pnpm-lock.yaml` 편집 차단 (PreToolUse hook)
+- wrangler.toml에 `account_id` 명시 필수 (환경변수 의존 금지)

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,22 @@
+# Foundry-X Testing Rules
+
+## Runner & Framework
+- Runner: Vitest 3.x (`vitest.config.ts` per package)
+- TSX 지원: `.test.tsx` 패턴, tsconfig `jsx: "react-jsx"`
+
+## CLI UI 테스트
+- ink-testing-library: `render()` → `lastFrame()` → assertion
+- Mock 전략: Ink 컴포넌트는 실제 렌더링, 외부 서비스만 mock
+
+## API 테스트
+- Hono `app.request()` 직접 호출 (supertest 아님)
+- D1 mock: in-memory SQLite (`better-sqlite3`)
+
+## E2E 테스트
+- Playwright (`packages/web/e2e/`), `pnpm e2e`로 실행
+- Assertion 수준: smoke(title 확인)가 아닌 **functional**(badge/tag/link/content 검증)
+- Skip 사유: 코드로 해결 불가한 skip은 Design 문서에 사유 기록
+
+## Test Data
+- 중앙 fixture factory: `test-data.ts` (CLI), `mock-factory.ts` (E2E)
+- 패턴: `make*()` + spread override

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,6 +40,16 @@
             "timeout": 5000
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/pre-bash-guard.sh",
+            "timeout": 5000
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,8 @@ foundry-x/
 ```
 
 ### .claude/ 프로젝트 설정
-- `.claude/hooks/` — PreToolUse (보호 파일 차단) + PostToolUse 외부 스크립트 (post-edit-format.sh, post-edit-typecheck.sh, post-edit-test-warn.sh)
+- `.claude/rules/` — 코딩 규칙 5종 (coding-style, git-workflow, testing, security, sdd-triangle) — CC 세션 시작 시 자동 로딩
+- `.claude/hooks/` — PreToolUse (보호 파일 차단 + git guard) + PostToolUse 외부 스크립트 (post-edit-format.sh, post-edit-typecheck.sh, post-edit-test-warn.sh)
 - `.claude/agents/` — 커스텀 에이전트 16종 (deploy-verifier, spec-checker, build-validator, ogd-{orchestrator,generator,discriminator}, shaping-{orchestrator,generator,discriminator}, six-hats-moderator, expert-{ta,aa,ca,da,qa}, auto-reviewer)
 - `.claude/skills/ax-bd-discovery/` — AX BD 2단계 발굴 프로세스 오케스트레이터 (v8.2)
 - `.claude/skills/ax-bd-shaping/` — AX BD 형상화 파이프라인 (Stage 3→4, Phase A~E)


### PR DESCRIPTION
## Summary
- **F330**: `.claude/rules/` 5종 신규 (coding-style, git-workflow, testing, security, sdd-triangle) — CC 세션 시작 시 자동 로딩
- **F331**: PreToolUse git guard — `git add .`, `--no-verify`, `--force`, `reset --hard` 4종 차단
- CLAUDE.md 갱신 (rules/ + git guard 섹션)

## Match Rate
**100%** (10/10 PASS)

## Verification
| # | 항목 | 결과 |
|---|------|------|
| V-01 | rules/ 5종 존재 | ✅ |
| V-02 | 각 파일 ≤30줄 | ✅ (max 22) |
| V-03 | guard.sh 실행 권한 | ✅ |
| V-04 | settings.json 유효 | ✅ |
| V-05 | Bash 매처 존재 | ✅ |
| V-06 | git add . 차단 | ✅ |
| V-07 | --no-verify 차단 | ✅ |
| V-08 | 기존 hooks 정상 | ✅ |
| V-09 | CLAUDE.md 갱신 | ✅ |
| V-10 | 합계 97줄 (≤130) | ✅ |

## Files Changed (8)
- `.claude/rules/` 5종 신규 (97줄)
- `.claude/hooks/pre-bash-guard.sh` 신규 (30줄)
- `.claude/settings.json` 수정 (Bash PreToolUse 추가)
- `CLAUDE.md` 수정 (rules/ 섹션 추가)

---
🤖 Generated from Sprint 146 autopilot