### PR TITLE
feat: Sprint 158 F351+F352 — Prototype Auto-Gen Foundation (Phase 16)

### DIFF
--- a/docs/04-report/sprint-158-prototype-foundation.report.md
+++ b/docs/04-report/sprint-158-prototype-foundation.report.md
@@ -1,0 +1,75 @@
+---
+code: FX-RPRT-158
+title: Sprint 158 Completion Report — Prototype Auto-Gen Foundation
+version: 1.0
+status: Active
+category: Report
+created: 2026-04-06
+updated: 2026-04-06
+author: AX BD팀
+---
+
+# Sprint 158 Completion Report
+
+## Summary
+
+| Item | Detail |
+|------|--------|
+| **Sprint** | 158 |
+| **Phase** | 16 — Prototype Auto-Gen |
+| **F-items** | F351 (React SPA 템플릿 + Builder Server 스캐폴딩) + F352 (CLI --bare PoC + 비용 추적) |
+| **Match Rate** | 80% (3/5 PASS + 2/5 PARTIAL — PARTIAL은 외부 환경 의존) |
+| **Tests** | 49 passed (state-machine 28 + cost-tracker 12 + executor 9) |
+| **Typecheck** | shared + prototype-builder 모두 통과 |
+
+## Deliverables
+
+### F351: React SPA 템플릿 + Builder Server 스캐폴딩
+
+| Deliverable | Location | Status |
+|-------------|----------|--------|
+| Shared Prototype types | `packages/shared/src/prototype.ts` | PASS |
+| Builder Server 스캐폴딩 (8 modules) | `prototype-builder/src/` | PASS |
+| State Machine (전환 규칙) | `prototype-builder/src/state-machine.ts` | PASS |
+| React SPA 템플릿 | `prototype-builder/templates/react-spa/` | PASS |
+| Docker 격리 환경 | `prototype-builder/docker/` | PASS |
+
+### F352: CLI --bare 모드 PoC + 비용 추적
+
+| Deliverable | Location | Status |
+|-------------|----------|--------|
+| Executor (CLI 실행) | `prototype-builder/src/executor.ts` | PASS |
+| CostTracker (비용 추적) | `prototype-builder/src/cost-tracker.ts` | PASS |
+| Fallback (CLI→API 전환) | `prototype-builder/src/fallback.ts` | PASS |
+| 5종 PRD 비용 실측 | — | PARTIAL (API 키 필요) |
+
+## Architecture Decisions
+
+1. **Monorepo 포함**: `prototype-builder`를 pnpm workspace에 추가하여 `@foundry-x/shared` 타입 공유
+2. **독립 배포**: Workers가 아닌 VPS 배포 (Docker + 파일시스템 필요)
+3. **비용 최적화**: Round 0~1은 Haiku, Round 2+는 Sonnet (비용 3.75배 차이)
+4. **State Machine**: shared에 전환 규칙 배치 → API/Builder 양쪽 동일 규칙
+
+## Test Results
+
+```
+ ✓ src/__tests__/executor.test.ts (9 tests)
+ ✓ src/__tests__/cost-tracker.test.ts (12 tests)
+ ✓ src/__tests__/state-machine.test.ts (28 tests)
+
+ Test Files  3 passed (3)
+      Tests  49 passed (49)
+```
+
+## PARTIAL Items (환경 의존)
+
+| Item | Reason | Resolution |
+|------|--------|------------|
+| E2E CLI 실행 | ANTHROPIC_API_KEY 필요 | Builder Server VPS 배포 후 실측 |
+| 5종 PRD 비용 실측 | 실제 API 호출 필요 | Sprint 160 통합 테스트에서 수행 |
+| Docker build | Docker 런타임 필요 | VPS 환경에서 검증 |
+
+## Next Steps (Sprint 159)
+
+- F353: D1 마이그레이션 (`prototypes` 테이블) + API 라우트 3개
+- F354: Fallback 아키텍처 실제 적용 + 비용 모니터링 API

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -333,6 +333,22 @@ export type {
   DiscoveryTypeV2,
 } from './discovery-v2.js';
 
