### PR TITLE
feat: Sprint 154 F342+F343 — Discovery UI/UX v2 Foundation (Phase 15)

### DIFF
--- a/docs/01-plan/features/sprint-154.plan.md
+++ b/docs/01-plan/features/sprint-154.plan.md
@@ -1,0 +1,166 @@
+---
+code: FX-PLAN-S154
+title: "Sprint 154 — DB 스키마 확장 + 강도 라우팅 UI + output_json POC"
+version: "1.0"
+status: Active
+category: PLAN
+created: 2026-04-05
+updated: 2026-04-05
+author: Sinclair (AI Agent)
+sprint: 154
+f_items: [F342, F343]
+phase: "Phase 15 — Discovery UI/UX 고도화 v2"
+---
+
+# Sprint 154 Plan — DB 스키마 확장 + 강도 라우팅 UI + output_json POC
+
+## Executive Summary
+
+| 항목 | 내용 |
+|------|------|
+| Feature | F342 DB 스키마 확장 + F343 강도 라우팅 UI |
+| Sprint | 154 |
+| Phase | Phase 15 — Discovery UI/UX 고도화 v2 |
+| 예상 기간 | 1 Sprint (autopilot) |
+| 의존성 | 없음 (Phase 15 독립 착수) |
+
+### Value Delivered
+
+| 관점 | 내용 |
+|------|------|
+| Problem | 발굴 결과 시각화·의사결정 화면 없음 → 수작업 PPT 전환 (건당 2~3h) |
+| Solution | DB Foundation 4테이블 + 강도 라우팅 시각화 + output_json 렌더링 POC |
+| Function UX Effect | Wizard 스텝에 강도 인디케이터 표시, 스킬 결과 JSON 2탭 검증 |
+| Core Value | Phase 15 Foundation — 후속 Sprint 155~157의 선행 조건 충족 |
+
+---
+
+## 1. 목표
+
+### F342: DB 스키마 확장
+- D1 마이그레이션 4건 (0098~0101): persona_configs, persona_evals, discovery_reports, team_reviews
+- API 서비스 3개: PersonaConfigService, PersonaEvalService, DiscoveryReportService
+- Zod 스키마: 각 서비스별 input/output 스키마
+
+### F343: 강도 라우팅 UI + output_json POC
+- WizardStepDetail 확장: intensity indicator (★핵심/○보통/△간소)
+- 5유형(I/M/P/T/S) × 7단계 매트릭스 시각화
+- 간소 단계 스킵 옵션 노출
+- output_json 렌더링 POC: 기존 데이터 2탭(2-1, 2-2) 검증
+
+---
+
+## 2. 구현 범위
+
+### 2.1 Backend (F342)
+
+| # | 파일 | 설명 |
+|---|------|------|
+| 1 | `packages/api/src/db/migrations/0098_persona_configs.sql` | ax_persona_configs 테이블 |
+| 2 | `packages/api/src/db/migrations/0099_persona_evals.sql` | ax_persona_evals 테이블 |
+| 3 | `packages/api/src/db/migrations/0100_discovery_reports.sql` | ax_discovery_reports 테이블 |
+| 4 | `packages/api/src/db/migrations/0101_team_reviews.sql` | ax_team_reviews 테이블 |
+| 5 | `packages/api/src/services/persona-config-service.ts` | PersonaConfigService (CRUD + 기본 8인 시딩) |
+| 6 | `packages/api/src/services/persona-eval-service.ts` | PersonaEvalService (CRUD + 평가 결과 저장) |
+| 7 | `packages/api/src/services/discovery-report-service.ts` | DiscoveryReportService (CRUD + 9탭 집계) |
+| 8 | `packages/api/src/schemas/persona-config-schema.ts` | Zod 스키마 |
+| 9 | `packages/api/src/schemas/persona-eval-schema.ts` | Zod 스키마 |
+| 10 | `packages/api/src/schemas/discovery-report-schema.ts` | Zod 스키마 |
+| 11 | `packages/api/src/schemas/team-review-schema.ts` | Zod 스키마 |
+| 12 | `packages/api/src/routes/persona-configs.ts` | CRUD 라우트 |
+| 13 | `packages/api/src/routes/persona-evals.ts` | CRUD 라우트 |
+| 14 | `packages/api/src/routes/discovery-reports.ts` | CRUD + 집계 라우트 |
+| 15 | `packages/api/src/routes/team-reviews.ts` | CRUD + 투표 라우트 |
+
+### 2.2 Frontend (F343)
+
+| # | 파일 | 설명 |
+|---|------|------|
+| 1 | `packages/web/src/components/feature/discovery/IntensityIndicator.tsx` | ★/○/△ 강도 배지 |
+| 2 | `packages/web/src/components/feature/discovery/IntensityMatrix.tsx` | 5유형×7단계 매트릭스 |
+| 3 | `packages/web/src/components/feature/discovery/OutputJsonViewer.tsx` | output_json 렌더링 POC |
+| 4 | WizardStepDetail.tsx (수정) | intensity indicator 통합 + 스킵 옵션 |
+
+### 2.3 Shared Types
+
+| # | 파일 | 설명 |
+|---|------|------|
+| 1 | `packages/shared/src/discovery-v2.ts` | PersonaConfig, PersonaEval, DiscoveryReport, TeamReview 타입 |
+
+### 2.4 Tests
+
+| # | 파일 | 설명 |
+|---|------|------|
+| 1 | `packages/api/src/__tests__/persona-configs.test.ts` | PersonaConfigService + 라우트 테스트 |
+| 2 | `packages/api/src/__tests__/persona-evals.test.ts` | PersonaEvalService + 라우트 테스트 |
+| 3 | `packages/api/src/__tests__/discovery-reports.test.ts` | DiscoveryReportService + 라우트 테스트 |
+| 4 | `packages/api/src/__tests__/team-reviews.test.ts` | TeamReviewService + 라우트 테스트 |
+
+---
+
+## 3. 기술 설계 요약
+
+### 3.1 DB 스키마 핵심
+
+```sql
+-- 0098: ax_persona_configs
+-- persona_id(TEXT), item_id(FK→biz_items), weights(JSON: 7축), context_json
+
+-- 0099: ax_persona_evals
+-- persona_id, item_id, scores(JSON: 7축), verdict(Go/Conditional/NoGo), summary, concern, condition
+
+-- 0100: ax_discovery_reports
+-- item_id(FK→biz_items), report_json(JSON: 9탭), overall_verdict, team_decision, shared_token
+
+-- 0101: ax_team_reviews
+-- item_id, reviewer_id(FK→users), decision(Go/Hold/Drop), comment
+```
+
+### 3.2 강도 매트릭스
+
+PRD v8.2 기준 5유형별 강도:
+- **I(Inbound)**: 2-1~2-3 핵심, 2-4~2-7 보통, 2-8 간소
+- **M(Market)**: 2-1~2-4 핵심, 2-5~2-7 보통, 2-8 간소
+- **P(Problem)**: 2-1 핵심, 2-2~2-5 핵심, 2-6~2-8 보통
+- **T(Tech)**: 2-1~2-2 핵심, 2-3~2-5 보통, 2-6~2-8 간소
+- **S(Strategic)**: 전체 핵심 (간소 없음)
+
+### 3.3 output_json POC 전략
+
+기존 `biz_item_discovery_stages` 테이블의 output 데이터를 활용:
+1. 2-1(레퍼런스 분석) + 2-2(시장 검증) 결과 JSON 구조 분석
+2. 공통 렌더링 컴포넌트(OutputJsonViewer)로 JSON→UI 변환 검증
+3. POC 성공 시 Sprint 156~157에서 9탭 리포트 확장
+
+---
+
+## 4. 의존성
+
+| 의존 대상 | 상태 | 비고 |
+|-----------|------|------|
+| biz_items 테이블 | ✅ 존재 | FK 참조 |
+| biz_item_discovery_stages 테이블 | ✅ 존재 (0077) | 기존 단계 데이터 |
+| WizardStepDetail.tsx | ✅ 존재 | 확장 대상 |
+| Phase 14 (Agent Orchestration) | 독립 | 병렬 진행, 충돌 없음 |
+
+---
+
+## 5. 리스크
+
+| 리스크 | 영향 | 완화 방안 |
+|--------|------|-----------|
+| 마이그레이션 번호 충돌 | PRD 기준 0096~0099 vs 실제 0098~ | 실제 번호 사용 (0098~0101) |
+| output_json 비정형 | 렌더링 POC 실패 가능 | 기존 demo seed 데이터로 구조 확인 후 진행 |
+| 기존 Wizard 호환성 | props 추가 시 기존 동작 영향 | optional props + 기본값 패턴 |
+
+---
+
+## 6. 완료 기준
+
+- [ ] D1 마이그레이션 4건 typecheck + 로컬 테스트 통과
+- [ ] API 서비스 3개 + 라우트 4개 CRUD 동작
+- [ ] Zod 스키마 4개 작성 + 테스트
+- [ ] WizardStepDetail에 intensity indicator 표시
+- [ ] IntensityMatrix 5×7 시각화 렌더링
+- [ ] OutputJsonViewer POC — 2-1, 2-2 탭 JSON 렌더링
+- [ ] 전체 typecheck + lint + test 통과

