### PR TITLE
feat: Sprint 143 — F327 제품화 탭 + F328 시작하기 (Phase 13 완결)

### DIFF
--- a/docs/03-analysis/features/sprint-143-product-getting-started.analysis.md
+++ b/docs/03-analysis/features/sprint-143-product-getting-started.analysis.md
@@ -1,0 +1,61 @@
+---
+code: FX-ANLS-S143
+title: "Sprint 143 — F327 제품화 탭 + F328 시작하기 통합 Gap Analysis"
+version: "1.0"
+status: Active
+category: ANLS
+created: 2026-04-05
+updated: 2026-04-05
+author: Claude Opus 4.6
+sprint: 143
+f_items: [F327, F328]
+design_ref: "[[FX-DSGN-S143]]"
+---
+
+# FX-ANLS-S143 — Gap Analysis
+
+## Executive Summary
+
+| 항목 | 값 |
+|------|-----|
+| Feature | F327 제품화 탭 + F328 시작하기 통합 |
+| Sprint | 143 |
+| Match Rate | **100%** (9/9 PASS) |
+| 변경 파일 | 3개 (1 신규 + 2 수정) |
+| 변경 라인 | ~70L |
+
+### Value Delivered
+
+| 관점 | 내용 |
+|------|------|
+| **Problem** | 제품화 MVP/PoC 분산, 시작하기에 온보딩만 존재 |
+| **Solution** | 제품화 2탭 통합 + 시작하기 5영역 허브 |
+| **Function UX Effect** | 탭 전환으로 맥락 유지, 원스톱 온보딩 허브 |
+| **Core Value** | Phase 13 IA v1.3 완결 — 7/7 F-items |
+
+## 검증 매트릭스
+
+| # | 검증 항목 | 기준 | 결과 | 비고 |
+|:-:|----------|------|:----:|------|
+| V1 | 제품화 2탭 | MVP/PoC 탭 전환 | PASS | TabsTrigger 2개 |
+| V2 | URL 탭 연동 | /product?tab=poc | PASS | searchParams |
+| V3 | MVP 기본 랜딩 | /product → MVP | PASS | ?? "mvp" fallback |
+| V4 | VersionBadge | 뱃지 표시 | PASS | F325에서 이미 적용 |
+| V5 | 시작하기 5영역 | 온보딩 + 4 HubCard | PASS | featureCards 4개 |
+| V6 | HubCard 네비게이션 | 올바른 경로 | PASS | wiki, tab=setup, demo, tab=skills |
+| V7 | 기존 리다이렉트 | /product/mvp → /product | PASS | router.tsx L141~142 |
+| V8 | typecheck | 0 errors | PASS | tsc --noEmit |
+| V9 | build | 성공 | PASS | vite build 483ms |
+
+## 변경 파일 목록
+
+| 파일 | 동작 | F# |
+|------|------|----|
+| `src/routes/product-unified.tsx` | 신규 (50L) | F327 |
+| `src/router.tsx` | 수정 (1L) | F327 |
+| `src/routes/getting-started.tsx` | 수정 (~15L) | F328 |
+
+## 설계 일치성
+
+- **F327**: Design §3 파일1~2 완전 일치. 파일3(offering-packs VersionBadge)은 이미 F325에서 적용되어 추가 변경 불필요
+- **F328**: Design §3 파일4 — HubCard 4개 추가. 리다이렉트 루프 방지를 위해 데모→/ax-bd/demo(실제 라우트 우선), 도구→?tab=skills(내부 탭)로 처리