+// F351: Prototype Auto-Gen types (Sprint 158, Phase 16)
+export {
+  PROTOTYPE_TRANSITIONS,
+  PROTOTYPE_TIMEOUTS,
+  isValidPrototypeTransition,
+  getAvailablePrototypeTransitions,
+} from './prototype.js';
+
+export type {
+  PrototypeStatus,
+  Prototype,
+  PrototypeCreateRequest,
+  PrototypeUpdateRequest,
+  PrototypeFeedbackRequest,
+} from './prototype.js';
+
 // F346+F347+F348+F349: Discovery Report types (Sprint 156~157, Phase 15)
 export type {
   ReferenceAnalysisData,

--- a/packages/shared/src/prototype.ts
+++ b/packages/shared/src/prototype.ts
@@ -1,0 +1,83 @@
+// F351: Prototype Auto-Gen shared types (Sprint 158, Phase 16)
+
+export type PrototypeStatus =
+  | 'queued'
+  | 'building'
+  | 'deploying'
+  | 'live'
+  | 'failed'
+  | 'deploy_failed'
+  | 'dead_letter'
+  | 'feedback_pending';
+
+export interface Prototype {
+  id: string;
+  projectId: string;
+  prdId: string | null;
+  name: string;
+  status: PrototypeStatus;
+  prdContent: string;
+  deployUrl: string | null;
+  previewScreenshot: string | null;
+  buildLog: string | null;
+  errorMessage: string | null;
+  qualityScore: number | null;
+  ogdRounds: number;
+  modelUsed: string;
+  apiCost: number;
+  feedbackContent: string | null;
+  createdAt: string;
+  updatedAt: string;
+  completedAt: string | null;
+}
+
+export interface PrototypeCreateRequest {
+  projectId: string;
+  prdId?: string | null;
+  prdContent: string;
+  name: string;
+}
+
+export interface PrototypeUpdateRequest {
+  status?: PrototypeStatus;
+  deployUrl?: string;
+  buildLog?: string;
+  errorMessage?: string;
+  qualityScore?: number;
+  ogdRounds?: number;
+  modelUsed?: string;
+  apiCost?: number;
+}
+
+export interface PrototypeFeedbackRequest {
+  content: string;
+}
+
+export const PROTOTYPE_TRANSITIONS: Record<PrototypeStatus, readonly PrototypeStatus[]> = {
+  queued:           ['building'],
+  building:         ['deploying', 'failed'],
+  deploying:        ['live', 'deploy_failed'],
+  live:             ['feedback_pending'],
+  failed:           ['queued', 'dead_letter'],
+  deploy_failed:    ['deploying', 'dead_letter'],
+  dead_letter:      [],
+  feedback_pending: ['building'],
+} as const;
+
+export const PROTOTYPE_TIMEOUTS: Record<string, number> = {
+  building: 15 * 60 * 1000,
+  deploying: 5 * 60 * 1000,
+};
+
+export function isValidPrototypeTransition(
+  from: PrototypeStatus,
+  to: PrototypeStatus,
+): boolean {
+  return PROTOTYPE_TRANSITIONS[from].includes(to);
+}
+
+export function getAvailablePrototypeTransitions(
+  status: PrototypeStatus,
+): readonly PrototypeStatus[] {
+  return PROTOTYPE_TRANSITIONS[status];
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,6 +246,28 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@1.21.7)(jsdom@29.0.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.12.12(@types/node@22.19.15)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
 
+  prototype-builder:
+    dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.39.0
+        version: 0.39.0
+      '@foundry-x/shared':
+        specifier: workspace:*
+        version: link:../packages/shared
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@29.0.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.12.12(@types/node@22.19.15)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
+
 packages:
 
   '@adobe/css-tools@4.4.4':
@@ -258,6 +280,9 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@anthropic-ai/sdk@0.39.0':
+    resolution: {integrity: sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==}
 
   '@ardatan/relay-compiler@13.0.1':
     resolution: {integrity: sha512-afG3YPwuSA0E5foouZusz5GlXKs74dObv4cuWyLyfKsYFj2r7oGRNB28v18HvwuLSQtQFCi+DpIe0TZkgQDYyg==}
@@ -3348,6 +3373,12 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/node-fetch@2.6.13':
+    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
+
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
+
   '@types/node@20.19.37':
     resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
 
@@ -3776,6 +3807,10 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -3866,6 +3901,9 @@ packages:
 
   async-lock@1.4.1:
     resolution: {integrity: sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   attr-accept@2.2.5:
     resolution: {integrity: sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==}
@@ -4168,6 +4206,10 @@ packages:
 
   color-string@1.9.1:
     resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
@@ -4531,6 +4573,10 @@ packages:
   delaunator@5.1.0:
     resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -4780,6 +4826,10 @@ packages:
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
   es-toolkit@1.45.1:
@@ -5065,6 +5115,17 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  form-data-encoder@1.7.2:
+    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
+  formdata-node@4.4.1:
+    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
+    engines: {node: '>= 12.20'}
+
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
@@ -5286,6 +5347,9 @@ packages:
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
+
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   hyphenate-style-name@1.1.0:
     resolution: {integrity: sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==}
@@ -6494,6 +6558,15 @@ packages:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
@@ -7753,6 +7826,9 @@ packages:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
@@ -7904,6 +7980,9 @@ packages:
   unc-path-regex@0.1.2:
     resolution: {integrity: sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==}
     engines: {node: '>=0.10.0'}
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -8256,11 +8335,18 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
+  web-streams-polyfill@4.0.0-beta.3:
+    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
+    engines: {node: '>= 14'}
+
   web-vitals@5.2.0:
     resolution: {integrity: sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==}
 
   webfontloader@1.6.28:
     resolution: {integrity: sha512-Egb0oFEga6f+nSgasH3E0M405Pzn6y3/9tOVanv/DLfa1YBIgcv90L18YyWnvXkRbIM17v5Kv6IT2N6g1x5tvQ==}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
@@ -8273,6 +8359,9 @@ packages:
   whatwg-url@16.0.1:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-typed-array@1.1.20:
     resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
@@ -8469,6 +8558,18 @@ snapshots:
       is-fullwidth-code-point: 4.0.0
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@anthropic-ai/sdk@0.39.0':
+    dependencies:
+      '@types/node': 18.19.130
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   '@ardatan/relay-compiler@13.0.1(graphql@15.8.0)':
     dependencies:
@@ -11459,6 +11560,15 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/node-fetch@2.6.13':
+    dependencies:
+      '@types/node': 22.19.15
+      form-data: 4.0.5
+
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/node@20.19.37':
     dependencies:
       undici-types: 6.21.0
@@ -12018,6 +12128,10 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  agentkeepalive@4.6.0:
+    dependencies:
+      humanize-ms: 1.2.1
+
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
@@ -12097,6 +12211,8 @@ snapshots:
       tslib: 2.8.1
 
   async-lock@1.4.1: {}
+
+  asynckit@0.4.0: {}
 
   attr-accept@2.2.5: {}
 
@@ -12441,6 +12557,10 @@ snapshots:
       color-name: 1.1.4
       simple-swizzle: 0.2.4
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   comma-separated-tokens@2.0.3: {}
 
   commander@11.1.0: {}
@@ -12777,6 +12897,8 @@ snapshots:
     dependencies:
       robust-predicates: 3.0.3
 
+  delayed-stream@1.0.0: {}
+
   depd@2.0.0: {}
 
   dependency-graph@0.11.0: {}
@@ -12917,6 +13039,13 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   es-toolkit@1.45.1: {}
 
@@ -13410,6 +13539,21 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  form-data-encoder@1.7.2: {}
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
+  formdata-node@4.4.1:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 4.0.0-beta.3
+
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
@@ -13666,6 +13810,10 @@ snapshots:
   human-signals@2.1.0: {}
 
   human-signals@8.0.1: {}
+
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
 
   hyphenate-style-name@1.1.0: {}
 
@@ -15253,6 +15401,10 @@ snapshots:
       semver: 7.7.4
 
   node-domexception@1.0.0: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   node-fetch@3.3.2:
     dependencies:
@@ -16905,6 +17057,8 @@ snapshots:
     dependencies:
       tldts: 7.0.26
 
+  tr46@0.0.3: {}
+
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
@@ -17042,6 +17196,8 @@ snapshots:
   uc.micro@2.1.0: {}
 
   unc-path-regex@0.1.2: {}
+
+  undici-types@5.26.5: {}
 
   undici-types@6.21.0: {}
 
@@ -17544,9 +17700,13 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
+  web-streams-polyfill@4.0.0-beta.3: {}
+
   web-vitals@5.2.0: {}
 
   webfontloader@1.6.28: {}
+
+  webidl-conversions@3.0.1: {}
 
   webidl-conversions@8.0.1: {}
 
@@ -17559,6 +17719,11 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-typed-array@1.1.20:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - "packages/*"
+  - "prototype-builder"

--- a/prototype-builder/docker/Dockerfile.generator
+++ b/prototype-builder/docker/Dockerfile.generator
@@ -1,0 +1,17 @@
+FROM node:20-slim
+
+# Claude Code CLI + 빌드 도구
+RUN npm install -g @anthropic-ai/claude-code wrangler
+
+# 작업 디렉토리
+WORKDIR /workspace
+
+# 호스트에서 템플릿 + PRD를 마운트
+# -v $(pwd)/work:/workspace
+
+# 환경변수 (런타임 주입)
+# ANTHROPIC_API_KEY — Claude CLI 인증
+# CLOUDFLARE_API_TOKEN — Pages 배포
+
+# 기본 명령: 없음 (executor가 docker exec으로 실행)
+CMD ["sleep", "infinity"]

--- a/prototype-builder/docker/docker-compose.yml
+++ b/prototype-builder/docker/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  generator:
+    build:
+      context: .
+      dockerfile: Dockerfile.generator
+    volumes:
+      - ../work:/workspace
+    environment:
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - CLOUDFLARE_API_TOKEN=${CLOUDFLARE_API_TOKEN}
+    # 리소스 제한 (Job당)
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+          cpus: "2.0"
+    # 네트워크 격리
+    networks:
+      - generator-net
+
+networks:
+  generator-net:
+    driver: bridge

--- a/prototype-builder/package.json
+++ b/prototype-builder/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@foundry-x/prototype-builder",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "dev": "tsx src/index.ts",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@foundry-x/shared": "workspace:*",
+    "@anthropic-ai/sdk": "^0.39.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "tsx": "^4.19.0",
+    "vitest": "^3.0.0",
+    "@types/node": "^22.0.0"
+  }
+}

--- a/prototype-builder/src/__tests__/cost-tracker.test.ts
+++ b/prototype-builder/src/__tests__/cost-tracker.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { CostTracker } from '../cost-tracker.js';
+
+describe('CostTracker', () => {
+  let tracker: CostTracker;
+
+  beforeEach(() => {
+    tracker = new CostTracker({ monthlyBudgetUsd: 20 });
+  });
+
+  describe('record', () => {
+    it('Haiku 모델 비용을 정확히 계산해요', () => {
+      const record = tracker.record('job-1', 0, 'haiku', 10_000, 5_000);
+      // input: 10k/1M * $0.80 = $0.008
+      // output: 5k/1M * $4.00 = $0.020
+      // total: $0.028
+      expect(record.cost).toBeCloseTo(0.028, 4);
+    });
+
+    it('Sonnet 모델 비용을 정확히 계산해요', () => {
+      const record = tracker.record('job-1', 0, 'sonnet', 10_000, 5_000);
+      // input: 10k/1M * $3.00 = $0.030
+      // output: 5k/1M * $15.00 = $0.075
+      // total: $0.105
+      expect(record.cost).toBeCloseTo(0.105, 4);
+    });
+
+    it('알 수 없는 모델에 대해 에러를 던져요', () => {
+      expect(() => tracker.record('job-1', 0, 'unknown', 100, 100)).toThrow('Unknown model');
+    });
+
+    it('정식 모델명도 지원해요', () => {
+      const record = tracker.record('job-1', 0, 'claude-haiku-4-5-20251001', 10_000, 5_000);
+      expect(record.cost).toBeCloseTo(0.028, 4);
+    });
+  });
+
+  describe('getJobCost', () => {
+    it('특정 Job의 누적 비용을 계산해요', () => {
+      tracker.record('job-1', 0, 'haiku', 10_000, 5_000);
+      tracker.record('job-1', 1, 'haiku', 10_000, 5_000);
+      tracker.record('job-2', 0, 'haiku', 10_000, 5_000);
+
+      expect(tracker.getJobCost('job-1')).toBeCloseTo(0.056, 4);
+      expect(tracker.getJobCost('job-2')).toBeCloseTo(0.028, 4);
+    });
+
+    it('기록이 없는 Job은 0을 반환해요', () => {
+      expect(tracker.getJobCost('nonexistent')).toBe(0);
+    });
+  });
+
+  describe('getMonthlyTotal', () => {
+    it('이번 달 총 비용을 계산해요', () => {
+      tracker.record('job-1', 0, 'haiku', 100_000, 50_000);
+      tracker.record('job-2', 0, 'sonnet', 100_000, 50_000);
+
+      const total = tracker.getMonthlyTotal();
+      // haiku: 100k/1M*0.8 + 50k/1M*4.0 = 0.08+0.20 = 0.28
+      // sonnet: 100k/1M*3.0 + 50k/1M*15.0 = 0.30+0.75 = 1.05
+      expect(total).toBeCloseTo(1.33, 2);
+    });
+  });
+
+  describe('budget', () => {
+    it('예산 사용률을 정확히 계산해요', () => {
+      tracker.record('job-1', 0, 'sonnet', 1_000_000, 500_000);
+      // sonnet: 1M/1M*3.0 + 500k/1M*15.0 = 3.0+7.5 = 10.5
+      expect(tracker.getBudgetUsage()).toBeCloseTo(0.525, 2); // $10.5/$20
+    });
+
+    it('예산 초과를 감지해요', () => {
+      // $20 예산을 초과하는 호출
+      tracker.record('job-1', 0, 'opus', 1_000_000, 500_000);
+      // opus: 1M/1M*15.0 + 500k/1M*75.0 = 15.0+37.5 = 52.5
+      expect(tracker.isOverBudget()).toBe(true);
+    });
+
+    it('예산 80% 경고를 감지해요', () => {
+      // $16+ (80% of $20)
+      tracker.record('job-1', 0, 'sonnet', 1_000_000, 1_000_000);
+      // sonnet: 3.0+15.0 = 18.0 → 90%
+      expect(tracker.isNearBudget(0.8)).toBe(true);
+    });
+
+    it('예산 미달이면 경고하지 않아요', () => {
+      tracker.record('job-1', 0, 'haiku', 10_000, 5_000);
+      expect(tracker.isNearBudget()).toBe(false);
+      expect(tracker.isOverBudget()).toBe(false);
+    });
+  });
+
+  describe('getJobSummary', () => {
+    it('Job별 요약을 생성해요', () => {
+      tracker.record('job-1', 0, 'haiku', 10_000, 5_000);
+      tracker.record('job-1', 1, 'haiku', 12_000, 6_000);
+      tracker.record('job-1', 2, 'sonnet', 10_000, 5_000);
+
+      const summary = tracker.getJobSummary('job-1');
+      expect(summary.rounds).toBe(3);
+      expect(summary.models).toEqual(expect.arrayContaining(['haiku', 'sonnet']));
+      expect(summary.totalInputTokens).toBe(32_000);
+      expect(summary.totalOutputTokens).toBe(16_000);
+      expect(summary.totalCost).toBeGreaterThan(0);
+    });
+  });
+});

--- a/prototype-builder/src/__tests__/executor.test.ts
+++ b/prototype-builder/src/__tests__/executor.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { buildGeneratorPrompt, buildCliArgs } from '../executor.js';
+import type { PrototypeJob } from '../types.js';
+
+function makeJob(overrides: Partial<PrototypeJob> = {}): PrototypeJob {
+  return {
+    id: 'test-job-1',
+    projectId: 'proj-1',
+    name: 'Test Prototype',
+    prdContent: '# Test PRD\n\n사용자가 로그인하면 대시보드를 볼 수 있다.',
+    feedbackContent: null,
+    workDir: '/tmp/test-work',
+    round: 0,
+    ...overrides,
+  };
+}
+
+describe('executor', () => {
+  describe('buildGeneratorPrompt', () => {
+    it('PRD 내용을 프롬프트에 포함해요', () => {
+      const prompt = buildGeneratorPrompt(makeJob(), 0);
+      expect(prompt).toContain('# Test PRD');
+      expect(prompt).toContain('대시보드');
+    });
+
+    it('피드백이 있으면 프롬프트에 포함해요', () => {
+      const job = makeJob({ feedbackContent: 'KPI를 3개로 늘려주세요' });
+      const prompt = buildGeneratorPrompt(job, 1);
+      expect(prompt).toContain('이전 피드백');
+      expect(prompt).toContain('KPI를 3개로');
+    });
+
+    it('round > 0이면 개선 지시를 포함해요', () => {
+      const prompt = buildGeneratorPrompt(makeJob(), 1);
+      expect(prompt).toContain('Round 2');
+      expect(prompt).toContain('품질을 개선');
+    });
+
+    it('round 0에서는 개선 지시를 포함하지 않아요', () => {
+      const prompt = buildGeneratorPrompt(makeJob(), 0);
+      expect(prompt).not.toContain('Round');
+    });
+  });
+
+  describe('buildCliArgs', () => {
+    it('--bare 플래그를 포함해요', () => {
+      const args = buildCliArgs(makeJob(), 0);
+      expect(args).toContain('--bare');
+    });
+
+    it('round < 2에서는 haiku 모델을 사용해요', () => {
+      const args = buildCliArgs(makeJob(), 0);
+      const modelIdx = args.indexOf('--model');
+      expect(args[modelIdx + 1]).toBe('haiku');
+    });
+
+    it('round >= 2에서는 sonnet 모델을 사용해요', () => {
+      const args = buildCliArgs(makeJob(), 2);
+      const modelIdx = args.indexOf('--model');
+      expect(args[modelIdx + 1]).toBe('sonnet');
+    });
+
+    it('도구 권한을 제한해요', () => {
+      const args = buildCliArgs(makeJob(), 0);
+      expect(args).toContain('--allowedTools');
+      expect(args).toContain('Bash,Read,Edit,Write');
+    });
+
+    it('JSON 출력 형식을 사용해요', () => {
+      const args = buildCliArgs(makeJob(), 0);
+      expect(args).toContain('--output-format');
+      expect(args).toContain('json');
+    });
+  });
+});

--- a/prototype-builder/src/__tests__/state-machine.test.ts
+++ b/prototype-builder/src/__tests__/state-machine.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import {
+  transition,
+  checkTimeout,
+  canDeadLetter,
+  canRetry,
+  canAcceptFeedback,
+  isTerminal,
+} from '../state-machine.js';
+
+describe('State Machine', () => {
+  describe('transition', () => {
+    it('queued → building 전환을 허용해요', () => {
+      const result = transition('queued', 'building');
+      expect(result.success).toBe(true);
+      expect(result.from).toBe('queued');
+      expect(result.to).toBe('building');
+    });
+
+    it('building → deploying 전환을 허용해요', () => {
+      expect(transition('building', 'deploying').success).toBe(true);
+    });
+
+    it('building → failed 전환을 허용해요', () => {
+      expect(transition('building', 'failed').success).toBe(true);
+    });
+
+    it('deploying → live 전환을 허용해요', () => {
+      expect(transition('deploying', 'live').success).toBe(true);
+    });
+
+    it('deploying → deploy_failed 전환을 허용해요', () => {
+      expect(transition('deploying', 'deploy_failed').success).toBe(true);
+    });
+
+    it('live → feedback_pending 전환을 허용해요', () => {
+      expect(transition('live', 'feedback_pending').success).toBe(true);
+    });
+
+    it('feedback_pending → building 전환을 허용해요 (재생성)', () => {
+      expect(transition('feedback_pending', 'building').success).toBe(true);
+    });
+
+    it('failed → queued 재시도를 허용해요', () => {
+      expect(transition('failed', 'queued').success).toBe(true);
+    });
+
+    it('failed → dead_letter 전환을 허용해요', () => {
+      expect(transition('failed', 'dead_letter').success).toBe(true);
+    });
+
+    it('유효하지 않은 전환을 거부해요', () => {
+      const result = transition('queued', 'live');
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid transition');
+      expect(result.error).toContain('queued');
+      expect(result.error).toContain('live');
+    });
+
+    it('dead_letter에서는 어떤 전환도 불가해요', () => {
+      expect(transition('dead_letter', 'queued').success).toBe(false);
+      expect(transition('dead_letter', 'building').success).toBe(false);
+    });
+
+    it('queued에서 직접 live로 건너뛸 수 없어요', () => {
+      expect(transition('queued', 'live').success).toBe(false);
+    });
+  });
+
+  describe('checkTimeout', () => {
+    it('building 15분 이내이면 timeout 아니에요', () => {
+      const now = Date.now();
+      const result = checkTimeout('building', now - 10 * 60 * 1000, now);
+      expect(result.isTimedOut).toBe(false);
+    });
+
+    it('building 15분 초과이면 timeout이에요', () => {
+      const now = Date.now();
+      const result = checkTimeout('building', now - 16 * 60 * 1000, now);
+      expect(result.isTimedOut).toBe(true);
+      expect(result.timeoutMs).toBe(15 * 60 * 1000);
+    });
+
+    it('deploying 5분 초과이면 timeout이에요', () => {
+      const now = Date.now();
+      const result = checkTimeout('deploying', now - 6 * 60 * 1000, now);
+      expect(result.isTimedOut).toBe(true);
+      expect(result.timeoutMs).toBe(5 * 60 * 1000);
+    });
+
+    it('timeout이 정의되지 않은 상태는 timeout되지 않아요', () => {
+      const now = Date.now();
+      const result = checkTimeout('queued', now - 100 * 60 * 1000, now);
+      expect(result.isTimedOut).toBe(false);
+    });
+  });
+
+  describe('canDeadLetter', () => {
+    it('failed 상태에서 dead_letter 전환 가능해요', () => {
+      expect(canDeadLetter('failed')).toBe(true);
+    });
+
+    it('deploy_failed 상태에서 dead_letter 전환 가능해요', () => {
+      expect(canDeadLetter('deploy_failed')).toBe(true);
+    });
+
+    it('queued 상태에서는 dead_letter 불가해요', () => {
+      expect(canDeadLetter('queued')).toBe(false);
+    });
+
+    it('live 상태에서는 dead_letter 불가해요', () => {
+      expect(canDeadLetter('live')).toBe(false);
+    });
+  });
+
+  describe('canRetry', () => {
+    it('failed 상태에서 재시도 가능해요', () => {
+      expect(canRetry('failed')).toBe(true);
+    });
+
+    it('deploy_failed 상태에서 재시도 가능해요', () => {
+      expect(canRetry('deploy_failed')).toBe(true);
+    });
+
+    it('dead_letter 상태에서는 재시도 불가해요', () => {
+      expect(canRetry('dead_letter')).toBe(false);
+    });
+  });
+
+  describe('canAcceptFeedback', () => {
+    it('live 상태에서만 피드백 수신 가능해요', () => {
+      expect(canAcceptFeedback('live')).toBe(true);
+    });
+
+    it('building 상태에서는 피드백 불가해요', () => {
+      expect(canAcceptFeedback('building')).toBe(false);
+    });
+  });
+
+  describe('isTerminal', () => {
+    it('dead_letter는 터미널 상태에요', () => {
+      expect(isTerminal('dead_letter')).toBe(true);
+    });
+
+    it('live는 터미널이 아니에요 (피드백 가능)', () => {
+      expect(isTerminal('live')).toBe(false);
+    });
+
+    it('queued는 터미널이 아니에요', () => {
+      expect(isTerminal('queued')).toBe(false);
+    });
+  });
+});

--- a/prototype-builder/src/cost-tracker.ts
+++ b/prototype-builder/src/cost-tracker.ts
@@ -1,0 +1,124 @@
+import type { CostRecord, BuilderConfig } from './types.js';
+
+// Anthropic 가격표 (2026-04 기준, USD per 1M tokens)
+const MODEL_PRICING: Record<string, { input: number; output: number }> = {
+  'claude-haiku-4-5-20251001': { input: 0.80, output: 4.00 },
+  'claude-sonnet-4-6':        { input: 3.00, output: 15.00 },
+  'claude-opus-4-6':          { input: 15.00, output: 75.00 },
+  // 별칭
+  haiku:  { input: 0.80, output: 4.00 },
+  sonnet: { input: 3.00, output: 15.00 },
+  opus:   { input: 15.00, output: 75.00 },
+};
+
+export class CostTracker {
+  private records: CostRecord[] = [];
+  private monthlyBudgetUsd: number;
+
+  constructor(config: Pick<BuilderConfig, 'monthlyBudgetUsd'>) {
+    this.monthlyBudgetUsd = config.monthlyBudgetUsd;
+  }
+
+  /**
+   * API 호출 비용 기록
+   */
+  record(
+    jobId: string,
+    round: number,
+    model: string,
+    inputTokens: number,
+    outputTokens: number,
+  ): CostRecord {
+    const pricing = MODEL_PRICING[model];
+    if (!pricing) {
+      throw new Error(`Unknown model: ${model}. Known: ${Object.keys(MODEL_PRICING).join(', ')}`);
+    }
+
+    const cost =
+      (inputTokens / 1_000_000) * pricing.input +
+      (outputTokens / 1_000_000) * pricing.output;
+
+    const entry: CostRecord = {
+      jobId,
+      round,
+      model,
+      inputTokens,
+      outputTokens,
+      cost,
+      timestamp: Date.now(),
+    };
+
+    this.records.push(entry);
+    return entry;
+  }
+
+  /**
+   * 특정 Job의 총 비용
+   */
+  getJobCost(jobId: string): number {
+    return this.records
+      .filter(r => r.jobId === jobId)
+      .reduce((sum, r) => sum + r.cost, 0);
+  }
+
+  /**
+   * 이번 달 총 비용
+   */
+  getMonthlyTotal(): number {
+    const now = new Date();
+    const monthStart = new Date(now.getFullYear(), now.getMonth(), 1).getTime();
+
+    return this.records
+      .filter(r => r.timestamp >= monthStart)
+      .reduce((sum, r) => sum + r.cost, 0);
+  }
+
+  /**
+   * 월 예산 대비 사용률 (0~1+)
+   */
+  getBudgetUsage(): number {
+    if (this.monthlyBudgetUsd <= 0) return 0;
+    return this.getMonthlyTotal() / this.monthlyBudgetUsd;
+  }
+
+  /**
+   * 예산 초과 여부
+   */
+  isOverBudget(): boolean {
+    return this.getBudgetUsage() >= 1.0;
+  }
+
+  /**
+   * 예산 경고 임계값 (80%) 초과 여부
+   */
+  isNearBudget(threshold = 0.8): boolean {
+    return this.getBudgetUsage() >= threshold;
+  }
+
+  /**
+   * 모든 기록 반환
+   */
+  getRecords(): readonly CostRecord[] {
+    return this.records;
+  }
+
+  /**
+   * Job별 비용 요약
+   */
+  getJobSummary(jobId: string): {
+    totalCost: number;
+    rounds: number;
+    models: string[];
+    totalInputTokens: number;
+    totalOutputTokens: number;
+  } {
+    const jobRecords = this.records.filter(r => r.jobId === jobId);
+    return {
+      totalCost: jobRecords.reduce((s, r) => s + r.cost, 0),
+      rounds: jobRecords.length,
+      models: [...new Set(jobRecords.map(r => r.model))],
+      totalInputTokens: jobRecords.reduce((s, r) => s + r.inputTokens, 0),
+      totalOutputTokens: jobRecords.reduce((s, r) => s + r.outputTokens, 0),
+    };
+  }
+}

--- a/prototype-builder/src/deployer.ts
+++ b/prototype-builder/src/deployer.ts
@@ -1,0 +1,54 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import path from 'node:path';
+import type { DeployResult, BuilderConfig } from './types.js';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Cloudflare Pages에 빌드 산출물 배포
+ * wrangler pages deploy dist/ --project-name=proto-{name}
+ */
+export async function deployToPages(
+  workDir: string,
+  projectName: string,
+  config: Pick<BuilderConfig, 'cloudflareApiToken' | 'cloudflareAccountId'>,
+): Promise<DeployResult> {
+  const distDir = path.join(workDir, 'dist');
+
+  const { stdout } = await execFileAsync(
+    'npx',
+    [
+      'wrangler', 'pages', 'deploy', distDir,
+      '--project-name', projectName,
+      '--commit-dirty=true',
+    ],
+    {
+      cwd: workDir,
+      timeout: 3 * 60 * 1000, // 3분
+      env: {
+        ...process.env,
+        CLOUDFLARE_API_TOKEN: config.cloudflareApiToken,
+        CLOUDFLARE_ACCOUNT_ID: config.cloudflareAccountId,
+      },
+    },
+  );
+
+  // wrangler 출력에서 배포 URL 추출
+  const urlMatch = stdout.match(/https:\/\/[\w-]+\.[\w-]+\.pages\.dev/);
+  const url = urlMatch ? urlMatch[0]! : `https://${projectName}.pages.dev`;
+
+  return { url, projectName };
+}
+
+/**
+ * 프로토타입 이름에서 안전한 Pages 프로젝트명 생성
+ * 한글→영문 변환은 하지 않고, kebab-case + prefix만 적용
+ */
+export function toProjectName(name: string): string {
+  return `proto-${name
+    .toLowerCase()
+    .replace(/[^a-z0-9가-힣]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 40)}`;
+}

--- a/prototype-builder/src/executor.ts
+++ b/prototype-builder/src/executor.ts
@@ -1,0 +1,127 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import type { PrototypeJob } from './types.js';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Generator 프롬프트 생성 — PRD + 체크리스트 + 이전 피드백 결합
+ */
+export function buildGeneratorPrompt(job: PrototypeJob, round: number): string {
+  const parts = [
+    '# Prototype Generator',
+    '',
+    '아래 PRD를 기반으로 인터랙티브 React SPA Prototype을 생성하세요.',
+    'src/ 디렉토리에 컴포넌트를 작성하고, App.tsx에서 조합하세요.',
+    'TailwindCSS + shadcn/ui를 사용하세요.',
+    '',
+    '## PRD',
+    job.prdContent,
+  ];
+
+  if (job.feedbackContent) {
+    parts.push('', '## 이전 피드백 (반드시 반영)', job.feedbackContent);
+  }
+
+  if (round > 0) {
+    parts.push('', `## Round ${round + 1}`, '이전 라운드의 피드백을 반영하여 품질을 개선하세요.');
+  }
+
+  return parts.join('\n');
+}
+
+/**
+ * CLI --bare 실행 인자 생성
+ */
+export function buildCliArgs(job: PrototypeJob, round: number): string[] {
+  return [
+    '--bare',
+    '-p', buildGeneratorPrompt(job, round),
+    '--allowedTools', 'Bash,Read,Edit,Write',
+    '--model', round < 2 ? 'haiku' : 'sonnet',
+    '--max-turns', '15',
+    '--output-format', 'json',
+  ];
+}
+
+/**
+ * 템플릿을 작업 디렉토리에 복사
+ */
+export async function copyTemplate(
+  templateDir: string,
+  workDir: string,
+): Promise<void> {
+  await fs.cp(templateDir, workDir, { recursive: true });
+}
+
+/**
+ * Claude Code CLI --bare 모드로 코드 생성 실행
+ */
+export async function runCliGenerator(
+  job: PrototypeJob,
+  round: number,
+  options: { cliPath?: string; timeoutMs?: number } = {},
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const cliPath = options.cliPath ?? 'claude';
+  const timeoutMs = options.timeoutMs ?? 10 * 60 * 1000; // 10분
+
+  const args = buildCliArgs(job, round);
+
+  try {
+    const { stdout, stderr } = await execFileAsync(cliPath, args, {
+      cwd: job.workDir,
+      timeout: timeoutMs,
+      env: {
+        ...process.env,
+        ANTHROPIC_API_KEY: process.env['ANTHROPIC_API_KEY'],
+      },
+    });
+    return { stdout, stderr, exitCode: 0 };
+  } catch (err) {
+    const error = err as { stdout?: string; stderr?: string; code?: number };
+    return {
+      stdout: error.stdout ?? '',
+      stderr: error.stderr ?? String(err),
+      exitCode: error.code ?? 1,
+    };
+  }
+}
+
+/**
+ * 작업 디렉토리에서 vite build 실행
+ */
+export async function runBuild(
+  workDir: string,
+  options: { timeoutMs?: number } = {},
+): Promise<{ success: boolean; output: string }> {
+  const timeoutMs = options.timeoutMs ?? 2 * 60 * 1000; // 2분
+
+  try {
+    const { stdout, stderr } = await execFileAsync(
+      'npx',
+      ['vite', 'build'],
+      { cwd: workDir, timeout: timeoutMs },
+    );
+    return { success: true, output: stdout + stderr };
+  } catch (err) {
+    return {
+      success: false,
+      output: String(err),
+    };
+  }
+}
+
+/**
+ * 빌드 산출물 디렉토리 존재 확인
+ */
+export async function verifyBuildOutput(workDir: string): Promise<boolean> {
+  const distDir = path.join(workDir, 'dist');
+  try {
+    const stat = await fs.stat(distDir);
+    return stat.isDirectory();
+  } catch {
+    return false;
+  }
+}

--- a/prototype-builder/src/fallback.ts
+++ b/prototype-builder/src/fallback.ts
@@ -1,0 +1,89 @@
+import Anthropic from '@anthropic-ai/sdk';
+import type { PrototypeJob } from './types.js';
+import { buildGeneratorPrompt } from './executor.js';
+
+export type FallbackLevel = 'cli' | 'api' | 'ensemble';
+
+export interface FallbackResult {
+  level: FallbackLevel;
+  output: string;
+  success: boolean;
+  error?: string;
+}
+
+/**
+ * CLI 실패 시 Anthropic API를 직접 호출하여 코드 생성
+ * 3단계 Fallback: CLI → API → 앙상블 (CLI+API 결합)
+ */
+export async function fallbackToApi(
+  job: PrototypeJob,
+  round: number,
+  options: { apiKey?: string } = {},
+): Promise<FallbackResult> {
+  const apiKey = options.apiKey ?? process.env['ANTHROPIC_API_KEY'];
+  if (!apiKey) {
+    return {
+      level: 'api',
+      output: '',
+      success: false,
+      error: 'ANTHROPIC_API_KEY not set',
+    };
+  }
+
+  const client = new Anthropic({ apiKey });
+  const prompt = buildGeneratorPrompt(job, round);
+
+  try {
+    const response = await client.messages.create({
+      model: 'claude-sonnet-4-6',
+      max_tokens: 16384,
+      messages: [{ role: 'user', content: prompt }],
+    });
+
+    const text = response.content
+      .filter((block): block is Anthropic.TextBlock => block.type === 'text')
+      .map(block => block.text)
+      .join('\n');
+
+    return { level: 'api', output: text, success: true };
+  } catch (err) {
+    return {
+      level: 'api',
+      output: '',
+      success: false,
+      error: String(err),
+    };
+  }
+}
+
+/**
+ * 3단계 Fallback 전략 실행
+ * 1. CLI --bare → 성공하면 반환
+ * 2. API 직접 호출 → 성공하면 반환
+ * 3. 모두 실패 → error 반환
+ */
+export async function executeWithFallback(
+  job: PrototypeJob,
+  round: number,
+  cliRunner: (job: PrototypeJob, round: number) => Promise<{ stdout: string; exitCode: number }>,
+): Promise<FallbackResult> {
+  // Level 1: CLI
+  const cliResult = await cliRunner(job, round);
+  if (cliResult.exitCode === 0) {
+    return { level: 'cli', output: cliResult.stdout, success: true };
+  }
+
+  // Level 2: API
+  const apiResult = await fallbackToApi(job, round);
+  if (apiResult.success) {
+    return apiResult;
+  }
+
+  // Level 3: 모두 실패
+  return {
+    level: 'ensemble',
+    output: '',
+    success: false,
+    error: `CLI failed (exit ${cliResult.exitCode}), API failed: ${apiResult.error}`,
+  };
+}

--- a/prototype-builder/src/index.ts
+++ b/prototype-builder/src/index.ts
@@ -1,0 +1,175 @@
+import http from 'node:http';
+import type { BuilderConfig, PrototypeJob } from './types.js';
+import { pollForJobs, pollForFeedbackJobs, updatePrototypeStatus, startPollingLoop } from './poller.js';
+import { copyTemplate, runBuild, verifyBuildOutput } from './executor.js';
+import { runOgdLoop } from './orchestrator.js';
+import { transition, checkTimeout, canDeadLetter } from './state-machine.js';
+import { deployToPages, toProjectName } from './deployer.js';
+import { buildCompletionMessage, sendSlackNotification } from './notifier.js';
+import { CostTracker } from './cost-tracker.js';
+import path from 'node:path';
+import os from 'node:os';
+import fs from 'node:fs/promises';
+
+function loadConfig(): BuilderConfig {
+  return {
+    apiBaseUrl: process.env['FOUNDRY_API_URL'] ?? 'http://localhost:8787',
+    apiToken: process.env['BUILDER_API_TOKEN'] ?? '',
+    anthropicApiKey: process.env['ANTHROPIC_API_KEY'] ?? '',
+    cloudflareApiToken: process.env['CLOUDFLARE_API_TOKEN'] ?? '',
+    cloudflareAccountId: process.env['CLOUDFLARE_ACCOUNT_ID'] ?? '',
+    pollIntervalMs: Number(process.env['POLL_INTERVAL_MS'] ?? 30_000),
+    maxOgdRounds: Number(process.env['MAX_OGD_ROUNDS'] ?? 3),
+    qualityThreshold: Number(process.env['QUALITY_THRESHOLD'] ?? 0.85),
+    monthlyBudgetUsd: Number(process.env['MONTHLY_BUDGET_USD'] ?? 20),
+    slackWebhookUrl: process.env['SLACK_WEBHOOK_URL'] ?? null,
+  };
+}
+
+const TEMPLATE_DIR = path.resolve(import.meta.dirname, '../templates/react-spa');
+
+async function processJob(
+  proto: { id: string; projectId: string; name: string; prdContent: string; feedbackContent: string | null },
+  config: BuilderConfig,
+  costTracker: CostTracker,
+): Promise<void> {
+  const workDir = path.join(os.tmpdir(), `proto-${proto.id}`);
+
+  try {
+    // 1. building 상태 전환
+    const t = transition('queued', 'building');
+    if (!t.success) return;
+    await updatePrototypeStatus(proto.id, { status: 'building' }, config);
+
+    // 2. 템플릿 복사
+    await copyTemplate(TEMPLATE_DIR, workDir);
+
+    // 3. O-G-D 루프 실행
+    const job: PrototypeJob = {
+      id: proto.id,
+      projectId: proto.projectId,
+      name: proto.name,
+      prdContent: proto.prdContent,
+      feedbackContent: proto.feedbackContent,
+      workDir,
+      round: 0,
+    };
+
+    const result = await runOgdLoop(job, {
+      maxRounds: config.maxOgdRounds,
+      qualityThreshold: config.qualityThreshold,
+      costTracker,
+    });
+
+    // 4. 빌드
+    const buildResult = await runBuild(workDir);
+    if (!buildResult.success || !(await verifyBuildOutput(workDir))) {
+      await updatePrototypeStatus(proto.id, {
+        status: 'failed',
+        errorMessage: `Build failed: ${buildResult.output.slice(0, 500)}`,
+        buildLog: buildResult.output,
+      }, config);
+      return;
+    }
+
+    // 5. deploying 상태 전환
+    await updatePrototypeStatus(proto.id, { status: 'deploying' }, config);
+
+    // 6. Pages 배포
+    const projectName = toProjectName(proto.name);
+    const deploy = await deployToPages(workDir, projectName, config);
+
+    // 7. live 상태 전환 + 결과 기록
+    await updatePrototypeStatus(proto.id, {
+      status: 'live',
+      deployUrl: deploy.url,
+      qualityScore: result.score,
+      ogdRounds: result.rounds,
+      apiCost: result.totalCost,
+      buildLog: buildResult.output,
+    }, config);
+
+    // 8. Slack 알림
+    const message = buildCompletionMessage({
+      name: proto.name,
+      status: 'live',
+      deployUrl: deploy.url,
+      qualityScore: result.score,
+      rounds: result.rounds,
+      cost: result.totalCost,
+    });
+    await sendSlackNotification(message, config);
+
+  } catch (err) {
+    await updatePrototypeStatus(proto.id, {
+      status: 'failed',
+      errorMessage: String(err),
+    }, config).catch(() => {});
+  } finally {
+    // 작업 디렉토리 정리
+    await fs.rm(workDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+async function main(): Promise<void> {
+  const config = loadConfig();
+  const costTracker = new CostTracker({ monthlyBudgetUsd: config.monthlyBudgetUsd });
+
+  console.log('[Builder] Starting Prototype Builder Server');
+  console.log(`[Builder] API: ${config.apiBaseUrl}`);
+  console.log(`[Builder] Poll interval: ${config.pollIntervalMs}ms`);
+  console.log(`[Builder] Budget: $${config.monthlyBudgetUsd}/month`);
+
+  // Health check 엔드포인트
+  const server = http.createServer((req, res) => {
+    if (req.url === '/health') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        status: 'ok',
+        budget: {
+          used: costTracker.getMonthlyTotal().toFixed(2),
+          limit: config.monthlyBudgetUsd,
+          usage: (costTracker.getBudgetUsage() * 100).toFixed(1) + '%',
+        },
+      }));
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+
+  server.listen(3001, () => {
+    console.log('[Builder] Health check on :3001/health');
+  });
+
+  // 폴링 루프 시작
+  const poller = startPollingLoop(async () => {
+    if (costTracker.isOverBudget()) {
+      console.warn('[Builder] Monthly budget exceeded — pausing');
+      return;
+    }
+
+    const jobs = await pollForJobs(config);
+    const feedbackJobs = await pollForFeedbackJobs(config);
+
+    for (const job of [...jobs, ...feedbackJobs]) {
+      console.log(`[Builder] Processing: ${job.name} (${job.id})`);
+      await processJob(job, config, costTracker);
+    }
+  }, config.pollIntervalMs);
+
+  // Graceful shutdown
+  const shutdown = () => {
+    console.log('[Builder] Shutting down...');
+    poller.stop();
+    server.close();
+  };
+
+  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', shutdown);
+}
+
+main().catch(err => {
+  console.error('[Builder] Fatal:', err);
+  process.exit(1);
+});

--- a/prototype-builder/src/notifier.ts
+++ b/prototype-builder/src/notifier.ts
@@ -1,0 +1,80 @@
+import type { BuilderConfig } from './types.js';
+
+export interface SlackMessage {
+  text: string;
+  blocks?: SlackBlock[];
+}
+
+interface SlackBlock {
+  type: 'section' | 'divider' | 'header';
+  text?: { type: 'mrkdwn' | 'plain_text'; text: string };
+  fields?: { type: 'mrkdwn'; text: string }[];
+}
+
+/**
+ * Prototype 빌드 완료 알림 메시지 생성
+ */
+export function buildCompletionMessage(params: {
+  name: string;
+  status: 'live' | 'failed';
+  deployUrl?: string;
+  qualityScore?: number;
+  rounds?: number;
+  cost?: number;
+  errorMessage?: string;
+}): SlackMessage {
+  const emoji = params.status === 'live' ? ':white_check_mark:' : ':x:';
+  const statusText = params.status === 'live' ? 'Live' : 'Failed';
+
+  const blocks: SlackBlock[] = [
+    {
+      type: 'header',
+      text: { type: 'plain_text', text: `${emoji} Prototype ${statusText}: ${params.name}` },
+    },
+  ];
+
+  if (params.status === 'live' && params.deployUrl) {
+    blocks.push({
+      type: 'section',
+      fields: [
+        { type: 'mrkdwn', text: `*URL:*\n<${params.deployUrl}>` },
+        { type: 'mrkdwn', text: `*Quality:* ${params.qualityScore?.toFixed(2) ?? 'N/A'}` },
+        { type: 'mrkdwn', text: `*Rounds:* ${params.rounds ?? 'N/A'}` },
+        { type: 'mrkdwn', text: `*Cost:* $${params.cost?.toFixed(2) ?? 'N/A'}` },
+      ],
+    });
+  }
+
+  if (params.status === 'failed' && params.errorMessage) {
+    blocks.push({
+      type: 'section',
+      text: { type: 'mrkdwn', text: `*Error:*\n\`\`\`${params.errorMessage}\`\`\`` },
+    });
+  }
+
+  return {
+    text: `Prototype ${statusText}: ${params.name}`,
+    blocks,
+  };
+}
+
+/**
+ * Slack Webhook으로 메시지 전송
+ */
+export async function sendSlackNotification(
+  message: SlackMessage,
+  config: Pick<BuilderConfig, 'slackWebhookUrl'>,
+): Promise<boolean> {
+  if (!config.slackWebhookUrl) return false;
+
+  try {
+    const response = await fetch(config.slackWebhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(message),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}

--- a/prototype-builder/src/orchestrator.ts
+++ b/prototype-builder/src/orchestrator.ts
@@ -1,0 +1,168 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { PrototypeJob, OgdResult, OgdEvaluation } from './types.js';
+import { runCliGenerator, runBuild } from './executor.js';
+import { executeWithFallback } from './fallback.js';
+import { CostTracker } from './cost-tracker.js';
+
+/**
+ * Discriminator 프롬프트 — 생성물 품질 평가
+ */
+function buildDiscriminatorPrompt(
+  job: PrototypeJob,
+  generatedCode: string,
+): string {
+  return [
+    '# Prototype Discriminator',
+    '',
+    'PRD 대비 생성된 Prototype 코드의 품질을 평가하세요.',
+    '',
+    '## 평가 기준',
+    '1. PRD 요구사항 충족도 (0~1)',
+    '2. UI/UX 완성도 (0~1)',
+    '3. 코드 빌드 가능성 (0~1)',
+    '4. 인터랙션 구현 (0~1)',
+    '',
+    '## 출력 형식 (JSON)',
+    '```json',
+    '{',
+    '  "qualityScore": 0.85,',
+    '  "feedback": "개선 필요 사항...",',
+    '  "details": { "requirements": 0.9, "ux": 0.8, "buildable": 1.0, "interaction": 0.7 }',
+    '}',
+    '```',
+    '',
+    '## PRD',
+    job.prdContent,
+    '',
+    '## 생성된 코드',
+    generatedCode,
+  ].join('\n');
+}
+
+/**
+ * 피드백을 작업 디렉토리에 저장 (다음 Round 입력)
+ */
+async function saveFeedback(
+  workDir: string,
+  round: number,
+  feedback: string,
+): Promise<void> {
+  const feedbackDir = path.join(workDir, '.ogd');
+  await fs.mkdir(feedbackDir, { recursive: true });
+  await fs.writeFile(
+    path.join(feedbackDir, `feedback_${round}.md`),
+    feedback,
+    'utf-8',
+  );
+}
+
+/**
+ * Discriminator 결과 파싱
+ */
+function parseEvaluation(raw: string): OgdEvaluation {
+  // JSON 블록 추출 시도
+  const jsonMatch = raw.match(/```json\s*([\s\S]*?)```/);
+  const jsonStr = jsonMatch ? jsonMatch[1]! : raw;
+
+  try {
+    const parsed = JSON.parse(jsonStr.trim()) as {
+      qualityScore?: number;
+      feedback?: string;
+    };
+    return {
+      qualityScore: parsed.qualityScore ?? 0,
+      feedback: parsed.feedback ?? raw,
+      tokensUsed: { input: 0, output: 0 }, // CLI 모드에서는 정확한 토큰 수 미확인
+      pass: (parsed.qualityScore ?? 0) >= 0.85,
+    };
+  } catch {
+    // JSON 파싱 실패 시 보수적 점수
+    return {
+      qualityScore: 0.3,
+      feedback: raw,
+      tokensUsed: { input: 0, output: 0 },
+      pass: false,
+    };
+  }
+}
+
+export interface OgdOptions {
+  maxRounds?: number;
+  qualityThreshold?: number;
+  costTracker?: CostTracker;
+}
+
+/**
+ * O-G-D 품질 루프 실행
+ * Generator → Discriminator → 수렴 판정 (max 3 rounds)
+ */
+export async function runOgdLoop(
+  job: PrototypeJob,
+  options: OgdOptions = {},
+): Promise<OgdResult> {
+  const maxRounds = options.maxRounds ?? 3;
+  const qualityThreshold = options.qualityThreshold ?? 0.85;
+  const costTracker = options.costTracker;
+
+  let bestScore = 0;
+  let bestOutput = '';
+  let totalCost = 0;
+
+  for (let round = 0; round < maxRounds; round++) {
+    const updatedJob: PrototypeJob = { ...job, round };
+
+    // 1. Generator: PRD + 이전 feedback → 코드 생성
+    const generated = await executeWithFallback(
+      updatedJob,
+      round,
+      (j, r) => runCliGenerator(j, r),
+    );
+
+    if (!generated.success) {
+      continue; // 생성 실패 → 다음 Round 시도
+    }
+
+    // 2. Discriminator: 생성물 평가 (현재는 스캐폴딩 — 실제 구현은 Sprint 160)
+    const evaluation = parseEvaluation(''); // placeholder — Sprint 160 F355에서 구현
+
+    // 3. 비용 추적
+    if (costTracker) {
+      const model = round < 2 ? 'haiku' : 'sonnet';
+      const record = costTracker.record(
+        job.id,
+        round,
+        model,
+        evaluation.tokensUsed.input,
+        evaluation.tokensUsed.output,
+      );
+      totalCost += record.cost;
+    }
+
+    // 4. 수렴 판정
+    if (evaluation.qualityScore >= qualityThreshold) {
+      return {
+        output: generated.output,
+        score: evaluation.qualityScore,
+        rounds: round + 1,
+        totalCost,
+      };
+    }
+
+    if (evaluation.qualityScore > bestScore) {
+      bestScore = evaluation.qualityScore;
+      bestOutput = generated.output;
+    }
+
+    // 5. 피드백을 다음 Round 입력으로 저장
+    await saveFeedback(job.workDir, round, evaluation.feedback);
+  }
+
+  // max rounds 도달 → 최고 점수 산출물 채택
+  return {
+    output: bestOutput,
+    score: bestScore,
+    rounds: maxRounds,
+    totalCost,
+  };
+}

--- a/prototype-builder/src/poller.ts
+++ b/prototype-builder/src/poller.ts
@@ -1,0 +1,106 @@
+import type { Prototype, BuilderConfig } from './types.js';
+
+/**
+ * Foundry-X API에서 대기 중인 Prototype Job을 폴링
+ */
+export async function pollForJobs(
+  config: Pick<BuilderConfig, 'apiBaseUrl' | 'apiToken'>,
+): Promise<Prototype[]> {
+  const response = await fetch(
+    `${config.apiBaseUrl}/api/prototypes?status=queued`,
+    {
+      headers: {
+        Authorization: `Bearer ${config.apiToken}`,
+        'Content-Type': 'application/json',
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`API polling failed: ${response.status} ${response.statusText}`);
+  }
+
+  const data = await response.json() as { items: Prototype[] };
+  return data.items;
+}
+
+/**
+ * feedback_pending 상태의 Job을 폴링 (피드백 재생성 대상)
+ */
+export async function pollForFeedbackJobs(
+  config: Pick<BuilderConfig, 'apiBaseUrl' | 'apiToken'>,
+): Promise<Prototype[]> {
+  const response = await fetch(
+    `${config.apiBaseUrl}/api/prototypes?status=feedback_pending`,
+    {
+      headers: {
+        Authorization: `Bearer ${config.apiToken}`,
+        'Content-Type': 'application/json',
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Feedback polling failed: ${response.status} ${response.statusText}`);
+  }
+
+  const data = await response.json() as { items: Prototype[] };
+  return data.items;
+}
+
+/**
+ * Prototype 상태를 API에 갱신
+ */
+export async function updatePrototypeStatus(
+  id: string,
+  update: Record<string, unknown>,
+  config: Pick<BuilderConfig, 'apiBaseUrl' | 'apiToken'>,
+): Promise<void> {
+  const response = await fetch(
+    `${config.apiBaseUrl}/api/prototypes/${id}`,
+    {
+      method: 'PATCH',
+      headers: {
+        Authorization: `Bearer ${config.apiToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(update),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Status update failed: ${response.status} ${response.statusText}`);
+  }
+}
+
+/**
+ * 폴링 루프 시작 — 주어진 간격으로 반복 실행
+ */
+export function startPollingLoop(
+  handler: () => Promise<void>,
+  intervalMs: number,
+): { stop: () => void } {
+  let running = true;
+  let timeoutId: ReturnType<typeof setTimeout>;
+
+  const loop = async () => {
+    if (!running) return;
+    try {
+      await handler();
+    } catch (err) {
+      console.error('[Poller] Error:', err);
+    }
+    if (running) {
+      timeoutId = setTimeout(loop, intervalMs);
+    }
+  };
+
+  void loop();
+
+  return {
+    stop() {
+      running = false;
+      clearTimeout(timeoutId);
+    },
+  };
+}

--- a/prototype-builder/src/state-machine.ts
+++ b/prototype-builder/src/state-machine.ts
@@ -1,0 +1,92 @@
+import {
+  type PrototypeStatus,
+  PROTOTYPE_TRANSITIONS,
+  PROTOTYPE_TIMEOUTS,
+  isValidPrototypeTransition,
+} from '@foundry-x/shared';
+
+export interface StateTransitionResult {
+  success: boolean;
+  from: PrototypeStatus;
+  to: PrototypeStatus;
+  error?: string;
+}
+
+export interface TimeoutCheck {
+  status: PrototypeStatus;
+  startedAt: number;
+  isTimedOut: boolean;
+  elapsedMs: number;
+  timeoutMs: number;
+}
+
+/**
+ * Prototype 상태 전환 실행 — 유효하지 않은 전환은 거부
+ */
+export function transition(
+  from: PrototypeStatus,
+  to: PrototypeStatus,
+): StateTransitionResult {
+  if (!isValidPrototypeTransition(from, to)) {
+    return {
+      success: false,
+      from,
+      to,
+      error: `Invalid transition: ${from} → ${to}. Allowed: [${PROTOTYPE_TRANSITIONS[from].join(', ')}]`,
+    };
+  }
+  return { success: true, from, to };
+}
+
+/**
+ * 상태별 timeout 초과 여부 확인
+ * building → 15분, deploying → 5분 초과 시 dead_letter 전환 대상
+ */
+export function checkTimeout(
+  status: PrototypeStatus,
+  startedAt: number,
+  now: number = Date.now(),
+): TimeoutCheck {
+  const timeoutMs = PROTOTYPE_TIMEOUTS[status] ?? Infinity;
+  const elapsedMs = now - startedAt;
+
+  return {
+    status,
+    startedAt,
+    isTimedOut: elapsedMs > timeoutMs,
+    elapsedMs,
+    timeoutMs,
+  };
+}
+
+/**
+ * dead-letter 전환이 가능한 상태인지 확인
+ */
+export function canDeadLetter(status: PrototypeStatus): boolean {
+  return isValidPrototypeTransition(status, 'dead_letter');
+}
+
+/**
+ * 재시도(retry) 가능한 상태인지 확인
+ * failed → queued, deploy_failed → deploying
+ */
+export function canRetry(status: PrototypeStatus): boolean {
+  if (status === 'failed') return isValidPrototypeTransition('failed', 'queued');
+  if (status === 'deploy_failed') return isValidPrototypeTransition('deploy_failed', 'deploying');
+  return false;
+}
+
+/**
+ * 피드백 재생성이 가능한 상태인지 확인
+ * live → feedback_pending → building
+ */
+export function canAcceptFeedback(status: PrototypeStatus): boolean {
+  return status === 'live';
+}
+
+/**
+ * 터미널(최종) 상태인지 확인
+ */
+export function isTerminal(status: PrototypeStatus): boolean {
+  return PROTOTYPE_TRANSITIONS[status].length === 0;
+}

--- a/prototype-builder/src/types.ts
+++ b/prototype-builder/src/types.ts
@@ -1,0 +1,66 @@
+// Builder Server 내부 타입 — shared types 위에 Builder 전용 타입 추가
+
+export type {
+  Prototype,
+  PrototypeStatus,
+  PrototypeCreateRequest,
+  PrototypeUpdateRequest,
+} from '@foundry-x/shared';
+
+export interface PrototypeJob {
+  id: string;
+  projectId: string;
+  name: string;
+  prdContent: string;
+  feedbackContent: string | null;
+  workDir: string;
+  round: number;
+}
+
+export interface OgdResult {
+  output: string;
+  score: number;
+  rounds: number;
+  totalCost: number;
+}
+
+export interface OgdEvaluation {
+  qualityScore: number;
+  feedback: string;
+  tokensUsed: { input: number; output: number };
+  pass: boolean;
+}
+
+export interface CostRecord {
+  jobId: string;
+  round: number;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cost: number;
+  timestamp: number;
+}
+
+export interface BuilderConfig {
+  apiBaseUrl: string;
+  apiToken: string;
+  anthropicApiKey: string;
+  cloudflareApiToken: string;
+  cloudflareAccountId: string;
+  pollIntervalMs: number;
+  maxOgdRounds: number;
+  qualityThreshold: number;
+  monthlyBudgetUsd: number;
+  slackWebhookUrl: string | null;
+}
+
+export interface DeployResult {
+  url: string;
+  projectName: string;
+}
+
+export type LogLevel = 'info' | 'warn' | 'error' | 'debug';
+
+export interface BuilderLogger {
+  log(level: LogLevel, message: string, meta?: Record<string, unknown>): void;
+}

--- a/prototype-builder/templates/react-spa/index.html
+++ b/prototype-builder/templates/react-spa/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Prototype</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/prototype-builder/templates/react-spa/package.json
+++ b/prototype-builder/templates/react-spa/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "prototype-spa",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.460.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "tailwind-merge": "^2.6.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.16",
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/prototype-builder/templates/react-spa/postcss.config.js
+++ b/prototype-builder/templates/react-spa/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/prototype-builder/templates/react-spa/src/App.tsx
+++ b/prototype-builder/templates/react-spa/src/App.tsx
@@ -1,0 +1,14 @@
+export default function App() {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <header className="border-b border-border px-6 py-4">
+        <h1 className="text-2xl font-bold">Prototype</h1>
+      </header>
+      <main className="p-6">
+        <p className="text-muted-foreground">
+          AI가 이 파일을 수정하여 PRD 기반 Prototype을 생성합니다.
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/prototype-builder/templates/react-spa/src/components/ui/button.tsx
+++ b/prototype-builder/templates/react-spa/src/components/ui/button.tsx
@@ -1,0 +1,46 @@
+import { type ButtonHTMLAttributes, forwardRef } from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '../../lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        outline: 'border border-border bg-background hover:bg-accent hover:text-accent-foreground',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 hover:underline',
+      },
+      size: {
+        default: 'h-10 px-4 py-2',
+        sm: 'h-9 rounded-md px-3',
+        lg: 'h-11 rounded-md px-8',
+        icon: 'h-10 w-10',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+);
+
+export interface ButtonProps
+  extends ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => (
+    <button
+      className={cn(buttonVariants({ variant, size, className }))}
+      ref={ref}
+      {...props}
+    />
+  ),
+);
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };

--- a/prototype-builder/templates/react-spa/src/components/ui/card.tsx
+++ b/prototype-builder/templates/react-spa/src/components/ui/card.tsx
@@ -1,0 +1,36 @@
+import { type HTMLAttributes, forwardRef } from 'react';
+import { cn } from '../../lib/utils';
+
+const Card = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('rounded-lg border bg-card text-card-foreground shadow-sm', className)}
+      {...props}
+    />
+  ),
+);
+Card.displayName = 'Card';
+
+const CardHeader = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+  ),
+);
+CardHeader.displayName = 'CardHeader';
+
+const CardTitle = forwardRef<HTMLParagraphElement, HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3 ref={ref} className={cn('text-2xl font-semibold leading-none tracking-tight', className)} {...props} />
+  ),
+);
+CardTitle.displayName = 'CardTitle';
+
+const CardContent = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+  ),
+);
+CardContent.displayName = 'CardContent';
+
+export { Card, CardHeader, CardTitle, CardContent };

--- a/prototype-builder/templates/react-spa/src/index.css
+++ b/prototype-builder/templates/react-spa/src/index.css
@@ -1,0 +1,33 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
+    --primary: 222.2 47.4% 11.2%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 214.3 31.8% 91.4%;
+    --radius: 0.5rem;
+  }
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/prototype-builder/templates/react-spa/src/lib/utils.ts
+++ b/prototype-builder/templates/react-spa/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/prototype-builder/templates/react-spa/src/main.tsx
+++ b/prototype-builder/templates/react-spa/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/prototype-builder/templates/react-spa/tailwind.config.ts
+++ b/prototype-builder/templates/react-spa/tailwind.config.ts
@@ -1,0 +1,46 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        border: 'hsl(var(--border))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
+        },
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/prototype-builder/templates/react-spa/tsconfig.json
+++ b/prototype-builder/templates/react-spa/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/prototype-builder/templates/react-spa/vite.config.ts
+++ b/prototype-builder/templates/react-spa/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: 'dist',
+    sourcemap: false,
+  },
+});

--- a/prototype-builder/tsconfig.json
+++ b/prototype-builder/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../packages/shared" }
+  ]
+}

--- a/prototype-builder/vitest.config.ts
+++ b/prototype-builder/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary
- F351: React SPA 템플릿(Vite+React18+TailwindCSS+shadcn/ui) + Builder Server 8모듈 스캐폴딩 + Docker 격리
- F352: Claude Code CLI `--bare` 모드 executor + CostTracker + Fallback 아키텍처
- 49 tests 통과 (state-machine 28 + cost-tracker 12 + executor 9)

## Test plan
- [x] `pnpm test` — 49 tests passing
- [x] State Machine 전환 규칙 검증
- [x] CostTracker 월 예산 알림 검증
- [x] CLI `--bare` 인자 빌드 검증
- [ ] E2E: 실제 API 키로 PRD→배포 (환경 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)