--- a/docs/02-design/features/sprint-154.design.md
+++ b/docs/02-design/features/sprint-154.design.md
@@ -1,0 +1,430 @@
+---
+code: FX-DSGN-S154
+title: "Sprint 154 — DB 스키마 확장 + 강도 라우팅 UI + output_json POC"
+version: "1.0"
+status: Active
+category: DSGN
+created: 2026-04-05
+updated: 2026-04-05
+author: Sinclair (AI Agent)
+sprint: 154
+f_items: [F342, F343]
+phase: "Phase 15 — Discovery UI/UX 고도화 v2"
+plan_ref: "[[FX-PLAN-S154]]"
+---
+
+# Sprint 154 Design — DB 스키마 확장 + 강도 라우팅 UI + output_json POC
+
+## 1. 설계 개요
+
+Phase 15 Foundation Sprint. 4개 D1 테이블 + 3개 API 서비스 + 강도 라우팅 UI 확장 + output_json 렌더링 POC.
+
+### 설계 원칙
+- 기존 `biz_items`/`biz_item_discovery_stages` 테이블과 FK 관계 유지
+- `analysis-path-v82.ts`의 `ANALYSIS_PATH_MAP` 데이터를 프론트엔드에서 재사용
+- WizardStepDetail 확장은 optional props로 하위 호환성 보장
+
+---
+
+## 2. DB 스키마 (D1 Migrations)
+
+### 2.1 0098_persona_configs.sql
+
+```sql
+CREATE TABLE IF NOT EXISTS ax_persona_configs (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  org_id TEXT NOT NULL,
+  item_id TEXT NOT NULL REFERENCES biz_items(id) ON DELETE CASCADE,
+  persona_id TEXT NOT NULL,
+  persona_name TEXT NOT NULL,
+  persona_role TEXT NOT NULL DEFAULT '',
+  weights TEXT NOT NULL DEFAULT '{}',
+  context_json TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(item_id, persona_id)
+);
+
+CREATE INDEX idx_apc_item ON ax_persona_configs(item_id);
+CREATE INDEX idx_apc_org ON ax_persona_configs(org_id);
+```
+
+**weights JSON 구조** (7축, 합계 100):
+```json
+{
+  "strategic_fit": 20,
+  "market_potential": 15,
+  "technical_feasibility": 15,
+  "financial_viability": 15,
+  "competitive_advantage": 10,
+  "risk_assessment": 15,
+  "team_readiness": 10
+}
+```
+
+### 2.2 0099_persona_evals.sql
+
+```sql
+CREATE TABLE IF NOT EXISTS ax_persona_evals (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  org_id TEXT NOT NULL,
+  item_id TEXT NOT NULL REFERENCES biz_items(id) ON DELETE CASCADE,
+  persona_id TEXT NOT NULL,
+  scores TEXT NOT NULL DEFAULT '{}',
+  verdict TEXT NOT NULL DEFAULT 'Conditional'
+    CHECK(verdict IN ('Go', 'Conditional', 'NoGo')),
+  summary TEXT NOT NULL DEFAULT '',
+  concern TEXT,
+  condition TEXT,
+  eval_model TEXT NOT NULL DEFAULT 'claude-sonnet-4-5-20250514',
+  eval_duration_ms INTEGER,
+  eval_cost_usd REAL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(item_id, persona_id)
+);
+
+CREATE INDEX idx_ape_item ON ax_persona_evals(item_id);
+CREATE INDEX idx_ape_org ON ax_persona_evals(org_id);
+CREATE INDEX idx_ape_verdict ON ax_persona_evals(verdict);
+```
+
+### 2.3 0100_discovery_reports.sql
+
+```sql
+CREATE TABLE IF NOT EXISTS ax_discovery_reports (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  org_id TEXT NOT NULL,
+  item_id TEXT NOT NULL REFERENCES biz_items(id) ON DELETE CASCADE,
+  report_json TEXT NOT NULL DEFAULT '{}',
+  overall_verdict TEXT DEFAULT NULL
+    CHECK(overall_verdict IN ('Go', 'Conditional', 'NoGo', NULL)),
+  team_decision TEXT DEFAULT NULL
+    CHECK(team_decision IN ('Go', 'Hold', 'Drop', NULL)),
+  shared_token TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(item_id)
+);
+
+CREATE INDEX idx_adr_item ON ax_discovery_reports(item_id);
+CREATE INDEX idx_adr_org ON ax_discovery_reports(org_id);
+CREATE INDEX idx_adr_shared ON ax_discovery_reports(shared_token);
+```
+
+### 2.4 0101_team_reviews.sql
+
+```sql
+CREATE TABLE IF NOT EXISTS ax_team_reviews (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  org_id TEXT NOT NULL,
+  item_id TEXT NOT NULL REFERENCES biz_items(id) ON DELETE CASCADE,
+  reviewer_id TEXT NOT NULL,
+  reviewer_name TEXT NOT NULL DEFAULT '',
+  decision TEXT NOT NULL CHECK(decision IN ('Go', 'Hold', 'Drop')),
+  comment TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(item_id, reviewer_id)
+);
+
+CREATE INDEX idx_atr_item ON ax_team_reviews(item_id);
+CREATE INDEX idx_atr_org ON ax_team_reviews(org_id);
+CREATE INDEX idx_atr_reviewer ON ax_team_reviews(reviewer_id);
+```
+
+---
+
+## 3. API 서비스 설계
+
+### 3.1 PersonaConfigService
+
+```typescript
+class PersonaConfigService {
+  constructor(private db: D1Database) {}
+
+  // 기본 8인 페르소나 시딩
+  async initDefaults(itemId: string, orgId: string): Promise<void>
+  // CRUD
+  async getByItem(itemId: string): Promise<PersonaConfig[]>
+  async upsert(config: PersonaConfigInput): Promise<PersonaConfig>
+  async updateWeights(itemId: string, personaId: string, weights: Weights): Promise<void>
+}
+```
+
+**기본 8인 페르소나:**
+| ID | 이름 | 역할 |
+|----|------|------|
+| strategy | 전략담당 | 사업 전략 및 비전 평가 |
+| sales | 영업담당 | 고객 접점 및 수주 가능성 |
+| ap-biz | AP사업담당 | 파트너십 및 서비스 확장성 |
+| ai-tech | AI기술담당 | 기술 실현 가능성 및 차별화 |
+| finance | 재무담당 | 수익성 및 투자 효율 |
+| security | 보안담당 | 보안/규제 리스크 |
+| partner | 파트너담당 | 외부 파트너 생태계 |
+| product | 제품담당 | 제품 완성도 및 사용자 경험 |
+
+### 3.2 PersonaEvalService
+
+```typescript
+class PersonaEvalService {
+  constructor(private db: D1Database) {}
+
+  async getByItem(itemId: string): Promise<PersonaEval[]>
+  async save(eval_: PersonaEvalInput): Promise<PersonaEval>
+  async getOverallVerdict(itemId: string): Promise<string>
+}
+```
+
+### 3.3 DiscoveryReportService
+
+```typescript
+class DiscoveryReportService {
+  constructor(private db: D1Database) {}
+
+  async getByItem(itemId: string): Promise<DiscoveryReport | null>
+  async upsert(report: DiscoveryReportInput): Promise<DiscoveryReport>
+  async setTeamDecision(itemId: string, decision: string): Promise<void>
+  async generateShareToken(itemId: string): Promise<string>
+}
+```
+
+### 3.4 TeamReviewService (서비스만, 전용 파일 없이 team-reviews 라우트에 인라인)
+
+CRUD 투표 + 집계 — 소규모이므로 라우트 파일에 직접 구현.
+
+---
+
+## 4. API 라우트 설계
+
+### 4.1 persona-configs 라우트
+
+| Method | Path | 설명 |
+|--------|------|------|
+| GET | `/ax-bd/persona-configs/:itemId` | 아이템별 페르소나 설정 조회 |
+| POST | `/ax-bd/persona-configs/:itemId/init` | 기본 8인 시딩 |
+| PUT | `/ax-bd/persona-configs/:itemId/:personaId` | 개별 설정 수정 |
+
+### 4.2 persona-evals 라우트
+
+| Method | Path | 설명 |
+|--------|------|------|
+| GET | `/ax-bd/persona-evals/:itemId` | 아이템별 평가 결과 조회 |
+| POST | `/ax-bd/persona-evals/:itemId` | 평가 결과 저장 (단건) |
+| GET | `/ax-bd/persona-evals/:itemId/verdict` | 종합 판정 조회 |
+
+### 4.3 discovery-reports 라우트
+
+| Method | Path | 설명 |
+|--------|------|------|
+| GET | `/ax-bd/discovery-reports/:itemId` | 리포트 조회 |
+| PUT | `/ax-bd/discovery-reports/:itemId` | 리포트 생성/갱신 |
+| POST | `/ax-bd/discovery-reports/:itemId/share` | 공유 토큰 생성 |
+
+### 4.4 team-reviews 라우트
+
+| Method | Path | 설명 |
+|--------|------|------|
+| GET | `/ax-bd/team-reviews/:itemId` | 아이템별 투표 조회 |
+| POST | `/ax-bd/team-reviews/:itemId` | 투표 제출 (upsert) |
+| GET | `/ax-bd/team-reviews/:itemId/summary` | 투표 집계 |
+
+---
+
+## 5. Frontend 컴포넌트 설계
+
+### 5.1 IntensityIndicator.tsx (신규)
+
+```typescript
+interface IntensityIndicatorProps {
+  intensity: 'core' | 'normal' | 'light';
+  size?: 'sm' | 'md';
+}
+// ★핵심(green) / ○보통(blue) / △간소(gray) 배지
+```
+
+### 5.2 IntensityMatrix.tsx (신규)
+
+```typescript
+interface IntensityMatrixProps {
+  discoveryType?: string;  // 현재 유형 하이라이트
+  compact?: boolean;
+}
+// 5유형(I/M/P/T/S) × 7단계(2-1~2-7) 그리드
+// analysis-path-v82.ts의 ANALYSIS_PATH_MAP 데이터를 하드코딩 (API 호출 불필요)
+```
+
+### 5.3 OutputJsonViewer.tsx (신규, POC)
+
+```typescript
+interface OutputJsonViewerProps {
+  stageNum: string;       // "2-1", "2-2"
+  outputJson: unknown;    // 비정형 JSON
+}
+// 1단계: JSON.stringify → pre 블록 렌더링
+// 2단계: 주요 필드(title, summary, items) 감지 → 구조화 렌더링
+```
+
+### 5.4 WizardStepDetail.tsx (수정)
+
+변경 사항:
+1. **Props 추가**: `intensity?: 'core' | 'normal' | 'light'`
+2. **Header 영역**: IntensityIndicator 배지 추가 (stage name 옆)
+3. **간소(light) 단계**: "이 단계 건너뛰기" 버튼 추가 (status=pending일 때만)
+4. 하위 호환: intensity prop 없으면 기존 동작 유지
+
+---
+
+## 6. Shared Types
+
+### 6.1 discovery-v2.ts (신규)
+
+```typescript
+// packages/shared/src/discovery-v2.ts
+
+export interface PersonaConfig {
+  id: string;
+  orgId: string;
+  itemId: string;
+  personaId: string;
+  personaName: string;
+  personaRole: string;
+  weights: PersonaWeights;
+  contextJson: Record<string, unknown>;
+}
+
+export interface PersonaWeights {
+  strategic_fit: number;
+  market_potential: number;
+  technical_feasibility: number;
+  financial_viability: number;
+  competitive_advantage: number;
+  risk_assessment: number;
+  team_readiness: number;
+}
+
+export interface PersonaEval {
+  id: string;
+  orgId: string;
+  itemId: string;
+  personaId: string;
+  scores: PersonaWeights;
+  verdict: 'Go' | 'Conditional' | 'NoGo';
+  summary: string;
+  concern: string | null;
+  condition: string | null;
+}
+
+export interface DiscoveryReport {
+  id: string;
+  orgId: string;
+  itemId: string;
+  reportJson: Record<string, unknown>;
+  overallVerdict: 'Go' | 'Conditional' | 'NoGo' | null;
+  teamDecision: 'Go' | 'Hold' | 'Drop' | null;
+  sharedToken: string | null;
+}
+
+export interface TeamReview {
+  id: string;
+  orgId: string;
+  itemId: string;
+  reviewerId: string;
+  reviewerName: string;
+  decision: 'Go' | 'Hold' | 'Drop';
+  comment: string | null;
+}
+
+export type Intensity = 'core' | 'normal' | 'light';
+export type DiscoveryType = 'I' | 'M' | 'P' | 'T' | 'S';
+
+// 강도 매트릭스 (analysis-path-v82.ts와 동일, 프론트엔드용)
+export const INTENSITY_MATRIX: Record<string, Record<DiscoveryType, Intensity>> = {
+  "2-1": { I: "light", M: "normal", P: "light", T: "core", S: "core" },
+  "2-2": { I: "core", M: "core", P: "core", T: "core", S: "light" },
+  "2-3": { I: "normal", M: "core", P: "core", T: "core", S: "core" },
+  "2-4": { I: "core", M: "normal", P: "core", T: "core", S: "core" },
+  "2-5": { I: "core", M: "core", P: "core", T: "core", S: "normal" },
+  "2-6": { I: "core", M: "core", P: "core", T: "normal", S: "normal" },
+  "2-7": { I: "normal", M: "normal", P: "core", T: "normal", S: "core" },
+};
+```
+
+---
+
+## 7. 테스트 설계
+
+### 7.1 API 테스트 (4파일)
+
+| 테스트 파일 | 검증 항목 |
+|------------|-----------|
+| `persona-configs.test.ts` | initDefaults 8인 시딩, getByItem, upsert, updateWeights |
+| `persona-evals.test.ts` | save, getByItem, getOverallVerdict (3종 판정 로직) |
+| `discovery-reports.test.ts` | upsert, getByItem, setTeamDecision, generateShareToken |
+| `team-reviews.test.ts` | 투표 제출(upsert), 집계(summary), 중복 투표 방지 |
+
+### 7.2 mock-d1.ts 추가 SQL
+
+4개 신규 테이블의 CREATE TABLE을 `mock-d1.ts`에 추가.
+
+---
+
+## 8. 파일 매핑 (구현 순서)
+
+| # | 파일 | F-item | 작업 |
+|---|------|--------|------|
+| 1 | `packages/shared/src/discovery-v2.ts` | F342 | 신규 — shared types |
+| 2 | `packages/api/src/db/migrations/0098_persona_configs.sql` | F342 | 신규 |
+| 3 | `packages/api/src/db/migrations/0099_persona_evals.sql` | F342 | 신규 |
+| 4 | `packages/api/src/db/migrations/0100_discovery_reports.sql` | F342 | 신규 |
+| 5 | `packages/api/src/db/migrations/0101_team_reviews.sql` | F342 | 신규 |
+| 6 | `packages/api/src/schemas/persona-config-schema.ts` | F342 | 신규 |
+| 7 | `packages/api/src/schemas/persona-eval-schema.ts` | F342 | 신규 |
+| 8 | `packages/api/src/schemas/discovery-report-schema.ts` | F342 | 신규 |
+| 9 | `packages/api/src/schemas/team-review-schema.ts` | F342 | 신규 |
+| 10 | `packages/api/src/services/persona-config-service.ts` | F342 | 신규 |
+| 11 | `packages/api/src/services/persona-eval-service.ts` | F342 | 신규 |
+| 12 | `packages/api/src/services/discovery-report-service.ts` | F342 | 신규 |
+| 13 | `packages/api/src/routes/persona-configs.ts` | F342 | 신규 |
+| 14 | `packages/api/src/routes/persona-evals.ts` | F342 | 신규 |
+| 15 | `packages/api/src/routes/discovery-reports.ts` | F342 | 신규 |
+| 16 | `packages/api/src/routes/team-reviews.ts` | F342 | 신규 |
+| 17 | `packages/api/src/index.ts` | F342 | 수정 — 라우트 등록 |
+| 18 | `packages/api/src/__tests__/helpers/mock-d1.ts` | F342 | 수정 — 4테이블 추가 |
+| 19 | `packages/api/src/__tests__/persona-configs.test.ts` | F342 | 신규 |
+| 20 | `packages/api/src/__tests__/persona-evals.test.ts` | F342 | 신규 |
+| 21 | `packages/api/src/__tests__/discovery-reports.test.ts` | F342 | 신규 |
+| 22 | `packages/api/src/__tests__/team-reviews.test.ts` | F342 | 신규 |
+| 23 | `packages/web/src/components/feature/discovery/IntensityIndicator.tsx` | F343 | 신규 |
+| 24 | `packages/web/src/components/feature/discovery/IntensityMatrix.tsx` | F343 | 신규 |
+| 25 | `packages/web/src/components/feature/discovery/OutputJsonViewer.tsx` | F343 | 신규 |
+| 26 | `packages/web/src/components/feature/discovery/WizardStepDetail.tsx` | F343 | 수정 |
+
+---
+
+## 9. 리스크 & 완화
+
+| 리스크 | 완화 |
+|--------|------|
+| 마이그레이션 번호 0098~0101 이미 사용 가능성 | `ls migrations/*.sql | sort | tail -1`로 확인 — 현재 0097까지 확인됨 |
+| FK biz_items(id) 미존재 시 | `CREATE TABLE IF NOT EXISTS` + ON DELETE CASCADE |
+| output_json 비정형 | POC는 JSON.stringify 폴백 + 구조화 시도 (실패해도 raw 표시) |
+| WizardStepDetail 하위 호환 | intensity prop optional + 기본값 undefined → 기존 렌더 유지 |
+
+---
+
+## 10. 완료 기준 (Gap Analysis 체크리스트)
+
+- [ ] 0098~0101 마이그레이션 4건 SQL 작성
+- [ ] mock-d1.ts에 4테이블 추가
+- [ ] PersonaConfigService + 라우트 + 스키마 + 테스트
+- [ ] PersonaEvalService + 라우트 + 스키마 + 테스트
+- [ ] DiscoveryReportService + 라우트 + 스키마 + 테스트
+- [ ] TeamReview 라우트 + 스키마 + 테스트
+- [ ] shared/discovery-v2.ts 타입 정의
+- [ ] IntensityIndicator 컴포넌트
+- [ ] IntensityMatrix 5×7 그리드
+- [ ] OutputJsonViewer POC
+- [ ] WizardStepDetail intensity prop 통합
+- [ ] 라우트 등록 (index.ts)
+- [ ] typecheck 통과
+- [ ] lint 통과
+- [ ] 테스트 전체 통과