--- a/docs/04-report/features/sprint-143-product-getting-started.report.md
+++ b/docs/04-report/features/sprint-143-product-getting-started.report.md
@@ -1,0 +1,63 @@
+---
+code: FX-RPRT-S143
+title: "Sprint 143 — F327 제품화 탭 + F328 시작하기 통합 완료 보고서"
+version: "1.0"
+status: Active
+category: RPRT
+created: 2026-04-05
+updated: 2026-04-05
+author: Claude Opus 4.6
+sprint: 143
+f_items: [F327, F328]
+analysis_ref: "[[FX-ANLS-S143]]"
+---
+
+# FX-RPRT-S143 — Sprint 143 완료 보고서
+
+## Executive Summary
+
+| 항목 | 값 |
+|------|-----|
+| Feature | F327 제품화 탭 통합 + F328 시작하기 통합 |
+| Sprint | 143 |
+| 시작일 | 2026-04-05 |
+| 완료일 | 2026-04-05 |
+| Match Rate | **100%** (9/9 PASS) |
+| 변경 파일 | 3개 |
+| 변경 라인 | ~70L |
+
+### Value Delivered
+
+| 관점 | 내용 |
+|------|------|
+| **Problem** | 제품화 MVP/PoC가 별도 메뉴로 분산. 시작하기에 온보딩만 있고 도구/데모 가이드 접근 어려움 |
+| **Solution** | 제품화 2탭(MVP/PoC) 통합 + 시작하기 5영역 허브 페이지 |
+| **Function UX Effect** | 제품화 메뉴 탭 전환으로 맥락 유지. 시작하기가 원스톱 온보딩 허브 |
+| **Core Value** | **Phase 13 IA v1.3 완결 — 7/7 F-items 전체 완료** |
+
+## 구현 내역
+
+### F327: 제품화 탭 통합
+1. `product-unified.tsx` 신규 생성 — 2탭(MVP/PoC) 래퍼, discovery-unified 패턴
+2. `router.tsx` — /product 라우트를 product-unified로 변경
+3. offering-packs.tsx VersionBadge — F325에서 이미 적용, 추가 변경 불필요
+
+### F328: 시작하기 5영역 허브
+1. `getting-started.tsx` — featureCards를 4개 HubCard로 교체
+   - BD 스킬 가이드 → /wiki
+   - Cowork / Claude Code → ?tab=setup (내부 탭)
+   - 데모 시나리오 → /ax-bd/demo (실제 라우트)
+   - 도구 가이드 → ?tab=skills (내부 탭)
+2. 그리드 레이아웃 4열로 확장
+
+## Phase 13 IA 재설계 v1.3 완결
+
+| Sprint | F-items | 상태 |
+|:------:|---------|:----:|
+| 139 | F322 사이드바 구조 재설계 | ✅ |
+| 140 | F323 대시보드 ToDo + F324 발굴 탭 | ✅ |
+| 141 | F325 형상화+버전관리 | ✅ |
+| 142 | F325(잔여) + F326 검증 탭 | ✅ |
+| **143** | **F327 제품화 탭 + F328 시작하기** | **✅** |
+
+**Phase 13 완결**: 7/7 F-items (F322~F328) 전체 완료