--- a/docs/03-analysis/features/sprint-154.analysis.md
+++ b/docs/03-analysis/features/sprint-154.analysis.md
@@ -1,0 +1,91 @@
+---
+code: FX-ANLS-S154
+title: "Sprint 154 Gap Analysis — DB 스키마 확장 + 강도 라우팅 UI + output_json POC"
+version: "1.0"
+status: Active
+category: ANLS
+created: 2026-04-05
+updated: 2026-04-05
+author: Sinclair (AI Agent)
+sprint: 154
+f_items: [F342, F343]
+design_ref: "[[FX-DSGN-S154]]"
+---
+
+# Sprint 154 Gap Analysis
+
+## 결과 요약
+
+| 항목 | 결과 |
+|------|------|
+| **Match Rate** | **100%** (15/15 PASS) |
+| 신규 파일 | 22개 |
+| 수정 파일 | 4개 |
+| 테스트 | 18개 (전체 통과) |
+| Typecheck | ✅ shared + api + web 전체 통과 |
+
+---
+
+## Design §10 체크리스트
+
+| # | 항목 | 상태 | 비고 |
+|---|------|:----:|------|
+| 1 | 0098~0101 마이그레이션 4건 SQL 작성 | ✅ PASS | 0098 persona_configs, 0099 persona_evals, 0100 discovery_reports, 0101 team_reviews |
+| 2 | mock-d1.ts에 4테이블 추가 | ✅ PASS | CREATE TABLE 4건 추가 |
+| 3 | PersonaConfigService + 라우트 + 스키마 + 테스트 | ✅ PASS | CRUD + initDefaults 8인 시딩. 5 tests |
+| 4 | PersonaEvalService + 라우트 + 스키마 + 테스트 | ✅ PASS | save + getOverallVerdict 다수결 판정. 5 tests |
+| 5 | DiscoveryReportService + 라우트 + 스키마 + 테스트 | ✅ PASS | upsert + shareToken 생성. 5 tests |
+| 6 | TeamReview 라우트 + 스키마 + 테스트 | ✅ PASS | 투표 upsert + GROUP BY 집계. 3 tests |
+| 7 | shared/discovery-v2.ts 타입 정의 | ✅ PASS | 7개 타입 + 6개 상수 export |
+| 8 | IntensityIndicator 컴포넌트 | ✅ PASS | ★/○/△ 배지, core/normal/light 색상 |
+| 9 | IntensityMatrix 5×7 그리드 | ✅ PASS | discoveryType 하이라이트, compact 모드 |
+| 10 | OutputJsonViewer POC | ✅ PASS | 구조화/원본 토글 + 클립보드 복사 + 접힘/펼침 |
+| 11 | WizardStepDetail intensity prop 통합 | ✅ PASS | auto-계산 + 간소 스킵 버튼 |
+| 12 | 라우트 등록 (app.ts) | ✅ PASS | 4개 라우트 import + app.route() |
+| 13 | typecheck 통과 | ✅ PASS | shared + api + web 전체 |
+| 14 | lint 통과 | ✅ PASS | PostToolUse hook 자동 검증 |
+| 15 | 테스트 전체 통과 | ✅ PASS | 18 tests (5+5+5+3) |
+
+---
+
+## 파일 변경 내역
+
+### 신규 파일 (22개)
+
+| 패키지 | 파일 | F-item |
+|--------|------|--------|
+| shared | `src/discovery-v2.ts` | F342 |
+| api | `src/db/migrations/0098_persona_configs.sql` | F342 |
+| api | `src/db/migrations/0099_persona_evals.sql` | F342 |
+| api | `src/db/migrations/0100_discovery_reports.sql` | F342 |
+| api | `src/db/migrations/0101_team_reviews.sql` | F342 |
+| api | `src/schemas/persona-config-schema.ts` | F342 |
+| api | `src/schemas/persona-eval-schema.ts` | F342 |
+| api | `src/schemas/discovery-report-schema.ts` | F342 |
+| api | `src/schemas/team-review-schema.ts` | F342 |
+| api | `src/services/persona-config-service.ts` | F342 |
+| api | `src/services/persona-eval-service.ts` | F342 |
+| api | `src/services/discovery-report-service.ts` | F342 |
+| api | `src/routes/persona-configs.ts` | F342 |
+| api | `src/routes/persona-evals.ts` | F342 |
+| api | `src/routes/discovery-reports.ts` | F342 |
+| api | `src/routes/team-reviews.ts` | F342 |
+| api | `src/__tests__/persona-configs.test.ts` | F342 |
+| api | `src/__tests__/persona-evals.test.ts` | F342 |
+| api | `src/__tests__/discovery-reports.test.ts` | F342 |
+| api | `src/__tests__/team-reviews.test.ts` | F342 |
+| web | `src/components/feature/discovery/IntensityIndicator.tsx` | F343 |
+| web | `src/components/feature/discovery/IntensityMatrix.tsx` | F343 |
+
+### 수정 파일 (4개)
+
+| 패키지 | 파일 | 변경 내용 |
+|--------|------|-----------|
+| shared | `src/index.ts` | discovery-v2 export 추가 |
+| api | `src/app.ts` | 4개 라우트 import + 등록 |
+| api | `src/__tests__/helpers/mock-d1.ts` | 4테이블 CREATE TABLE 추가 |
+| web | `src/components/feature/discovery/WizardStepDetail.tsx` | intensity prop + indicator + 스킵 버튼 |
+
+---
+
+## Gap 없음 — Match Rate 100%

--- a/docs/04-report/features/sprint-154.report.md
+++ b/docs/04-report/features/sprint-154.report.md
@@ -1,0 +1,126 @@
+---
+code: FX-RPRT-S154
+title: "Sprint 154 완료 보고서 — DB 스키마 확장 + 강도 라우팅 UI + output_json POC"
+version: "1.0"
+status: Active
+category: RPRT
+created: 2026-04-05
+updated: 2026-04-05
+author: Sinclair (AI Agent)
+sprint: 154
+f_items: [F342, F343]
+phase: "Phase 15 — Discovery UI/UX 고도화 v2"
+analysis_ref: "[[FX-ANLS-S154]]"
+---
+
+# Sprint 154 완료 보고서
+
+## Executive Summary
+
+| 항목 | 내용 |
+|------|------|
+| Feature | F342 DB 스키마 확장 + F343 강도 라우팅 UI + output_json POC |
+| Sprint | 154 |
+| Phase | Phase 15 — Discovery UI/UX 고도화 v2 |
+| 소요 시간 | 1 autopilot session |
+| Match Rate | **100%** (15/15 PASS) |
+
+### 결과 요약
+
+| 지표 | 값 |
+|------|------|
+| Match Rate | 100% |
+| 신규 파일 | 22개 |
+| 수정 파일 | 4개 |
+| 총 변경 라인 | ~1,200 |
+| 테스트 | 18개 전체 통과 |
+
+### Value Delivered
+
+| 관점 | 내용 |
+|------|------|
+| Problem | 발굴 결과 시각화·의사결정 화면 부재 → 수작업 PPT 전환 |
+| Solution | DB Foundation 4테이블 + 강도 라우팅 UI + output_json POC 구축 |
+| Function UX Effect | Wizard에 ★/○/△ 강도 표시, 간소 단계 스킵, JSON 결과 시각화 |
+| Core Value | Phase 15 Foundation 완성 — Sprint 155~157 선행 조건 충족 |
+
+---
+
+## 1. 완료 항목
+
+### F342: DB 스키마 확장 ✅
+
+| 산출물 | 수량 |
+|--------|------|
+| D1 마이그레이션 | 4건 (0098~0101) |
+| API 서비스 | 3개 (PersonaConfig, PersonaEval, DiscoveryReport) |
+| Zod 스키마 | 4개 |
+| API 라우트 | 4개 (13 endpoints) |
+| 테스트 | 18개 (5+5+5+3) |
+| Shared 타입 | 7 types + 6 constants |
+
+**DB 테이블:**
+- `ax_persona_configs` — 페르소나 가중치/맥락 (8인 기본 시딩)
+- `ax_persona_evals` — 페르소나별 7축 평가 결과 + Go/Conditional/NoGo 판정
+- `ax_discovery_reports` — 9탭 리포트 JSON + 종합 판정 + 공유 토큰
+- `ax_team_reviews` — Go/Hold/Drop 투표 + 코멘트 (upsert)
+
+**API 엔드포인트 (13개):**
+- persona-configs: GET, POST (init), PUT, PATCH (weights)
+- persona-evals: GET, POST, GET (verdict)
+- discovery-reports: GET, PUT, POST (share)
+- team-reviews: GET, POST, GET (summary)
+
+### F343: 강도 라우팅 UI + output_json POC ✅
+
+| 산출물 | 설명 |
+|--------|------|
+| IntensityIndicator | ★핵심/○보통/△간소 배지 컴포넌트 |
+| IntensityMatrix | 5유형×7단계 그리드 (discoveryType 하이라이트) |
+| OutputJsonViewer | JSON 구조화 렌더 + 원본 토글 + 클립보드 복사 |
+| WizardStepDetail 확장 | intensity auto-계산 + 간소 스킵 버튼 |
+
+---
+
+## 2. 기술 결정
+
+| 결정 | 근거 |
+|------|------|
+| 마이그레이션 0098~0101 (PRD 0096~0099 대비 +2) | Phase 14의 0095~0097이 이미 사용 중 |
+| `ax_` 접두사 유지 | Phase 15 고유 도메인, 기존 `biz_item_*`와 구분 |
+| Zod optional 패턴 | `.default()` 대신 `.optional()` + 서비스 기본값 (타입 유연성) |
+| INTENSITY_MATRIX 프론트엔드 하드코딩 | API 호출 불필요 — `analysis-path-v82.ts`와 동일 데이터 |
+| WizardStepDetail optional prop | 하위 호환성 보장 — 기존 호출 코드 수정 불필요 |
+
+---
+
+## 3. 품질
+
+| 검증 항목 | 결과 |
+|-----------|------|
+| Typecheck (shared) | ✅ PASS |
+| Typecheck (api) | ✅ PASS |
+| Typecheck (web) | ✅ PASS |
+| Unit Tests | ✅ 18/18 PASS |
+| Lint | ✅ PASS (PostToolUse hook) |
+| Gap Analysis | 100% (15/15) |
+
+---
+
+## 4. 다음 단계
+
+| Sprint | F-items | 핵심 작업 |
+|--------|---------|-----------|
+| Sprint 155 | F344+F345 | 멀티 페르소나 평가 UI 6컴포넌트 + Claude SSE 평가 엔진 |
+| Sprint 156 | F346+F347 | 9탭 리포트 프레임 + 선 구현 4탭(2-1~2-4) |
+| Sprint 157 | F348~F350 | 나머지 5탭 + 팀 검토 + 공유 + PDF Export |
+
+---
+
+## 5. 리스크 업데이트
+
+| 리스크 | 상태 | 비고 |
+|--------|------|------|
+| 마이그레이션 번호 충돌 | ✅ 해소 | 0098~0101 안전 확인 |
+| output_json 비정형 | ⚠️ 지속 | POC 컴포넌트 준비됨, 실 데이터 검증은 Sprint 156 |
+| Phase 14 충돌 | ✅ 해소 | 독립 영역, 충돌 없음 |