--- a/packages/web/src/router.tsx
+++ b/packages/web/src/router.tsx
@@ -26,7 +26,7 @@ export const router = createBrowserRouter([
       // ── Phase 13 v1.3 신규 경로 ──
       { path: "discovery", lazy: () => import("@/routes/discovery-unified") },
       { path: "validation", lazy: () => import("@/routes/validation-unified") },
-      { path: "product", lazy: () => import("@/routes/mvp-tracking") },
+      { path: "product", lazy: () => import("@/routes/product-unified") },
       { path: "shaping/business-plan", lazy: () => import("@/routes/ax-bd/index") },
       { path: "validation/share", lazy: () => import("@/routes/team-shared") },
       { path: "product/offering-pack", lazy: () => import("@/routes/offering-packs") },

--- a/packages/web/src/routes/getting-started.tsx
+++ b/packages/web/src/routes/getting-started.tsx
@@ -15,6 +15,9 @@ import {
   TrendingUp,
   RotateCcw,
   ArrowRight,
+  Library,
+  Presentation,
+  PenTool,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
@@ -106,28 +109,36 @@ const workflowCards = [
 
 const featureCards = [
   {
-    href: "/agents",
+    href: "/wiki",
+    icon: Library,
+    title: "BD 스킬 가이드",
+    description: "68개 발굴 스킬의 용도와 실행 방법",
+    color: "text-axis-violet",
+    bg: "bg-axis-violet/10",
+  },
+  {
+    href: "/getting-started?tab=setup",
     icon: Bot,
-    title: "에이전트",
-    description: "AI 에이전트의 작업 현황과 PR 파이프라인 관리",
+    title: "Cowork / Claude Code",
+    description: "AI 에이전트 협업 환경 설정과 사용법",
     color: "text-axis-primary",
     bg: "bg-axis-primary/10",
   },
   {
-    href: "/architecture",
-    icon: Blocks,
-    title: "아키텍처",
-    description: "코드 아키텍처를 4가지 뷰로 시각화",
-    color: "text-axis-warm",
-    bg: "bg-axis-warm/10",
+    href: "/ax-bd/demo",
+    icon: Presentation,
+    title: "데모 시나리오",
+    description: "헬스케어 AI + GIVC 시드 데이터 체험",
+    color: "text-axis-accent",
+    bg: "bg-axis-accent/10",
   },
   {
-    href: "/wiki",
-    icon: BookOpen,
-    title: "지식베이스",
-    description: "팀 지식을 구조화하고 AI가 자동 업데이트",
-    color: "text-axis-violet",
-    bg: "bg-axis-violet/10",
+    href: "/getting-started?tab=skills",
+    icon: PenTool,
+    title: "도구 가이드",
+    description: "Marker.io, TinaCMS 등 팀 도구 사용법",
+    color: "text-axis-warm",
+    bg: "bg-axis-warm/10",
   },
 ];
 
@@ -268,7 +279,7 @@ function FeatureCardsSection() {
   return (
     <section>
       <h2 className="mb-4 text-lg font-semibold">더 알아보기</h2>
-      <div className="grid gap-4 sm:grid-cols-1 md:grid-cols-3">
+      <div className="grid gap-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-4">
         {featureCards.map((card) => (
           <Card key={card.href} className="flex flex-col">
             <CardHeader className="pb-2">

--- a/packages/web/src/routes/product-unified.tsx
+++ b/packages/web/src/routes/product-unified.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+/**
+ * F327 — 제품화 통합 페이지
+ * 2탭: MVP / PoC
+ * URL: /product?tab=mvp|poc
+ */
+import { useSearchParams } from "react-router-dom";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Target, TestTubes } from "lucide-react";
+
+import { Component as MvpTracking } from "@/routes/mvp-tracking";
+import { Component as ProductPoc } from "@/routes/product-poc";
+
+export function Component() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tab = searchParams.get("tab") ?? "mvp";
+
+  return (
+    <div className="space-y-6 p-6">
+      <div>
+        <h1 className="text-2xl font-bold font-display">제품화</h1>
+        <p className="text-muted-foreground">MVP · PoC 추적 관리</p>
+      </div>
+
+      <Tabs
+        value={tab}
+        onValueChange={(v) => setSearchParams({ tab: v }, { replace: true })}
+      >
+        <TabsList>
+          <TabsTrigger value="mvp">
+            <Target className="mr-2 size-4" /> MVP
+          </TabsTrigger>
+          <TabsTrigger value="poc">
+            <TestTubes className="mr-2 size-4" /> PoC
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="mvp">
+          <MvpTracking />
+        </TabsContent>
+
+        <TabsContent value="poc">
+          <ProductPoc />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **F327**: 제품화 2탭(MVP/PoC) 통합 — `product-unified.tsx` 신규 + router 변경
- **F328**: 시작하기 5영역 허브 — 4개 HubCard (BD스킬/Cowork/데모/도구)
- **Phase 13 IA v1.3 완결** — 7/7 F-items (F322~F328) 전체 완료

## Match Rate
**100%** (9/9 PASS)

## Changed Files
| 파일 | 동작 |
|------|------|
| `packages/web/src/routes/product-unified.tsx` | 신규 (50L) |
| `packages/web/src/router.tsx` | 수정 (1L) |
| `packages/web/src/routes/getting-started.tsx` | 수정 (~15L) |

## Test plan
- [ ] /product → MVP 탭 기본 표시
- [ ] /product?tab=poc → PoC 탭 활성
- [ ] /product/offering-pack → VersionBadge 표시
- [ ] /getting-started → 4개 HubCard 표시
- [ ] typecheck 0 errors
- [ ] build 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)