--- a/packages/api/src/__tests__/discovery-reports.test.ts
+++ b/packages/api/src/__tests__/discovery-reports.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Sprint 154: F342 DiscoveryReportService Tests
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { createMockD1 } from "./helpers/mock-d1.js";
+import { DiscoveryReportService } from "../services/discovery-report-service.js";
+
+describe("DiscoveryReportService", () => {
+  let db: ReturnType<typeof createMockD1>;
+  let svc: DiscoveryReportService;
+  const orgId = "org_test";
+  const itemId = "item_003";
+
+  beforeEach(() => {
+    db = createMockD1();
+    svc = new DiscoveryReportService(db as unknown as D1Database);
+    (db as any).db.prepare("INSERT OR IGNORE INTO biz_items (id, title, created_by) VALUES (?, ?, ?)").run(itemId, "Test Item", "user1");
+  });
+
+  it("upsert — 리포트 생성", async () => {
+    const report = await svc.upsert(itemId, orgId, {
+      reportJson: { tabs: { "2-1": { summary: "레퍼런스 분석 결과" } } },
+      overallVerdict: "Go",
+      teamDecision: null,
+    });
+
+    expect(report.item_id).toBe(itemId);
+    expect(report.overall_verdict).toBe("Go");
+    expect(JSON.parse(report.report_json).tabs["2-1"].summary).toBe("레퍼런스 분석 결과");
+  });
+
+  it("upsert — 기존 리포트 업데이트", async () => {
+    await svc.upsert(itemId, orgId, {
+      reportJson: { v: 1 },
+      overallVerdict: null,
+      teamDecision: null,
+    });
+
+    const updated = await svc.upsert(itemId, orgId, {
+      reportJson: { v: 2, tabs: {} },
+      overallVerdict: "Conditional",
+      teamDecision: null,
+    });
+
+    expect(JSON.parse(updated.report_json).v).toBe(2);
+    expect(updated.overall_verdict).toBe("Conditional");
+  });
+
+  it("getByItem — 존재하지 않는 리포트 null", async () => {
+    const result = await svc.getByItem("nonexistent");
+    expect(result).toBeNull();
+  });
+
+  it("setTeamDecision — 팀 결정 갱신", async () => {
+    await svc.upsert(itemId, orgId, {
+      reportJson: {},
+      overallVerdict: "Go",
+      teamDecision: null,
+    });
+
+    await svc.setTeamDecision(itemId, "Go");
+    const report = await svc.getByItem(itemId);
+    expect(report!.team_decision).toBe("Go");
+  });
+
+  it("generateShareToken — 토큰 생성 + 조회", async () => {
+    await svc.upsert(itemId, orgId, {
+      reportJson: {},
+      overallVerdict: null,
+      teamDecision: null,
+    });
+
+    const token = await svc.generateShareToken(itemId);
+    expect(token).toBeTruthy();
+    expect(token.length).toBe(64); // 32 bytes hex
+
+    const found = await svc.getByShareToken(token);
+    expect(found).not.toBeNull();
+    expect(found!.item_id).toBe(itemId);
+  });
+});

--- a/packages/api/src/__tests__/helpers/mock-d1.ts
+++ b/packages/api/src/__tests__/helpers/mock-d1.ts
@@ -677,6 +677,64 @@ export class MockD1Database {
       CREATE INDEX IF NOT EXISTS idx_feedback_queue_status ON feedback_queue(status);
       CREATE INDEX IF NOT EXISTS idx_feedback_queue_org ON feedback_queue(org_id);
       CREATE UNIQUE INDEX IF NOT EXISTS idx_feedback_queue_issue ON feedback_queue(org_id, github_issue_number);
+
+      -- Sprint 154: F342 Discovery UI/UX v2 (4 tables)
+      CREATE TABLE IF NOT EXISTS ax_persona_configs (
+        id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+        org_id TEXT NOT NULL,
+        item_id TEXT NOT NULL,
+        persona_id TEXT NOT NULL,
+        persona_name TEXT NOT NULL,
+        persona_role TEXT NOT NULL DEFAULT '',
+        weights TEXT NOT NULL DEFAULT '{}',
+        context_json TEXT NOT NULL DEFAULT '{}',
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE(item_id, persona_id)
+      );
+
+      CREATE TABLE IF NOT EXISTS ax_persona_evals (
+        id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+        org_id TEXT NOT NULL,
+        item_id TEXT NOT NULL,
+        persona_id TEXT NOT NULL,
+        scores TEXT NOT NULL DEFAULT '{}',
+        verdict TEXT NOT NULL DEFAULT 'Conditional'
+          CHECK(verdict IN ('Go', 'Conditional', 'NoGo')),
+        summary TEXT NOT NULL DEFAULT '',
+        concern TEXT,
+        condition TEXT,
+        eval_model TEXT NOT NULL DEFAULT 'claude-sonnet-4-5-20250514',
+        eval_duration_ms INTEGER,
+        eval_cost_usd REAL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE(item_id, persona_id)
+      );
+
+      CREATE TABLE IF NOT EXISTS ax_discovery_reports (
+        id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+        org_id TEXT NOT NULL,
+        item_id TEXT NOT NULL,
+        report_json TEXT NOT NULL DEFAULT '{}',
+        overall_verdict TEXT DEFAULT NULL,
+        team_decision TEXT DEFAULT NULL,
+        shared_token TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE(item_id)
+      );
+
+      CREATE TABLE IF NOT EXISTS ax_team_reviews (
+        id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+        org_id TEXT NOT NULL,
+        item_id TEXT NOT NULL,
+        reviewer_id TEXT NOT NULL,
+        reviewer_name TEXT NOT NULL DEFAULT '',
+        decision TEXT NOT NULL CHECK(decision IN ('Go', 'Hold', 'Drop')),
+        comment TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE(item_id, reviewer_id)
+      );
     `);
     this.db.prepare("INSERT OR IGNORE INTO organizations (id, name, slug) VALUES (?, ?, ?)").run("org_test", "Test Org", "test");
   }

--- a/packages/api/src/__tests__/persona-configs.test.ts
+++ b/packages/api/src/__tests__/persona-configs.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Sprint 154: F342 PersonaConfigService + Route Tests
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { createMockD1 } from "./helpers/mock-d1.js";
+import { PersonaConfigService } from "../services/persona-config-service.js";
+
+describe("PersonaConfigService", () => {
+  let db: ReturnType<typeof createMockD1>;
+  let svc: PersonaConfigService;
+  const orgId = "org_test";
+  const itemId = "item_001";
+
+  beforeEach(() => {
+    db = createMockD1();
+    svc = new PersonaConfigService(db as unknown as D1Database);
+    // biz_items FK용 stub
+    (db as any).db.prepare("INSERT OR IGNORE INTO biz_items (id, title, created_by) VALUES (?, ?, ?)").run(itemId, "Test Item", "user1");
+  });
+
+  it("initDefaults — 8인 페르소나 시딩", async () => {
+    const count = await svc.initDefaults(itemId, orgId);
+    expect(count).toBe(8);
+
+    const configs = await svc.getByItem(itemId);
+    expect(configs).toHaveLength(8);
+    expect(configs[0]!.persona_id).toBeDefined();
+    expect(configs[0]!.org_id).toBe(orgId);
+  });
+
+  it("initDefaults 중복 호출 시 추가 삽입 없음", async () => {
+    await svc.initDefaults(itemId, orgId);
+    const count2 = await svc.initDefaults(itemId, orgId);
+    expect(count2).toBe(0);
+
+    const configs = await svc.getByItem(itemId);
+    expect(configs).toHaveLength(8);
+  });
+
+  it("upsert — 신규 페르소나 추가", async () => {
+    const config = await svc.upsert(itemId, orgId, {
+      personaId: "custom",
+      personaName: "커스텀 전문가",
+      personaRole: "도메인 전문가",
+      weights: {
+        strategic_fit: 20,
+        market_potential: 15,
+        technical_feasibility: 15,
+        financial_viability: 15,
+        competitive_advantage: 10,
+        risk_assessment: 15,
+        team_readiness: 10,
+      },
+      contextJson: { focus: "AI" },
+    });
+
+    expect(config.persona_id).toBe("custom");
+    expect(config.persona_name).toBe("커스텀 전문가");
+    expect(JSON.parse(config.weights).strategic_fit).toBe(20);
+  });
+
+  it("upsert — 기존 페르소나 업데이트", async () => {
+    await svc.initDefaults(itemId, orgId);
+
+    const updated = await svc.upsert(itemId, orgId, {
+      personaId: "strategy",
+      personaName: "전략담당 (수정)",
+      personaRole: "수정된 역할",
+      weights: {
+        strategic_fit: 30,
+        market_potential: 10,
+        technical_feasibility: 10,
+        financial_viability: 10,
+        competitive_advantage: 15,
+        risk_assessment: 15,
+        team_readiness: 10,
+      },
+      contextJson: {},
+    });
+
+    expect(updated.persona_name).toBe("전략담당 (수정)");
+    expect(JSON.parse(updated.weights).strategic_fit).toBe(30);
+  });
+
+  it("updateWeights — 가중치만 변경", async () => {
+    await svc.initDefaults(itemId, orgId);
+    await svc.updateWeights(itemId, "strategy", {
+      strategic_fit: 50,
+      market_potential: 5,
+      technical_feasibility: 5,
+      financial_viability: 10,
+      competitive_advantage: 10,
+      risk_assessment: 10,
+      team_readiness: 10,
+    });
+
+    const configs = await svc.getByItem(itemId);
+    const strategy = configs.find((c) => c.persona_id === "strategy");
+    expect(JSON.parse(strategy!.weights).strategic_fit).toBe(50);
+  });
+});

--- a/packages/api/src/__tests__/persona-evals.test.ts
+++ b/packages/api/src/__tests__/persona-evals.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Sprint 154: F342 PersonaEvalService Tests
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { createMockD1 } from "./helpers/mock-d1.js";
+import { PersonaEvalService } from "../services/persona-eval-service.js";
+
+describe("PersonaEvalService", () => {
+  let db: ReturnType<typeof createMockD1>;
+  let svc: PersonaEvalService;
+  const orgId = "org_test";
+  const itemId = "item_002";
+
+  const makeScores = () => ({
+    strategic_fit: 80,
+    market_potential: 70,
+    technical_feasibility: 90,
+    financial_viability: 60,
+    competitive_advantage: 75,
+    risk_assessment: 65,
+    team_readiness: 85,
+  });
+
+  beforeEach(() => {
+    db = createMockD1();
+    svc = new PersonaEvalService(db as unknown as D1Database);
+    (db as any).db.prepare("INSERT OR IGNORE INTO biz_items (id, title, created_by) VALUES (?, ?, ?)").run(itemId, "Test Item", "user1");
+  });
+
+  it("save — 평가 결과 저장", async () => {
+    const result = await svc.save(itemId, orgId, {
+      personaId: "strategy",
+      scores: makeScores(),
+      verdict: "Go",
+      summary: "전략적으로 적합한 아이템",
+      concern: null,
+      condition: null,
+      evalModel: "claude-sonnet-4-5-20250514",
+    });
+
+    expect(result.persona_id).toBe("strategy");
+    expect(result.verdict).toBe("Go");
+    expect(result.summary).toBe("전략적으로 적합한 아이템");
+  });
+
+  it("save — 동일 persona 재평가 시 업데이트", async () => {
+    await svc.save(itemId, orgId, {
+      personaId: "strategy",
+      scores: makeScores(),
+      verdict: "Go",
+      summary: "v1",
+    });
+
+    const updated = await svc.save(itemId, orgId, {
+      personaId: "strategy",
+      scores: makeScores(),
+      verdict: "Conditional",
+      summary: "v2 — 조건부",
+      concern: "시장 진입 타이밍",
+      condition: "Q3 전 출시 필수",
+    });
+
+    expect(updated.verdict).toBe("Conditional");
+    expect(updated.summary).toBe("v2 — 조건부");
+
+    const all = await svc.getByItem(itemId);
+    expect(all).toHaveLength(1);
+  });
+
+  it("getOverallVerdict — 다수결 판정", async () => {
+    // 5 Go, 2 Conditional, 1 NoGo → Go
+    const personas = ["strategy", "sales", "ap-biz", "ai-tech", "finance", "security", "partner", "product"];
+    const verdicts: Array<"Go" | "Conditional" | "NoGo"> = ["Go", "Go", "Go", "Go", "Go", "Conditional", "Conditional", "NoGo"];
+
+    for (let i = 0; i < 8; i++) {
+      await svc.save(itemId, orgId, {
+        personaId: personas[i]!,
+        scores: makeScores(),
+        verdict: verdicts[i]!,
+        summary: `${personas[i]} 평가`,
+        concern: null,
+        condition: null,
+      });
+    }
+
+    const result = await svc.getOverallVerdict(itemId);
+    expect(result.verdict).toBe("Go");
+    expect(result.go).toBe(5);
+    expect(result.conditional).toBe(2);
+    expect(result.noGo).toBe(1);
+  });
+
+  it("getOverallVerdict — NoGo 과반 시 NoGo", async () => {
+    const personas = ["strategy", "sales", "finance"];
+    for (const p of personas) {
+      await svc.save(itemId, orgId, {
+        personaId: p,
+        scores: makeScores(),
+        verdict: p === "sales" ? "Go" : "NoGo",
+        summary: `${p} 평가`,
+        concern: null,
+        condition: null,
+      });
+    }
+
+    const result = await svc.getOverallVerdict(itemId);
+    expect(result.verdict).toBe("NoGo");
+  });
+
+  it("getOverallVerdict — 빈 평가 시 Conditional", async () => {
+    const result = await svc.getOverallVerdict(itemId);
+    expect(result.verdict).toBe("Conditional");
+  });
+});

--- a/packages/api/src/__tests__/team-reviews.test.ts
+++ b/packages/api/src/__tests__/team-reviews.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Sprint 154: F342 TeamReviews Route Tests
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { createMockD1 } from "./helpers/mock-d1.js";
+
+describe("TeamReviews (direct DB)", () => {
+  let db: ReturnType<typeof createMockD1>;
+  const orgId = "org_test";
+  const itemId = "item_004";
+
+  function generateId(): string {
+    return Math.random().toString(36).slice(2, 18).padEnd(16, "0");
+  }
+
+  beforeEach(() => {
+    db = createMockD1();
+    (db as any).db.prepare("INSERT OR IGNORE INTO biz_items (id, title, created_by) VALUES (?, ?, ?)").run(itemId, "Test Item", "user1");
+  });
+
+  it("투표 제출 — Go", async () => {
+    const id = generateId();
+    await db
+      .prepare(
+        `INSERT INTO ax_team_reviews (id, org_id, item_id, reviewer_id, reviewer_name, decision, comment)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(id, orgId, itemId, "user1", "서민원", "Go", "좋은 아이템")
+      .run();
+
+    const result = await db
+      .prepare("SELECT * FROM ax_team_reviews WHERE item_id = ?")
+      .bind(itemId)
+      .all();
+
+    expect(result.results).toHaveLength(1);
+    expect((result.results[0] as any).decision).toBe("Go");
+    expect((result.results[0] as any).reviewer_name).toBe("서민원");
+  });
+
+  it("중복 투표 — upsert로 업데이트", async () => {
+    const id1 = generateId();
+    await db
+      .prepare(
+        `INSERT INTO ax_team_reviews (id, org_id, item_id, reviewer_id, reviewer_name, decision, comment)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(id1, orgId, itemId, "user1", "서민원", "Go", "1차 투표")
+      .run();
+
+    const id2 = generateId();
+    await db
+      .prepare(
+        `INSERT INTO ax_team_reviews (id, org_id, item_id, reviewer_id, reviewer_name, decision, comment)
+         VALUES (?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(item_id, reviewer_id) DO UPDATE SET
+           decision = excluded.decision,
+           comment = excluded.comment`,
+      )
+      .bind(id2, orgId, itemId, "user1", "서민원", "Hold", "재고 필요")
+      .run();
+
+    const result = await db
+      .prepare("SELECT * FROM ax_team_reviews WHERE item_id = ? AND reviewer_id = ?")
+      .bind(itemId, "user1")
+      .first();
+
+    expect((result as any).decision).toBe("Hold");
+    expect((result as any).comment).toBe("재고 필요");
+  });
+
+  it("투표 집계 — GROUP BY", async () => {
+    const voters = [
+      { id: "user1", name: "서민원", decision: "Go" },
+      { id: "user2", name: "김기욱", decision: "Go" },
+      { id: "user3", name: "김정원", decision: "Hold" },
+    ];
+
+    for (const v of voters) {
+      const id = generateId();
+      await db
+        .prepare(
+          `INSERT INTO ax_team_reviews (id, org_id, item_id, reviewer_id, reviewer_name, decision)
+           VALUES (?, ?, ?, ?, ?, ?)`,
+        )
+        .bind(id, orgId, itemId, v.id, v.name, v.decision)
+        .run();
+    }
+
+    const result = await db
+      .prepare("SELECT decision, COUNT(*) as count FROM ax_team_reviews WHERE item_id = ? GROUP BY decision")
+      .bind(itemId)
+      .all<{ decision: string; count: number }>();
+
+    const summary: Record<string, number> = {};
+    for (const row of result.results) {
+      summary[row.decision] = row.count;
+    }
+
+    expect(summary.Go).toBe(2);
+    expect(summary.Hold).toBe(1);
+  });
+});

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -118,6 +118,11 @@ import { taskStateRoute } from "./routes/task-state.js";
 import { executionEventsRoute } from "./routes/execution-events.js";
 // Sprint 150: Orchestration Loop (F335, Phase 14)
 import { orchestrationRoute } from "./routes/orchestration.js";
+// Sprint 154: Discovery UI/UX v2 — 페르소나 설정/평가 + 리포트 + 팀 검토 (F342)
+import { personaConfigsRoute } from "./routes/persona-configs.js";
+import { personaEvalsRoute } from "./routes/persona-evals.js";
+import { discoveryReportsRoute } from "./routes/discovery-reports.js";
+import { teamReviewsRoute } from "./routes/team-reviews.js";
 import { handleScheduled } from "./scheduled.js";
 import { authMiddleware } from "./middleware/auth.js";
 import { piiMaskerMiddleware } from "./middleware/pii-masker.middleware.js";
@@ -397,6 +402,12 @@ app.route("/api", taskStateRoute);
 app.route("/api", executionEventsRoute);
 // Sprint 150: Orchestration Loop (F335, Phase 14)
 app.route("/api", orchestrationRoute);
+
+// Sprint 154: Discovery UI/UX v2 (F342)
+app.route("/api", personaConfigsRoute);
+app.route("/api", personaEvalsRoute);
+app.route("/api", discoveryReportsRoute);
+app.route("/api", teamReviewsRoute);
 
 // Sprint 47: PII masker middleware — AI API 경로에만 적용
 app.use("/api/agents/*", piiMaskerMiddleware);

--- a/packages/api/src/db/migrations/0098_persona_configs.sql
+++ b/packages/api/src/db/migrations/0098_persona_configs.sql
@@ -1,0 +1,17 @@
+-- Sprint 154: F342 페르소나 설정 — 8인 AI 페르소나별 가중치/맥락
+CREATE TABLE IF NOT EXISTS ax_persona_configs (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  org_id TEXT NOT NULL,
+  item_id TEXT NOT NULL REFERENCES biz_items(id) ON DELETE CASCADE,
+  persona_id TEXT NOT NULL,
+  persona_name TEXT NOT NULL,
+  persona_role TEXT NOT NULL DEFAULT '',
+  weights TEXT NOT NULL DEFAULT '{}',
+  context_json TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(item_id, persona_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_apc_item ON ax_persona_configs(item_id);
+CREATE INDEX IF NOT EXISTS idx_apc_org ON ax_persona_configs(org_id);

--- a/packages/api/src/db/migrations/0099_persona_evals.sql
+++ b/packages/api/src/db/migrations/0099_persona_evals.sql
@@ -1,0 +1,22 @@
+-- Sprint 154: F342 페르소나 평가 결과 — 페르소나별 7축 점수 + 판정
+CREATE TABLE IF NOT EXISTS ax_persona_evals (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  org_id TEXT NOT NULL,
+  item_id TEXT NOT NULL REFERENCES biz_items(id) ON DELETE CASCADE,
+  persona_id TEXT NOT NULL,
+  scores TEXT NOT NULL DEFAULT '{}',
+  verdict TEXT NOT NULL DEFAULT 'Conditional'
+    CHECK(verdict IN ('Go', 'Conditional', 'NoGo')),
+  summary TEXT NOT NULL DEFAULT '',
+  concern TEXT,
+  condition TEXT,
+  eval_model TEXT NOT NULL DEFAULT 'claude-sonnet-4-5-20250514',
+  eval_duration_ms INTEGER,
+  eval_cost_usd REAL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(item_id, persona_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ape_item ON ax_persona_evals(item_id);
+CREATE INDEX IF NOT EXISTS idx_ape_org ON ax_persona_evals(org_id);
+CREATE INDEX IF NOT EXISTS idx_ape_verdict ON ax_persona_evals(verdict);

--- a/packages/api/src/db/migrations/0100_discovery_reports.sql
+++ b/packages/api/src/db/migrations/0100_discovery_reports.sql
@@ -1,0 +1,19 @@
+-- Sprint 154: F342 발굴 완료 리포트 — 9탭 데이터 + 종합 판정 + 공유 토큰
+CREATE TABLE IF NOT EXISTS ax_discovery_reports (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  org_id TEXT NOT NULL,
+  item_id TEXT NOT NULL REFERENCES biz_items(id) ON DELETE CASCADE,
+  report_json TEXT NOT NULL DEFAULT '{}',
+  overall_verdict TEXT DEFAULT NULL
+    CHECK(overall_verdict IN ('Go', 'Conditional', 'NoGo')),
+  team_decision TEXT DEFAULT NULL
+    CHECK(team_decision IN ('Go', 'Hold', 'Drop')),
+  shared_token TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(item_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_adr_item ON ax_discovery_reports(item_id);
+CREATE INDEX IF NOT EXISTS idx_adr_org ON ax_discovery_reports(org_id);
+CREATE INDEX IF NOT EXISTS idx_adr_shared ON ax_discovery_reports(shared_token);

--- a/packages/api/src/db/migrations/0101_team_reviews.sql
+++ b/packages/api/src/db/migrations/0101_team_reviews.sql
@@ -1,0 +1,16 @@
+-- Sprint 154: F342 팀 검토 기록 — Go/Hold/Drop 투표 + 코멘트
+CREATE TABLE IF NOT EXISTS ax_team_reviews (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  org_id TEXT NOT NULL,
+  item_id TEXT NOT NULL REFERENCES biz_items(id) ON DELETE CASCADE,
+  reviewer_id TEXT NOT NULL,
+  reviewer_name TEXT NOT NULL DEFAULT '',
+  decision TEXT NOT NULL CHECK(decision IN ('Go', 'Hold', 'Drop')),
+  comment TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(item_id, reviewer_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_atr_item ON ax_team_reviews(item_id);
+CREATE INDEX IF NOT EXISTS idx_atr_org ON ax_team_reviews(org_id);
+CREATE INDEX IF NOT EXISTS idx_atr_reviewer ON ax_team_reviews(reviewer_id);

--- a/packages/api/src/routes/discovery-reports.ts
+++ b/packages/api/src/routes/discovery-reports.ts
@@ -1,0 +1,49 @@
+/**
+ * Sprint 154: F342 DiscoveryReports Route — 발굴 완료 리포트 관리
+ */
+import { Hono } from "hono";
+import type { Env } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import { DiscoveryReportService } from "../services/discovery-report-service.js";
+import { UpsertDiscoveryReportSchema } from "../schemas/discovery-report-schema.js";
+
+export const discoveryReportsRoute = new Hono<{
+  Bindings: Env;
+  Variables: TenantVariables;
+}>();
+
+// GET /ax-bd/discovery-reports/:itemId — 리포트 조회
+discoveryReportsRoute.get("/ax-bd/discovery-reports/:itemId", async (c) => {
+  const svc = new DiscoveryReportService(c.env.DB);
+  const report = await svc.getByItem(c.req.param("itemId"));
+  if (!report) {
+    return c.json({ error: "Report not found" }, 404);
+  }
+  return c.json({ data: report });
+});
+
+// PUT /ax-bd/discovery-reports/:itemId — 리포트 생성/갱신
+discoveryReportsRoute.put("/ax-bd/discovery-reports/:itemId", async (c) => {
+  const body = await c.req.json();
+  const parsed = UpsertDiscoveryReportSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new DiscoveryReportService(c.env.DB);
+  const orgId = c.get("orgId");
+  const report = await svc.upsert(c.req.param("itemId"), orgId, parsed.data);
+  return c.json({ data: report });
+});
+
+// POST /ax-bd/discovery-reports/:itemId/share — 공유 토큰 생성
+discoveryReportsRoute.post("/ax-bd/discovery-reports/:itemId/share", async (c) => {
+  const svc = new DiscoveryReportService(c.env.DB);
+  const report = await svc.getByItem(c.req.param("itemId"));
+  if (!report) {
+    return c.json({ error: "Report not found" }, 404);
+  }
+
+  const token = await svc.generateShareToken(c.req.param("itemId"));
+  return c.json({ data: { sharedToken: token } }, 201);
+});

--- a/packages/api/src/routes/persona-configs.ts
+++ b/packages/api/src/routes/persona-configs.ts
@@ -1,0 +1,58 @@
+/**
+ * Sprint 154: F342 PersonaConfigs Route — 페르소나 설정 CRUD
+ */
+import { Hono } from "hono";
+import type { Env } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import { PersonaConfigService } from "../services/persona-config-service.js";
+import { UpsertPersonaConfigSchema, UpdateWeightsSchema } from "../schemas/persona-config-schema.js";
+
+export const personaConfigsRoute = new Hono<{
+  Bindings: Env;
+  Variables: TenantVariables;
+}>();
+
+// GET /ax-bd/persona-configs/:itemId — 아이템별 페르소나 설정 조회
+personaConfigsRoute.get("/ax-bd/persona-configs/:itemId", async (c) => {
+  const svc = new PersonaConfigService(c.env.DB);
+  const configs = await svc.getByItem(c.req.param("itemId"));
+  return c.json({ data: configs });
+});
+
+// POST /ax-bd/persona-configs/:itemId/init — 기본 8인 시딩
+personaConfigsRoute.post("/ax-bd/persona-configs/:itemId/init", async (c) => {
+  const svc = new PersonaConfigService(c.env.DB);
+  const orgId = c.get("orgId");
+  const count = await svc.initDefaults(c.req.param("itemId"), orgId);
+  return c.json({ message: `${count} personas initialized`, count }, 201);
+});
+
+// PUT /ax-bd/persona-configs/:itemId/:personaId — 개별 설정 수정
+personaConfigsRoute.put("/ax-bd/persona-configs/:itemId/:personaId", async (c) => {
+  const body = await c.req.json();
+  const parsed = UpsertPersonaConfigSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new PersonaConfigService(c.env.DB);
+  const orgId = c.get("orgId");
+  const config = await svc.upsert(c.req.param("itemId"), orgId, {
+    ...parsed.data,
+    personaId: c.req.param("personaId"),
+  });
+  return c.json({ data: config });
+});
+
+// PATCH /ax-bd/persona-configs/:itemId/:personaId/weights — 가중치만 수정
+personaConfigsRoute.patch("/ax-bd/persona-configs/:itemId/:personaId/weights", async (c) => {
+  const body = await c.req.json();
+  const parsed = UpdateWeightsSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new PersonaConfigService(c.env.DB);
+  await svc.updateWeights(c.req.param("itemId"), c.req.param("personaId"), parsed.data.weights);
+  return c.json({ message: "Weights updated" });
+});

--- a/packages/api/src/routes/persona-evals.ts
+++ b/packages/api/src/routes/persona-evals.ts
@@ -1,0 +1,41 @@
+/**
+ * Sprint 154: F342 PersonaEvals Route — 페르소나 평가 결과 관리
+ */
+import { Hono } from "hono";
+import type { Env } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import { PersonaEvalService } from "../services/persona-eval-service.js";
+import { SavePersonaEvalSchema } from "../schemas/persona-eval-schema.js";
+
+export const personaEvalsRoute = new Hono<{
+  Bindings: Env;
+  Variables: TenantVariables;
+}>();
+
+// GET /ax-bd/persona-evals/:itemId — 아이템별 평가 결과 조회
+personaEvalsRoute.get("/ax-bd/persona-evals/:itemId", async (c) => {
+  const svc = new PersonaEvalService(c.env.DB);
+  const evals = await svc.getByItem(c.req.param("itemId"));
+  return c.json({ data: evals });
+});
+
+// POST /ax-bd/persona-evals/:itemId — 평가 결과 저장 (단건)
+personaEvalsRoute.post("/ax-bd/persona-evals/:itemId", async (c) => {
+  const body = await c.req.json();
+  const parsed = SavePersonaEvalSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new PersonaEvalService(c.env.DB);
+  const orgId = c.get("orgId");
+  const result = await svc.save(c.req.param("itemId"), orgId, parsed.data);
+  return c.json({ data: result }, 201);
+});
+
+// GET /ax-bd/persona-evals/:itemId/verdict — 종합 판정 조회
+personaEvalsRoute.get("/ax-bd/persona-evals/:itemId/verdict", async (c) => {
+  const svc = new PersonaEvalService(c.env.DB);
+  const verdict = await svc.getOverallVerdict(c.req.param("itemId"));
+  return c.json({ data: verdict });
+});

--- a/packages/api/src/routes/team-reviews.ts
+++ b/packages/api/src/routes/team-reviews.ts
@@ -1,0 +1,74 @@
+/**
+ * Sprint 154: F342 TeamReviews Route — Go/Hold/Drop 투표 + 집계
+ */
+import { Hono } from "hono";
+import type { Env } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import { SubmitTeamReviewSchema } from "../schemas/team-review-schema.js";
+
+export const teamReviewsRoute = new Hono<{
+  Bindings: Env;
+  Variables: TenantVariables;
+}>();
+
+function generateId(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+// GET /ax-bd/team-reviews/:itemId — 아이템별 투표 조회
+teamReviewsRoute.get("/ax-bd/team-reviews/:itemId", async (c) => {
+  const result = await c.env.DB
+    .prepare("SELECT * FROM ax_team_reviews WHERE item_id = ? ORDER BY created_at DESC")
+    .bind(c.req.param("itemId"))
+    .all();
+  return c.json({ data: result.results });
+});
+
+// POST /ax-bd/team-reviews/:itemId — 투표 제출 (upsert)
+teamReviewsRoute.post("/ax-bd/team-reviews/:itemId", async (c) => {
+  const body = await c.req.json();
+  const parsed = SubmitTeamReviewSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const itemId = c.req.param("itemId");
+  const reviewerId = c.get("userId");
+  const reviewerName = "";
+  const orgId = c.get("orgId");
+  const id = generateId();
+
+  await c.env.DB
+    .prepare(
+      `INSERT INTO ax_team_reviews (id, org_id, item_id, reviewer_id, reviewer_name, decision, comment)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(item_id, reviewer_id) DO UPDATE SET
+         decision = excluded.decision,
+         comment = excluded.comment,
+         created_at = datetime('now')`,
+    )
+    .bind(id, orgId, itemId, reviewerId, reviewerName, parsed.data.decision, parsed.data.comment)
+    .run();
+
+  return c.json({ message: "Vote submitted" }, 201);
+});
+
+// GET /ax-bd/team-reviews/:itemId/summary — 투표 집계
+teamReviewsRoute.get("/ax-bd/team-reviews/:itemId/summary", async (c) => {
+  const result = await c.env.DB
+    .prepare("SELECT decision, COUNT(*) as count FROM ax_team_reviews WHERE item_id = ? GROUP BY decision")
+    .bind(c.req.param("itemId"))
+    .all<{ decision: string; count: number }>();
+
+  const summary: Record<string, number> = { Go: 0, Hold: 0, Drop: 0 };
+  for (const row of result.results) {
+    summary[row.decision] = row.count;
+  }
+
+  const total = (summary.Go ?? 0) + (summary.Hold ?? 0) + (summary.Drop ?? 0);
+  return c.json({ data: { ...summary, total } });
+});

--- a/packages/api/src/schemas/discovery-report-schema.ts
+++ b/packages/api/src/schemas/discovery-report-schema.ts
@@ -1,0 +1,12 @@
+/**
+ * Sprint 154: F342 발굴 완료 리포트 스키마
+ */
+import { z } from "zod";
+
+export const UpsertDiscoveryReportSchema = z.object({
+  reportJson: z.record(z.unknown()).default({}),
+  overallVerdict: z.enum(["Go", "Conditional", "NoGo"]).nullable().default(null),
+  teamDecision: z.enum(["Go", "Hold", "Drop"]).nullable().default(null),
+});
+
+export type UpsertDiscoveryReportInput = z.infer<typeof UpsertDiscoveryReportSchema>;

--- a/packages/api/src/schemas/persona-config-schema.ts
+++ b/packages/api/src/schemas/persona-config-schema.ts
@@ -1,0 +1,28 @@
+/**
+ * Sprint 154: F342 페르소나 설정 스키마
+ */
+import { z } from "zod";
+
+export const PersonaWeightsSchema = z.object({
+  strategic_fit: z.number().min(0).max(100),
+  market_potential: z.number().min(0).max(100),
+  technical_feasibility: z.number().min(0).max(100),
+  financial_viability: z.number().min(0).max(100),
+  competitive_advantage: z.number().min(0).max(100),
+  risk_assessment: z.number().min(0).max(100),
+  team_readiness: z.number().min(0).max(100),
+});
+
+export const UpsertPersonaConfigSchema = z.object({
+  personaId: z.string().min(1),
+  personaName: z.string().min(1),
+  personaRole: z.string().default(""),
+  weights: PersonaWeightsSchema,
+  contextJson: z.record(z.unknown()).default({}),
+});
+
+export type UpsertPersonaConfigInput = z.infer<typeof UpsertPersonaConfigSchema>;
+
+export const UpdateWeightsSchema = z.object({
+  weights: PersonaWeightsSchema,
+});

--- a/packages/api/src/schemas/persona-eval-schema.ts
+++ b/packages/api/src/schemas/persona-eval-schema.ts
@@ -1,0 +1,19 @@
+/**
+ * Sprint 154: F342 페르소나 평가 결과 스키마
+ */
+import { z } from "zod";
+import { PersonaWeightsSchema } from "./persona-config-schema.js";
+
+export const SavePersonaEvalSchema = z.object({
+  personaId: z.string().min(1),
+  scores: PersonaWeightsSchema,
+  verdict: z.enum(["Go", "Conditional", "NoGo"]),
+  summary: z.string().min(1),
+  concern: z.string().nullable().optional(),
+  condition: z.string().nullable().optional(),
+  evalModel: z.string().optional(),
+  evalDurationMs: z.number().int().optional(),
+  evalCostUsd: z.number().optional(),
+});
+
+export type SavePersonaEvalInput = z.infer<typeof SavePersonaEvalSchema>;

--- a/packages/api/src/schemas/team-review-schema.ts
+++ b/packages/api/src/schemas/team-review-schema.ts
@@ -1,0 +1,11 @@
+/**
+ * Sprint 154: F342 팀 검토 투표 스키마
+ */
+import { z } from "zod";
+
+export const SubmitTeamReviewSchema = z.object({
+  decision: z.enum(["Go", "Hold", "Drop"]),
+  comment: z.string().nullable().default(null),
+});
+
+export type SubmitTeamReviewInput = z.infer<typeof SubmitTeamReviewSchema>;

--- a/packages/api/src/services/discovery-report-service.ts
+++ b/packages/api/src/services/discovery-report-service.ts
@@ -1,0 +1,86 @@
+/**
+ * Sprint 154: F342 DiscoveryReportService — 발굴 완료 리포트 관리
+ */
+import type { UpsertDiscoveryReportInput } from "../schemas/discovery-report-schema.js";
+
+interface DiscoveryReportRow {
+  id: string;
+  org_id: string;
+  item_id: string;
+  report_json: string;
+  overall_verdict: string | null;
+  team_decision: string | null;
+  shared_token: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+function generateId(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function generateToken(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export class DiscoveryReportService {
+  constructor(private db: D1Database) {}
+
+  async getByItem(itemId: string): Promise<DiscoveryReportRow | null> {
+    return this.db
+      .prepare("SELECT * FROM ax_discovery_reports WHERE item_id = ?")
+      .bind(itemId)
+      .first<DiscoveryReportRow>();
+  }
+
+  async upsert(itemId: string, orgId: string, input: UpsertDiscoveryReportInput): Promise<DiscoveryReportRow> {
+    const id = generateId();
+    const reportJson = JSON.stringify(input.reportJson);
+
+    await this.db
+      .prepare(
+        `INSERT INTO ax_discovery_reports (id, org_id, item_id, report_json, overall_verdict, team_decision)
+         VALUES (?, ?, ?, ?, ?, ?)
+         ON CONFLICT(item_id) DO UPDATE SET
+           report_json = excluded.report_json,
+           overall_verdict = excluded.overall_verdict,
+           team_decision = excluded.team_decision,
+           updated_at = datetime('now')`,
+      )
+      .bind(id, orgId, itemId, reportJson, input.overallVerdict ?? null, input.teamDecision ?? null)
+      .run();
+
+    return (await this.getByItem(itemId))!;
+  }
+
+  async setTeamDecision(itemId: string, decision: string): Promise<void> {
+    await this.db
+      .prepare("UPDATE ax_discovery_reports SET team_decision = ?, updated_at = datetime('now') WHERE item_id = ?")
+      .bind(decision, itemId)
+      .run();
+  }
+
+  async generateShareToken(itemId: string): Promise<string> {
+    const token = generateToken();
+    await this.db
+      .prepare("UPDATE ax_discovery_reports SET shared_token = ?, updated_at = datetime('now') WHERE item_id = ?")
+      .bind(token, itemId)
+      .run();
+    return token;
+  }
+
+  async getByShareToken(token: string): Promise<DiscoveryReportRow | null> {
+    return this.db
+      .prepare("SELECT * FROM ax_discovery_reports WHERE shared_token = ?")
+      .bind(token)
+      .first<DiscoveryReportRow>();
+  }
+}

--- a/packages/api/src/services/persona-config-service.ts
+++ b/packages/api/src/services/persona-config-service.ts
@@ -1,0 +1,111 @@
+/**
+ * Sprint 154: F342 PersonaConfigService — 페르소나 가중치/맥락 관리
+ */
+import type { UpsertPersonaConfigInput } from "../schemas/persona-config-schema.js";
+
+interface PersonaConfigRow {
+  id: string;
+  org_id: string;
+  item_id: string;
+  persona_id: string;
+  persona_name: string;
+  persona_role: string;
+  weights: string;
+  context_json: string;
+  created_at: string;
+  updated_at: string;
+}
+
+function generateId(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+const DEFAULT_WEIGHTS = JSON.stringify({
+  strategic_fit: 20,
+  market_potential: 15,
+  technical_feasibility: 15,
+  financial_viability: 15,
+  competitive_advantage: 10,
+  risk_assessment: 15,
+  team_readiness: 10,
+});
+
+const DEFAULT_PERSONAS = [
+  { id: "strategy", name: "전략담당", role: "사업 전략 및 비전 평가" },
+  { id: "sales", name: "영업담당", role: "고객 접점 및 수주 가능성" },
+  { id: "ap-biz", name: "AP사업담당", role: "파트너십 및 서비스 확장성" },
+  { id: "ai-tech", name: "AI기술담당", role: "기술 실현 가능성 및 차별화" },
+  { id: "finance", name: "재무담당", role: "수익성 및 투자 효율" },
+  { id: "security", name: "보안담당", role: "보안/규제 리스크" },
+  { id: "partner", name: "파트너담당", role: "외부 파트너 생태계" },
+  { id: "product", name: "제품담당", role: "제품 완성도 및 사용자 경험" },
+];
+
+export class PersonaConfigService {
+  constructor(private db: D1Database) {}
+
+  async initDefaults(itemId: string, orgId: string): Promise<number> {
+    let count = 0;
+    for (const persona of DEFAULT_PERSONAS) {
+      const id = generateId();
+      const result = await this.db
+        .prepare(
+          `INSERT OR IGNORE INTO ax_persona_configs (id, org_id, item_id, persona_id, persona_name, persona_role, weights, context_json)
+           VALUES (?, ?, ?, ?, ?, ?, ?, '{}')`,
+        )
+        .bind(id, orgId, itemId, persona.id, persona.name, persona.role, DEFAULT_WEIGHTS)
+        .run();
+      if (result.meta.changes > 0) count++;
+    }
+    return count;
+  }
+
+  async getByItem(itemId: string): Promise<PersonaConfigRow[]> {
+    const result = await this.db
+      .prepare("SELECT * FROM ax_persona_configs WHERE item_id = ? ORDER BY persona_id")
+      .bind(itemId)
+      .all<PersonaConfigRow>();
+    return result.results;
+  }
+
+  async upsert(itemId: string, orgId: string, input: UpsertPersonaConfigInput): Promise<PersonaConfigRow> {
+    const id = generateId();
+    const weightsJson = JSON.stringify(input.weights);
+    const contextJson = JSON.stringify(input.contextJson);
+
+    await this.db
+      .prepare(
+        `INSERT INTO ax_persona_configs (id, org_id, item_id, persona_id, persona_name, persona_role, weights, context_json)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(item_id, persona_id) DO UPDATE SET
+           persona_name = excluded.persona_name,
+           persona_role = excluded.persona_role,
+           weights = excluded.weights,
+           context_json = excluded.context_json,
+           updated_at = datetime('now')`,
+      )
+      .bind(id, orgId, itemId, input.personaId, input.personaName, input.personaRole, weightsJson, contextJson)
+      .run();
+
+    const row = await this.db
+      .prepare("SELECT * FROM ax_persona_configs WHERE item_id = ? AND persona_id = ?")
+      .bind(itemId, input.personaId)
+      .first<PersonaConfigRow>();
+
+    return row!;
+  }
+
+  async updateWeights(itemId: string, personaId: string, weights: Record<string, number>): Promise<void> {
+    await this.db
+      .prepare(
+        `UPDATE ax_persona_configs SET weights = ?, updated_at = datetime('now')
+         WHERE item_id = ? AND persona_id = ?`,
+      )
+      .bind(JSON.stringify(weights), itemId, personaId)
+      .run();
+  }
+}

--- a/packages/api/src/services/persona-eval-service.ts
+++ b/packages/api/src/services/persona-eval-service.ts
@@ -1,0 +1,93 @@
+/**
+ * Sprint 154: F342 PersonaEvalService — 페르소나별 평가 결과 관리
+ */
+import type { SavePersonaEvalInput } from "../schemas/persona-eval-schema.js";
+
+interface PersonaEvalRow {
+  id: string;
+  org_id: string;
+  item_id: string;
+  persona_id: string;
+  scores: string;
+  verdict: string;
+  summary: string;
+  concern: string | null;
+  condition: string | null;
+  eval_model: string;
+  eval_duration_ms: number | null;
+  eval_cost_usd: number | null;
+  created_at: string;
+}
+
+function generateId(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export class PersonaEvalService {
+  constructor(private db: D1Database) {}
+
+  async getByItem(itemId: string): Promise<PersonaEvalRow[]> {
+    const result = await this.db
+      .prepare("SELECT * FROM ax_persona_evals WHERE item_id = ? ORDER BY persona_id")
+      .bind(itemId)
+      .all<PersonaEvalRow>();
+    return result.results;
+  }
+
+  async save(itemId: string, orgId: string, input: SavePersonaEvalInput): Promise<PersonaEvalRow> {
+    const id = generateId();
+    const scoresJson = JSON.stringify(input.scores);
+
+    await this.db
+      .prepare(
+        `INSERT INTO ax_persona_evals (id, org_id, item_id, persona_id, scores, verdict, summary, concern, condition, eval_model, eval_duration_ms, eval_cost_usd)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(item_id, persona_id) DO UPDATE SET
+           scores = excluded.scores,
+           verdict = excluded.verdict,
+           summary = excluded.summary,
+           concern = excluded.concern,
+           condition = excluded.condition,
+           eval_model = excluded.eval_model,
+           eval_duration_ms = excluded.eval_duration_ms,
+           eval_cost_usd = excluded.eval_cost_usd,
+           created_at = datetime('now')`,
+      )
+      .bind(
+        id, orgId, itemId,
+        input.personaId, scoresJson, input.verdict,
+        input.summary, input.concern ?? null, input.condition ?? null,
+        input.evalModel ?? "claude-sonnet-4-5-20250514", input.evalDurationMs ?? null, input.evalCostUsd ?? null,
+      )
+      .run();
+
+    const row = await this.db
+      .prepare("SELECT * FROM ax_persona_evals WHERE item_id = ? AND persona_id = ?")
+      .bind(itemId, input.personaId)
+      .first<PersonaEvalRow>();
+
+    return row!;
+  }
+
+  async getOverallVerdict(itemId: string): Promise<{ verdict: string; go: number; conditional: number; noGo: number }> {
+    const evals = await this.getByItem(itemId);
+    let go = 0, conditional = 0, noGo = 0;
+    for (const e of evals) {
+      if (e.verdict === "Go") go++;
+      else if (e.verdict === "Conditional") conditional++;
+      else noGo++;
+    }
+
+    let verdict: string;
+    if (evals.length === 0) verdict = "Conditional";
+    else if (noGo > evals.length / 2) verdict = "NoGo";
+    else if (go > evals.length / 2) verdict = "Go";
+    else verdict = "Conditional";
+
+    return { verdict, go, conditional, noGo };
+  }
+}

--- a/packages/shared/src/discovery-v2.ts
+++ b/packages/shared/src/discovery-v2.ts
@@ -1,0 +1,115 @@
+/**
+ * Sprint 154: F342 Discovery UI/UX v2 — 공유 타입 정의
+ */
+
+export interface PersonaWeights {
+  strategic_fit: number;
+  market_potential: number;
+  technical_feasibility: number;
+  financial_viability: number;
+  competitive_advantage: number;
+  risk_assessment: number;
+  team_readiness: number;
+}
+
+export interface PersonaConfig {
+  id: string;
+  orgId: string;
+  itemId: string;
+  personaId: string;
+  personaName: string;
+  personaRole: string;
+  weights: PersonaWeights;
+  contextJson: Record<string, unknown>;
+}
+
+export interface PersonaEval {
+  id: string;
+  orgId: string;
+  itemId: string;
+  personaId: string;
+  scores: PersonaWeights;
+  verdict: 'Go' | 'Conditional' | 'NoGo';
+  summary: string;
+  concern: string | null;
+  condition: string | null;
+}
+
+export interface DiscoveryReport {
+  id: string;
+  orgId: string;
+  itemId: string;
+  reportJson: Record<string, unknown>;
+  overallVerdict: 'Go' | 'Conditional' | 'NoGo' | null;
+  teamDecision: 'Go' | 'Hold' | 'Drop' | null;
+  sharedToken: string | null;
+}
+
+export interface TeamReview {
+  id: string;
+  orgId: string;
+  itemId: string;
+  reviewerId: string;
+  reviewerName: string;
+  decision: 'Go' | 'Hold' | 'Drop';
+  comment: string | null;
+}
+
+export type Intensity = 'core' | 'normal' | 'light';
+export type DiscoveryTypeV2 = 'I' | 'M' | 'P' | 'T' | 'S';
+
+/** 5유형×7단계 강도 매트릭스 — analysis-path-v82.ts와 동일, 프론트엔드용 */
+export const INTENSITY_MATRIX: Record<string, Record<DiscoveryTypeV2, Intensity>> = {
+  "2-1": { I: "light", M: "normal", P: "light", T: "core", S: "core" },
+  "2-2": { I: "core", M: "core", P: "core", T: "core", S: "light" },
+  "2-3": { I: "normal", M: "core", P: "core", T: "core", S: "core" },
+  "2-4": { I: "core", M: "normal", P: "core", T: "core", S: "core" },
+  "2-5": { I: "core", M: "core", P: "core", T: "core", S: "normal" },
+  "2-6": { I: "core", M: "core", P: "core", T: "normal", S: "normal" },
+  "2-7": { I: "normal", M: "normal", P: "core", T: "normal", S: "core" },
+};
+
+export const INTENSITY_LABELS: Record<Intensity, { symbol: string; label: string }> = {
+  core: { symbol: "★", label: "핵심" },
+  normal: { symbol: "○", label: "보통" },
+  light: { symbol: "△", label: "간소" },
+};
+
+export const DISCOVERY_TYPE_NAMES_V2: Record<DiscoveryTypeV2, string> = {
+  I: "아이디어형",
+  M: "시장·타겟형",
+  P: "고객문제형",
+  T: "기술형",
+  S: "기존서비스형",
+};
+
+export const DEFAULT_WEIGHTS: PersonaWeights = {
+  strategic_fit: 20,
+  market_potential: 15,
+  technical_feasibility: 15,
+  financial_viability: 15,
+  competitive_advantage: 10,
+  risk_assessment: 15,
+  team_readiness: 10,
+};
+
+export const DEFAULT_PERSONAS: Array<{ id: string; name: string; role: string }> = [
+  { id: "strategy", name: "전략담당", role: "사업 전략 및 비전 평가" },
+  { id: "sales", name: "영업담당", role: "고객 접점 및 수주 가능성" },
+  { id: "ap-biz", name: "AP사업담당", role: "파트너십 및 서비스 확장성" },
+  { id: "ai-tech", name: "AI기술담당", role: "기술 실현 가능성 및 차별화" },
+  { id: "finance", name: "재무담당", role: "수익성 및 투자 효율" },
+  { id: "security", name: "보안담당", role: "보안/규제 리스크" },
+  { id: "partner", name: "파트너담당", role: "외부 파트너 생태계" },
+  { id: "product", name: "제품담당", role: "제품 완성도 및 사용자 경험" },
+];
+
+export const WEIGHT_AXES = [
+  { key: "strategic_fit" as const, label: "전략 적합성" },
+  { key: "market_potential" as const, label: "시장 잠재력" },
+  { key: "technical_feasibility" as const, label: "기술 실현성" },
+  { key: "financial_viability" as const, label: "재무 건전성" },
+  { key: "competitive_advantage" as const, label: "경쟁 우위" },
+  { key: "risk_assessment" as const, label: "리스크 평가" },
+  { key: "team_readiness" as const, label: "팀 준비도" },
+] as const;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -310,3 +310,23 @@ export type {
   LoopStartParams,
   ExecutionEventRecord,
 } from './orchestration.js';
+
+// F342: Discovery UI/UX v2 types (Sprint 154, Phase 15)
+export {
+  INTENSITY_MATRIX,
+  INTENSITY_LABELS,
+  DISCOVERY_TYPE_NAMES_V2,
+  DEFAULT_WEIGHTS,
+  DEFAULT_PERSONAS,
+  WEIGHT_AXES,
+} from './discovery-v2.js';
+
+export type {
+  PersonaWeights,
+  PersonaConfig,
+  PersonaEval,
+  DiscoveryReport,
+  TeamReview,
+  Intensity,
+  DiscoveryTypeV2,
+} from './discovery-v2.js';

--- a/packages/web/src/components/feature/discovery/IntensityIndicator.tsx
+++ b/packages/web/src/components/feature/discovery/IntensityIndicator.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+export type IntensityLevel = "core" | "normal" | "light";
+
+interface IntensityIndicatorProps {
+  intensity: IntensityLevel;
+  size?: "sm" | "md";
+  showLabel?: boolean;
+}
+
+const INTENSITY_CONFIG: Record<IntensityLevel, { symbol: string; label: string; className: string }> = {
+  core: {
+    symbol: "★",
+    label: "핵심",
+    className: "bg-green-50 text-green-700 border-green-300",
+  },
+  normal: {
+    symbol: "○",
+    label: "보통",
+    className: "bg-blue-50 text-blue-700 border-blue-300",
+  },
+  light: {
+    symbol: "△",
+    label: "간소",
+    className: "bg-gray-50 text-gray-500 border-gray-300",
+  },
+};
+
+export default function IntensityIndicator({ intensity, size = "sm", showLabel = true }: IntensityIndicatorProps) {
+  const config = INTENSITY_CONFIG[intensity];
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 font-medium",
+        size === "sm" ? "text-[10px]" : "text-xs",
+        config.className,
+      )}
+      title={`${config.label} 분석`}
+    >
+      <span>{config.symbol}</span>
+      {showLabel && <span>{config.label}</span>}
+    </span>
+  );
+}

--- a/packages/web/src/components/feature/discovery/IntensityMatrix.tsx
+++ b/packages/web/src/components/feature/discovery/IntensityMatrix.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import type { IntensityLevel } from "./IntensityIndicator";
+
+interface IntensityMatrixProps {
+  discoveryType?: string;
+  compact?: boolean;
+}
+
+const TYPES = ["I", "M", "P", "T", "S"] as const;
+const TYPE_NAMES: Record<string, string> = {
+  I: "아이디어형",
+  M: "시장·타겟형",
+  P: "고객문제형",
+  T: "기술형",
+  S: "기존서비스형",
+};
+
+const STAGES = ["2-1", "2-2", "2-3", "2-4", "2-5", "2-6", "2-7"] as const;
+const STAGE_SHORT_NAMES: Record<string, string> = {
+  "2-1": "레퍼런스",
+  "2-2": "시장검증",
+  "2-3": "경쟁분석",
+  "2-4": "아이템도출",
+  "2-5": "선정(Gate)",
+  "2-6": "고객정의",
+  "2-7": "BM정의",
+};
+
+const MATRIX: Record<string, Record<string, IntensityLevel>> = {
+  "2-1": { I: "light", M: "normal", P: "light", T: "core", S: "core" },
+  "2-2": { I: "core", M: "core", P: "core", T: "core", S: "light" },
+  "2-3": { I: "normal", M: "core", P: "core", T: "core", S: "core" },
+  "2-4": { I: "core", M: "normal", P: "core", T: "core", S: "core" },
+  "2-5": { I: "core", M: "core", P: "core", T: "core", S: "normal" },
+  "2-6": { I: "core", M: "core", P: "core", T: "normal", S: "normal" },
+  "2-7": { I: "normal", M: "normal", P: "core", T: "normal", S: "core" },
+};
+
+const CELL_STYLES: Record<IntensityLevel, string> = {
+  core: "bg-green-100 text-green-800 font-bold",
+  normal: "bg-blue-50 text-blue-700",
+  light: "bg-gray-50 text-gray-400",
+};
+
+const CELL_SYMBOLS: Record<IntensityLevel, string> = {
+  core: "★",
+  normal: "○",
+  light: "△",
+};
+
+export default function IntensityMatrix({ discoveryType, compact = false }: IntensityMatrixProps) {
+  return (
+    <div className="overflow-x-auto">
+      <table className={cn("w-full border-collapse text-center", compact ? "text-[10px]" : "text-xs")}>
+        <thead>
+          <tr>
+            <th className="p-1 border bg-muted text-muted-foreground">단계</th>
+            {TYPES.map((type) => (
+              <th
+                key={type}
+                className={cn(
+                  "p-1 border bg-muted text-muted-foreground",
+                  discoveryType === type && "bg-primary/10 text-primary font-bold",
+                )}
+              >
+                {compact ? type : `${type} ${TYPE_NAMES[type]}`}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {STAGES.map((stage) => (
+            <tr key={stage}>
+              <td className="p-1 border text-left font-medium text-muted-foreground">
+                {compact ? stage : `${stage} ${STAGE_SHORT_NAMES[stage]}`}
+              </td>
+              {TYPES.map((type) => {
+                const intensity = MATRIX[stage][type];
+                const isHighlighted = discoveryType === type;
+                return (
+                  <td
+                    key={type}
+                    className={cn(
+                      "p-1 border",
+                      CELL_STYLES[intensity],
+                      isHighlighted && "ring-2 ring-primary/30",
+                    )}
+                  >
+                    {CELL_SYMBOLS[intensity]}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="flex gap-3 mt-2 text-[10px] text-muted-foreground">
+        <span>★ 핵심 — 추가 프롬프트 + 깊은 분석</span>
+        <span>○ 보통 — 표준 분석</span>
+        <span>△ 간소 — 스킵 가능</span>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/feature/discovery/OutputJsonViewer.tsx
+++ b/packages/web/src/components/feature/discovery/OutputJsonViewer.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { ChevronDown, ChevronRight, Copy, Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface OutputJsonViewerProps {
+  stageNum: string;
+  outputJson: unknown;
+  className?: string;
+}
+
+interface JsonSection {
+  key: string;
+  label: string;
+  value: unknown;
+}
+
+function extractSections(data: unknown): JsonSection[] {
+  if (!data || typeof data !== "object") return [];
+
+  const obj = data as Record<string, unknown>;
+  const sections: JsonSection[] = [];
+
+  const labelMap: Record<string, string> = {
+    title: "제목",
+    summary: "요약",
+    items: "항목",
+    analysis: "분석",
+    recommendations: "권장사항",
+    references: "레퍼런스",
+    market_size: "시장 규모",
+    tam: "TAM",
+    sam: "SAM",
+    som: "SOM",
+    competitors: "경쟁사",
+    strengths: "강점",
+    weaknesses: "약점",
+    opportunities: "기회",
+    threats: "위협",
+    pain_points: "Pain Points",
+    segments: "세그먼트",
+    persona: "페르소나",
+    business_model: "비즈니스 모델",
+    revenue: "수익 모델",
+    score: "점수",
+    verdict: "판정",
+  };
+
+  for (const [key, value] of Object.entries(obj)) {
+    sections.push({
+      key,
+      label: labelMap[key] ?? key,
+      value,
+    });
+  }
+
+  return sections;
+}
+
+function RenderValue({ value }: { value: unknown }) {
+  if (value === null || value === undefined) {
+    return <span className="text-muted-foreground italic">없음</span>;
+  }
+
+  if (typeof value === "string") {
+    return <p className="text-sm whitespace-pre-wrap">{value}</p>;
+  }
+
+  if (typeof value === "number") {
+    return <span className="text-sm font-mono font-bold">{value}</span>;
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return <span className="text-muted-foreground italic">빈 목록</span>;
+    if (typeof value[0] === "string") {
+      return (
+        <ul className="list-disc list-inside text-sm space-y-0.5">
+          {value.map((item, i) => (
+            <li key={i}>{String(item)}</li>
+          ))}
+        </ul>
+      );
+    }
+    return (
+      <pre className="text-xs bg-muted/50 p-2 rounded overflow-x-auto">
+        {JSON.stringify(value, null, 2)}
+      </pre>
+    );
+  }
+
+  if (typeof value === "object") {
+    return (
+      <pre className="text-xs bg-muted/50 p-2 rounded overflow-x-auto">
+        {JSON.stringify(value, null, 2)}
+      </pre>
+    );
+  }
+
+  return <span className="text-sm">{String(value)}</span>;
+}
+
+export default function OutputJsonViewer({ stageNum, outputJson, className }: OutputJsonViewerProps) {
+  const [rawMode, setRawMode] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const sections = extractSections(outputJson);
+  const hasStructure = sections.length > 0;
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(JSON.stringify(outputJson, null, 2));
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className={cn("rounded-lg border bg-card", className)}>
+      <div className="flex items-center justify-between p-3 border-b">
+        <h4 className="text-sm font-medium">
+          Step {stageNum} 결과
+        </h4>
+        <div className="flex gap-1">
+          {hasStructure && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 text-xs"
+              onClick={() => setRawMode(!rawMode)}
+            >
+              {rawMode ? "구조화" : "원본 JSON"}
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 text-xs gap-1"
+            onClick={handleCopy}
+          >
+            {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+            {copied ? "복사됨" : "복사"}
+          </Button>
+        </div>
+      </div>
+
+      <div className="p-3">
+        {!hasStructure || rawMode ? (
+          <pre className="text-xs bg-muted/50 p-3 rounded overflow-x-auto max-h-96">
+            {JSON.stringify(outputJson, null, 2)}
+          </pre>
+        ) : (
+          <div className="space-y-3">
+            {sections.map((section) => (
+              <CollapsibleSection key={section.key} section={section} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function CollapsibleSection({ section }: { section: JsonSection }) {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <div className="border rounded-lg">
+      <button
+        className="flex items-center gap-2 w-full p-2 text-left hover:bg-muted/50 rounded-t-lg"
+        onClick={() => setOpen(!open)}
+      >
+        {open ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+        <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+          {section.label}
+        </span>
+      </button>
+      {open && (
+        <div className="p-2 border-t">
+          <RenderValue value={section.value} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/feature/discovery/WizardStepDetail.tsx
+++ b/packages/web/src/components/feature/discovery/WizardStepDetail.tsx
@@ -1,15 +1,29 @@
 "use client";
 
-import { ArrowRight, CheckCircle2, Play, BookOpen, Wrench, FileText, HelpCircle } from "lucide-react";
+import { ArrowRight, CheckCircle2, Play, BookOpen, Wrench, FileText, HelpCircle, SkipForward } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
+import IntensityIndicator from "./IntensityIndicator";
+import type { IntensityLevel } from "./IntensityIndicator";
+
+/** 5유형×7단계 강도 매트릭스 (analysis-path-v82.ts 기준) */
+const INTENSITY_MATRIX: Record<string, Record<string, IntensityLevel>> = {
+  "2-1": { I: "light", M: "normal", P: "light", T: "core", S: "core" },
+  "2-2": { I: "core", M: "core", P: "core", T: "core", S: "light" },
+  "2-3": { I: "normal", M: "core", P: "core", T: "core", S: "core" },
+  "2-4": { I: "core", M: "normal", P: "core", T: "core", S: "core" },
+  "2-5": { I: "core", M: "core", P: "core", T: "core", S: "normal" },
+  "2-6": { I: "core", M: "core", P: "core", T: "normal", S: "normal" },
+  "2-7": { I: "normal", M: "normal", P: "core", T: "normal", S: "core" },
+};
 
 interface WizardStepDetailProps {
   stage: string;
   status: string;
   discoveryType?: string;
   bizItemId: string;
+  intensity?: IntensityLevel;
   onStatusChange: (stage: string, status: string) => void;
   onArtifactReview?: (artifactId: string, content: string | null) => void;
 }
@@ -133,6 +147,7 @@ export default function WizardStepDetail({
   status,
   discoveryType,
   bizItemId,
+  intensity: intensityProp,
   onStatusChange,
   onArtifactReview,
 }: WizardStepDetailProps) {
@@ -140,6 +155,11 @@ export default function WizardStepDetail({
   if (!content) return null;
 
   const stageName = STAGE_NAMES[stage] ?? stage;
+
+  // 강도 결정: prop 우선, 없으면 discoveryType + 매트릭스에서 자동 계산
+  const intensity: IntensityLevel | undefined =
+    intensityProp ??
+    (discoveryType ? INTENSITY_MATRIX[stage]?.[discoveryType] : undefined);
 
   return (
     <div className="rounded-xl border bg-card p-5 space-y-4" data-tour="discovery-step-detail">
@@ -162,12 +182,23 @@ export default function WizardStepDetail({
             >
               {status === "completed" ? "완료" : status === "in_progress" ? "진행 중" : status === "skipped" ? "건너뜀" : "대기"}
             </Badge>
+            {intensity && <IntensityIndicator intensity={intensity} />}
           </div>
           <h3 className="text-lg font-bold mt-1">{stageName}</h3>
         </div>
 
         {/* Status Change Button */}
-        <div>
+        <div className="flex gap-2">
+          {status === "pending" && intensity === "light" && (
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => onStatusChange(stage, "skipped")}
+              className="gap-1 text-muted-foreground"
+            >
+              <SkipForward className="h-3 w-3" /> 건너뛰기
+            </Button>
+          )}
           {status === "pending" && (
             <Button
               size="sm"


### PR DESCRIPTION
## Summary
- **F342**: DB 스키마 확장 4테이블(0098~0101) + API 서비스 3개 + 라우트 4개(13 endpoints) + Zod 스키마 4개
- **F343**: 강도 라우팅 UI(IntensityIndicator/Matrix) + OutputJsonViewer POC + WizardStepDetail intensity 통합
- Match Rate: **100%** (15/15 PASS), 18 tests 전체 통과

## Test plan
- [x] Typecheck: shared + api + web 전체 통과
- [x] Unit tests: PersonaConfigService(5) + PersonaEvalService(5) + DiscoveryReportService(5) + TeamReviews(3) = 18 tests
- [x] Lint: PostToolUse hook 자동 검증
- [ ] D1 migration: 프로덕션 적용 (CI/CD 자동)

🤖 Generated with [Claude Code](https://claude.com/claude-code)