### PR TITLE
feat: Sprint 166 — offering-pptx SKILL.md + ax-bd-offering-agent (F367, F368)

### DIFF
--- a/.claude/agents/ax-bd-offering-agent.md
+++ b/.claude/agents/ax-bd-offering-agent.md
@@ -1,0 +1,274 @@
+---
+name: ax-bd-offering-agent
+description: 형상화 라이프사이클 오케스트레이터 — DiscoveryPackage → Offering(HTML/PPTX) 전체 관리, 6 capability
+model: opus
+tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Agent
+  - Bash
+  - WebSearch
+color: cyan
+role: orchestrator
+---
+
+# AX BD Offering Agent
+
+형상화(3단계) 전체 라이프사이클을 관리하는 오케스트레이터.
+DiscoveryPackage(발굴 산출물)를 입력으로 받아 표준 사업기획서(HTML/PPTX)를 생성한다.
+
+## 상위 관계
+
+- **ax-bd-offering-agent**: 형상화 전체 워크플로우 (Phase 0~4) — 본 에이전트
+- **shaping-orchestrator**: Phase C O-G-D 루프만 관리 (기존, 변경 없음)
+- **offering-html / offering-pptx**: 포맷별 생성 스킬 (에이전트가 호출)
+
+```
+ax-bd-offering-agent (본 에이전트)
+├── Phase 0~2: 초기화 + 콘텐츠 준비 + 생성
+├── Phase 3: validate_orchestration
+│   ├── shaping-orchestrator → O-G-D Loop
+│   ├── six-hats-moderator → 6색 모자 토론
+│   └── expert-ta~qa → 5인 전문가 리뷰
+└── Phase 4: version_guide → 반복 개선
+```
+
+## 입력
+
+스킬(offering-html 또는 offering-pptx)로부터 다음을 수신한다:
+- **discovery_package**: 발굴 단계(2-0~2-8) 산출물 경로
+- **offering_config**: 목적(purpose), 포맷(format), 섹션 토글, 디자인 토큰 오버라이드
+- **workspace**: 작업 디렉토리 (예: `_workspace/offering/{run-id}`)
+
+## 사전 조건
+
+1. DiscoveryPackage가 2-8 Packaging까지 완료되어야 한다 (불완전 시 부족한 단계 목록 + AskUserQuestion)
+2. OfferingConfig가 유효해야 한다 (purpose, format 필수)
+3. workspace 디렉토리가 쓰기 가능해야 한다
+
+## 6 Capability
+
+### C1: format_selection — 포맷 결정
+
+OfferingConfig.format + 컨텍스트에 따라 출력 포맷을 결정한다.
+
+```
+Input:
+  - OfferingConfig.format: "html" | "pptx" | "auto"
+  - context: { audience, occasion, deliveryMethod }
+
+Logic:
+  if format == "auto":
+    if audience == "external_client" → "pptx"
+    if audience == "internal_exec" → "pptx"
+    if audience == "team_review" → "html"
+    default → "html"
+  else:
+    use specified format
+
+Output: { format: "html" | "pptx", reason: string }
+```
+
+### C2: content_adapter — 톤 변환
+
+DiscoveryPackage에서 목적별 톤으로 콘텐츠를 변환한다.
+
+```
+Input:
+  - DiscoveryPackage (2-0 ~ 2-8 산출물)
+  - OfferingConfig.purpose: "report" | "proposal" | "review"
+
+Tone Rules:
+  report:   경영 언어 ("~를 추진", "약 XX억원"), Exec Summary 강조
+  proposal: 기술 상세 (솔루션 아키텍처, PoC 시나리오), 구현 가능성 강조
+  review:   리스크 중심 (No-Go 기준, 리스크 매트릭스), 비판적 검토
+
+Section Mapping (INDEX.md DiscoveryPackage Schema):
+  2-0 item_overview    → Hero, Exec Summary, §02-3
+  2-1 reference_analysis → §02-6 글로벌·국내 동향
+  2-2 market_validation  → §04-2 시장 분석
+  2-3 competition_analysis → §04-2 경쟁, §05 GTM
+  2-4 item_derivation    → §02-1~02-2 Why
+  2-5 core_selection     → §01 추진배경
+  2-6 customer_profile   → §02-3, §03-2 시나리오
+  2-7 business_model     → §04-3 매출 계획
+  2-8 packaging          → 전체 기초 자료
+
+Output: SectionContent[] (18섹션별 톤 적용 콘텐츠)
+```
+
+### C3: structure_crud — 섹션 목차 관리
+
+Offering 섹션 목차를 관리한다.
+
+```
+Operations:
+  create: 18섹션 기본 목차 초기화 (필수 16 + 선택 2)
+  read:   현재 목차 + 필수/선택 상태
+  update: 섹션 토글 (활성/비활성), 커스텀 섹션 추가
+  delete: 커스텀 섹션 삭제 (표준 섹션은 비활성만 가능)
+
+Rules:
+  - 필수(●) 섹션은 비활성화 불가
+  - 선택(○) 섹션: 02-4 (기존 사업 현황), 02-5 (Gap 분석)
+  - 커스텀 섹션: 표준 목차 사이에 삽입 가능 (번호: C01, C02, ...)
+```
+
+### C4: design_management — 디자인 토큰 관리
+
+디자인 토큰을 적용하고 브랜드 커스터마이징을 관리한다.
+
+```
+Input:
+  - design-tokens.md (기본 39 토큰)
+  - OfferingConfig.designTokenOverrides (선택, Partial)
+
+Logic:
+  1. design-tokens.md에서 기본 토큰 로드
+  2. designTokenOverrides 병합 (존재하는 키만 오버라이드)
+  3. 안전성 검증:
+     - 변경 가능: color.data.*, typography.hero/section 크기, layout.maxWidth
+     - 변경 주의 (경고): layout.breakpoint, spacing.grid.gap
+     - 변경 금지 (거부): typography.body, animation
+  4. 포맷별 변환:
+     HTML: CSS custom properties → base.html :root 주입
+     PPTX: 슬라이드 마스터 스타일 속성으로 변환
+
+Output: AppliedTokens (최종 적용된 토큰 세트 + 경고 목록)
+```
+
+### C5: validate_orchestration — 검증 오케스트레이션
+
+기존 O-G-D + Six Hats + Expert 인프라를 활용해 Offering 품질을 검증한다.
+
+```
+Input: Offering draft (HTML 또는 PPTX 콘텐츠)
+
+Execution:
+  Step 1: O-G-D Loop (ogd-orchestrator → ogd-generator ↔ ogd-discriminator)
+    - Offering 콘텐츠를 PRD처럼 취급하여 추진론/반대론 생성
+    - max_rounds: 3, convergence: quality_score >= 0.85
+    - 산출물: {workspace}/validation/ogd-result.md
+
+  Step 2: Six Hats 토론 (six-hats-moderator)
+    - O-G-D 결과 + Offering 콘텐츠 입력
+    - 6색 모자별 의견 수집 → 합의안 도출
+    - 산출물: {workspace}/validation/six-hats-result.md
+
+  Step 3: Expert 5인 리뷰 (expert-ta, aa, ca, da, qa)
+    - TA: 기술 실현성
+    - AA: 아키텍처 적합성
+    - CA: 클라우드 인프라
+    - DA: 데이터 전략
+    - QA: 품질/테스트 관점
+    - 산출물: {workspace}/validation/expert-{role}-result.md
+
+  Step 4: 종합 판정
+    - 3단계 결과 종합 → §04-5 교차검증 섹션 자동 구성
+    - Pass: 3단계 모두 긍정 → Offering 승인
+    - Conditional: 일부 조건부 → 수정 후 재검증
+    - Fail: 구조적 결함 → 재생성 권고
+
+Output:
+  ValidationResult {
+    verdict: "pass" | "conditional" | "fail"
+    ganResult: OGDResult
+    sixHatsResult: SixHatsResult
+    expertResults: ExpertResult[]
+    crossValidationSection: string  // §04-5 콘텐츠
+  }
+```
+
+### C6: version_guide — 버전 관리 가이드
+
+피드백 기반 버전 관리를 가이드한다.
+
+```
+Input: Offering + Feedback[]
+
+Logic:
+  1. 피드백 분류:
+     - 구조적: 목차 변경, 섹션 추가/삭제
+     - 내용적: 데이터 수정, 문구 변경
+     - 어조: 톤 변경 (report↔proposal↔review)
+  2. 영향 범위 분석:
+     - 구조적 → 전체 재생성 (content_adapter + structure_crud 재실행)
+     - 내용적 → 부분 수정 (해당 섹션만 재생성)
+     - 어조 → content_adapter 재실행 (구조 유지, 톤만 변경)
+  3. 버전 결정:
+     - 구조적 변경 → major: v0.1 → v0.2
+     - 내용적 변경 → minor: v0.1 내 업데이트
+     - 어조 변경 → content_adapter 재실행, 버전 유지
+  4. 변경 이력 기록: {workspace}/version-history.md
+
+Output:
+  VersionPlan {
+    nextVersion: string
+    changeScope: "full" | "partial" | "tone-only"
+    affectedSections: string[]
+    regenerateStrategy: string
+  }
+```
+
+## 실행 프로토콜
+
+### Phase 0: 초기화
+
+1. DiscoveryPackage 존재 확인 (2-0~2-8 산출물)
+   - 불완전 시: 부족한 단계 목록 출력 + AskUserQuestion
+2. OfferingConfig 파싱 + 검증
+   - purpose: "report" | "proposal" | "review" (필수)
+   - format: "html" | "pptx" | "auto" (필수)
+   - sections: SectionToggle[] (선택, 기본=전체 필수)
+   - designTokenOverrides: Partial (선택)
+3. workspace 생성: `_workspace/offering/{run-id}/`
+
+### Phase 1: 콘텐츠 준비
+
+1. **C1 format_selection** → 최종 포맷 결정
+2. **C2 content_adapter** → 톤 변환된 18섹션 콘텐츠 생성
+3. **C3 structure_crud** → 목차 초기화 (필수/선택 섹션 토글)
+
+### Phase 2: 생성
+
+1. **C4 design_management** → 디자인 토큰 적용
+2. 스킬 호출:
+   - format == "html" → offering-html 스킬의 [4] 초안 생성 실행
+   - format == "pptx" → offering-pptx 스킬의 [4] 초안 생성 실행
+3. 산출물: `{workspace}/offering-v0.1.{html|pptx}`
+
+### Phase 3: 검증 (자동)
+
+1. **C5 validate_orchestration** 실행
+   - O-G-D Loop → Six Hats → Expert 5인
+2. §04-5 교차검증 섹션 자동 구성
+3. 검증 결과 반영: Offering에 §04-5 슬라이드/섹션 삽입
+4. 판정: Pass → Phase 4 스킵, Conditional/Fail → Phase 4
+
+### Phase 4: 반복 개선
+
+1. **C6 version_guide** → 피드백 분석 + 버전 전략
+2. Phase 1~3 반복 (최대 4회 = v0.1 ~ v0.4)
+3. v0.5+: 보고용 마무리 (경영 언어 최종 점검)
+4. v1.0: 최종 확정 (보고 대상·일정 확인 후)
+
+## 에러 핸들링
+
+| 상황 | 조치 |
+|------|------|
+| DiscoveryPackage 불완전 (2-8 미완) | 부족한 단계 목록 + AskUserQuestion으로 보충 수집 |
+| O-G-D Loop 수렴 실패 | shaping-orchestrator FORCED_STOP → 사용자 에스컬레이션 |
+| 디자인 토큰 오버라이드 무효 | 무효 키 무시 + 경고 메시지, 기본 토큰 유지 |
+| Expert Agent 호출 실패 | 실패 Expert 건너뛰기 + 부분 결과 반환 + 경고 |
+| PPTX 엔진 미설정 (F380 전) | "PPTX 엔진은 Sprint 172에서 구현됩니다" 안내 |
+
+## 주의사항
+
+- offering-html과 offering-pptx는 **동일 입력 스키마**를 공유한다 — 포맷만 다름
+- validate_orchestration은 **기존 O-G-D 인프라를 그대로 재활용**한다 — 신규 구현 최소화
+- 이 에이전트는 **산출물 자체를 직접 수정하지 않는다** — 스킬(offering-html/pptx)에 위임
+- DiscoveryPackage 부재 시 강제 생성 금지 — 반드시 발굴 단계(2-0~2-8) 완료 후 실행
+- design-tokens.md Phase 1(MD)에서 Phase 2(JSON) 전환 시 C4 로직 갱신 필요 (Sprint 173 F381)

--- a/.claude/skills/ax-bd/shape/INDEX.md
+++ b/.claude/skills/ax-bd/shape/INDEX.md
@@ -15,7 +15,7 @@ AX BD 프로세스 6단계 중 3단계: 발굴 산출물 → 사업기획서 형
 | # | Skill | Input | Output | Format | Status |
 |---|-------|-------|--------|--------|--------|
 | 3-1 | [offering-html](offering-html/SKILL.md) | DiscoveryPackage + OfferingConfig | OfferingHTML | HTML | Active |
-| 3-2 | [offering-pptx](offering-pptx/SKILL.md) | DiscoveryPackage + OfferingConfig | OfferingPPTX | PPTX | Stub |
+| 3-2 | [offering-pptx](offering-pptx/SKILL.md) | DiscoveryPackage + OfferingConfig | OfferingPPTX | PPTX | Active |
 | 3-P | [prototype-builder](prototype-builder/SKILL.md) | OfferingArtifact + PrototypeConfig | Prototype | React/HTML | Stub |
 
 ## OfferingConfig Schema

--- a/.claude/skills/ax-bd/shape/offering-pptx/SKILL.md
+++ b/.claude/skills/ax-bd/shape/offering-pptx/SKILL.md
@@ -2,39 +2,226 @@
 name: offering-pptx
 domain: ax-bd
 stage: shape
-version: "0.1"
-description: "AX BD팀 사업기획서(PPTX) 생성 스킬 — Sprint 166 F367에서 본구현"
+version: "1.0"
+description: "AX BD팀 사업기획서(PPTX) 생성 스킬 — 18섹션 표준 슬라이드, 디자인 토큰 기반 렌더링"
 input_schema: DiscoveryPackage + OfferingConfig
 output_schema: OfferingPPTX
 upstream: [ax-bd/discover/packaging]
 downstream: [ax-bd/validate/gan-cross-review]
 agent: ax-bd-offering-agent
-status: stub
+status: Active
+triggers:
+  - 사업기획서 PPT
+  - offering pptx
+  - 형상화 PPTX
+  - business proposal pptx
+  - PPT 만들어줘
 evolution:
   track: DERIVED
   registry_id: null
 ---
 
-# Offering PPTX (Stub)
+# Offering PPTX — AX BD 사업기획서 생성 스킬 (PPTX)
 
-Sprint 166 F367에서 본구현 예정.
+AX BD팀이 발굴한 사업 아이템을 KT 연계 AX 사업기획서(PPTX)로 형상화하는 스킬.
+KT 연계 AX 사업개발 체계의 **3. 형상화** 단계를 자동화한다.
+
+> offering-html과 대칭 구조. 동일 DiscoveryPackage + OfferingConfig를 입력으로 받아 PPTX로 출력한다.
 
 ## When
 
-대외 제안용 사업기획서가 PPTX 포맷으로 필요할 때.
+- 발굴 단계(2-0~2-8) 산출물이 **2-8 Packaging**까지 완료된 후
+- 사용자가 "사업기획서 PPT 만들어줘" 또는 "offering pptx" 요청 시
+- OfferingConfig.format = "pptx" 인 경우
 
-## How
+### 3가지 트리거 시나리오
 
-1. DiscoveryPackage 로드
-2. OfferingConfig.format = "pptx" 확인
-3. 표준 슬라이드 목차에 따라 PPTX 생성
-4. Cowork pptx 스킬 연동 (공유·편집)
+| 시나리오 | purpose | 특성 |
+|---------|---------|------|
+| 대외 제안용 | proposal | 고객/파트너 제출, 기술 상세 + 솔루션 강조 |
+| 경영회의 보고용 | report | 본부장/대표 보고, 경영 언어 + Exec Summary 강조 |
+| 팀 내부 검토용 | review | 진행상황 공유, 리스크 중심 + No-Go 기준 강조 |
+
+## How (8단계 생성 프로세스)
+
+```
+[1] 아이템 확인
+    └── 발굴 단계(2-0~2-8) 산출물 확인
+    └── 어떤 단계까지 완료되었는지 파악
+        ↓
+[2] 슬라이드 목차 확정
+    └── 18섹션 표준 목차에서 필수/선택 결정
+    └── 선택 섹션(02-4, 02-5) 포함 여부 판단:
+        - 기존 고객: 02-4 포함 (레버리지 자산)
+        - 신규 고객: 02-4 → "고객 접근 전략"으로 대체
+        - 신규 시장: 02-5 → "시장 진입 장벽 분석"으로 대체
+    └── 섹션→슬라이드 매핑 (§표준 슬라이드 목차)
+        ↓
+[3] 핵심 정보 수집
+    └── DiscoveryPackage에서 슬라이드별 데이터 매핑
+    └── 부족한 정보는 사용자에게 AskUserQuestion
+        ↓
+[4] 초안 생성 (v0.1)
+    └── PPTX 엔진으로 슬라이드 생성 (§PPTX 엔진)
+    └── design-tokens.md 기반 슬라이드 스타일 적용
+    └── OfferingConfig.purpose에 따라 톤 결정:
+        - report:   경영 언어, Exec Summary 강조, 발표 노트 간결
+        - proposal: 기술 상세, 솔루션 아키텍처 다이어그램 포함
+        - review:   리스크 매트릭스, No-Go 판정 기준 강조
+        ↓
+[5] 피드백 반영
+    └── 슬라이드별 수정 요청 반영 → 버전 업 (v0.2~v0.4)
+    └── 발표 노트 추가/수정
+        ↓
+[6] 교차검증 (자동)
+    └── §04-5 사업성 교차검증 슬라이드 자동 구성
+    └── ax-bd-offering-agent → validate_orchestration 호출
+    └── GAN 추진론/반대론 + Six Hats + Expert 5인 결과 → 슬라이드 반영
+        ↓
+[7] 보고용 마무리 (v0.5+)
+    └── 본부장/대표 보고 수준 품질 확인
+    └── 경영 언어 원칙 최종 점검
+    └── 발표 노트 완성 (슬라이드당 2~3문장)
+        ↓
+[8] 최종 확정 (v1.0)
+    └── 보고 대상·일정 확인 후 최종본
+```
+
+## 표준 슬라이드 목차 (18섹션→슬라이드 매핑)
+
+| 섹션 # | 섹션명 | 슬라이드 수 | 슬라이드 유형 | 필수 |
+|--------|--------|------------|-------------|------|
+| — | 표지 | 1 | title-slide | ● |
+| — | 목차 | 1 | toc-slide | ● |
+| 0 | Hero | 1 | hero-slide (KPI 3개 포함) | ● |
+| 0.5 | Executive Summary | 2 | exec-summary (텍스트+도표) | ● |
+| 01 | 추진 배경 및 목적 | 2 | content-slide (3축 구조) | ● |
+| 02-1 | 왜 이 문제/영역 | 1 | content-slide | ● |
+| 02-2 | 왜 이 기술/접근법 | 1 | content-slide | ● |
+| 02-3 | 왜 이 고객/도메인 | 1 | content-slide | ● |
+| 02-4 | 기존 사업 현황 | 1 | data-slide (레버리지 차트) | ○ |
+| 02-5 | Gap 분석 | 1 | compare-slide (현재 vs 목표) | ○ |
+| 02-6 | 글로벌·국내 동향 | 2 | data-slide (경쟁사 매트릭스) | ● |
+| 03-1 | 솔루션 개요 | 2 | before-after-slide | ● |
+| 03-2 | 시나리오/Use Case | 2 | scenario-slide (PoC + 본사업) | ● |
+| 03-3 | 사업화 로드맵 | 1 | roadmap-slide (타임라인) | ● |
+| 04-1 | 데이터 확보 방식 | 1 | content-slide (계층별) | ● |
+| 04-2 | 시장 분석 및 경쟁 환경 | 2 | data-slide (TAM/SAM/SOM) | ● |
+| 04-3 | 사업화 방향 및 매출 계획 | 2 | data-slide (3개년 시나리오) | ● |
+| 04-4 | 추진 체계 및 투자 계획 | 1 | org-slide (조직·비용) | ● |
+| 04-5 | 사업성 교차검증 | 2 | gan-slide (추진론/반대론) | ● |
+| 04-6 | 기대효과 | 1 | impact-slide | ● |
+| 05 | KT 연계 GTM 전략(안) | 2 | strategy-slide | ● |
+| — | 마무리 | 1 | closing-slide | ● |
+
+> ● = 필수, ○ = 선택
+> **총 슬라이드**: 필수 31장 + 선택 2장 = 33장 (최대)
+
+### 슬라이드 유형별 레이아웃
+
+| 유형 | 레이아웃 | 디자인 토큰 매핑 |
+|------|---------|-----------------|
+| title-slide | 중앙 정렬, 고객명 + 프로젝트명 + 날짜 | typography.hero, color.bg.default |
+| toc-slide | 2열 목차, 섹션 번호 + 제목 | typography.section, color.text.primary |
+| hero-slide | 한줄 요약 + KPI 3개 카드 | typography.hero, typography.kpi |
+| exec-summary | 좌: 텍스트 요약 / 우: 핵심 도표 | typography.body, layout.maxWidth |
+| content-slide | 제목 + 본문 + 보조 그래픽 | typography.section, typography.body |
+| data-slide | 제목 + 차트/테이블 + 범례 | color.data.*, typography.label |
+| compare-slide | 좌: Before / 우: After | color.border.strong |
+| before-after-slide | 상: Before / 하: After (화살표) | color.data.positive/negative |
+| scenario-slide | 시나리오 카드 2~3개 | layout.cardRadius, spacing.grid.gap |
+| roadmap-slide | 타임라인 (단기→중기→장기) | color.data.*, typography.label |
+| org-slide | 조직도 + 비용 테이블 | typography.body, color.border.default |
+| gan-slide | 좌: 추진론 / 우: 반대론 + 판정 | color.data.positive/negative |
+| impact-slide | 기대효과 리스트 + 수치 | typography.kpi, color.data.positive |
+| strategy-slide | GTM 전략 + KT 연계 구조 | typography.section |
+| closing-slide | 감사 인사 + 연락처 | typography.hero |
+
+## 작성 원칙
+
+### 경영 언어 (HTML과 동일)
+- "~할 수 있다" → "~를 제안 예정", "~를 추진"
+- 금액에 반드시 "약" 표기
+- "최초", "첫" 표현 금지 → "선도적 사례", "초기 시장"
+- 볼드는 핵심 키워드에만 (슬라이드당 2~3개)
+
+### PPTX 특화 원칙
+- **발표 노트**: 슬라이드당 2~3문장, 발표자가 읽는 용도
+- **글자 크기**: 본문 최소 14pt, 제목 최소 24pt (가독성)
+- **슬라이드당 핵심 메시지**: 1개 (한줄로 요약 가능해야 함)
+- **애니메이션**: 기본 없음 (필요 시 Fade-In만 허용)
+- **차트/테이블**: 색상은 data-tokens만 사용, 불필요한 장식 배제
+
+### KT 연계 (HTML과 동일)
+- KT 연계 없는 사업은 이 포맷의 대상이 아님
+- KT와의 현재 상태를 솔직하게 기술
+- 단계적: kt ds 주도 → KT 사전 협의 → KT 공동 제안
 
 ## Output Format
 
-`AX Discovery_사업기획서_{고객명}_v{버전}_{YYMMDD}.pptx`
+### 파일명
+```
+AX Discovery_사업기획서_{고객명}_v{버전}_{YYMMDD}.pptx
+```
+
+### 버전 관리
+| 버전 | 의미 |
+|------|------|
+| v0.1 | 초안 (목차 + 핵심 슬라이드) |
+| v0.2~0.4 | 피드백 반영 수정 |
+| v0.5+ | 본부장/대표 보고용 |
+| v1.0 | 최종 확정본 |
+
+## PPTX 엔진
+
+> Sprint 172 F380에서 최종 선택. 여기서는 비교 매트릭스만 제공한다.
+
+| 기준 | pptxgenjs | python-pptx |
+|------|----------|-------------|
+| 언어 | TypeScript/JS | Python |
+| 런타임 | Node.js / Browser | Python subprocess |
+| 차트 지원 | ● 내장 | ● 내장 |
+| 슬라이드 마스터 | ○ 제한적 | ● 완전 지원 |
+| 한국어 폰트 | ● Pretendard embed 가능 | ● 가능 |
+| Workers 호환 | ✅ (ESM) | ❌ (subprocess 필요) |
+| 패키지 크기 | ~300KB | ~50MB (Python 환경) |
+
+**유력 후보**: pptxgenjs — Workers 환경에서 직접 실행 가능, ESM 호환, 가벼움.
+**대안**: python-pptx — 슬라이드 마스터 복잡도가 높을 경우.
+
+## Cowork PPTX 연동
+
+PPTX 공유·편집을 위한 Cowork 연동 인터페이스 설계:
+
+```
+CoworkPPTXInterface:
+  upload(pptxBuffer, metadata) → CoworkDocId
+  share(docId, users[])       → ShareLink
+  getComments(docId)           → Comment[]
+  exportVersion(docId, ver)    → Buffer
+```
+
+### 워크플로우
+
+```
+[1] Offering PPTX 생성 (이 스킬)
+        ↓
+[2] Cowork 업로드 (CoworkPPTXInterface.upload)
+        ↓
+[3] 팀/고객 공유 (CoworkPPTXInterface.share)
+        ↓
+[4] 코멘트 수집 (CoworkPPTXInterface.getComments)
+        ↓
+[5] 피드백 반영 → v0.2+ 재생성
+        ↓
+[6] 최종본 export (CoworkPPTXInterface.exportVersion)
+```
+
+> 실구현은 Cowork MCP 연동 시점에 확정. 현재는 인터페이스 정의.
 
 ## Dependencies
 
-- pptxgenjs 또는 python-pptx (Sprint 172 F380에서 엔진 선택)
-- Cowork pptx 연동 (Sprint 166 F367 설계)
+- **offering-html** — 동일 DiscoveryPackage + OfferingConfig 구조 공유
+- **design-tokens.md** — PPTX 슬라이드 스타일링에 동일 토큰 적용
+- **ax-bd-offering-agent** — 형상화 라이프사이클 오케스트레이션 (Sprint 166 F368)
+- **PPTX 엔진** — Sprint 172 F380에서 선택 + 구현

--- a/docs/01-plan/features/sprint-166.plan.md
+++ b/docs/01-plan/features/sprint-166.plan.md
@@ -1,0 +1,192 @@
+---
+code: FX-PLAN-S166
+title: "Sprint 166: Foundation — Agent 확장 + PPTX 설계"
+version: 1.0
+status: Active
+category: PLAN
+created: 2026-04-06
+updated: 2026-04-06
+author: Sinclair Seo
+feature: sprint-166
+phase: "[[FX-PLAN-018]]"
+sprint: 166
+f_items: [F367, F368]
+---
+
+## Executive Summary
+
+| 항목 | 내용 |
+|------|------|
+| Feature | Sprint 166 — Foundation: Agent 확장 + PPTX 설계 |
+| 시작일 | 2026-04-06 |
+| F-items | F367 (offering-pptx SKILL.md), F368 (ax-bd-offering-agent 6 capability) |
+| 의존성 | F363 (offering-html SKILL.md, Sprint 165 ✅) 선행 |
+
+### Value Delivered (4-Perspective)
+
+| 관점 | 설명 |
+|------|------|
+| **Problem** | 형상화 단계에서 PPTX 스킬이 stub 상태이고, 발굴→형상화를 총괄하는 에이전트가 부재 |
+| **Solution** | offering-pptx SKILL.md 본구현 + ax-bd-offering-agent 6 capability 에이전트 정의 |
+| **Function UX Effect** | PPTX 생성 프로세스가 정의되고, 형상화 전체 라이프사이클을 단일 에이전트가 오케스트레이션 |
+| **Core Value** | Phase 18 후속 Sprint(167~174)가 안정적으로 API/UI를 구현할 수 있는 에이전트·스킬 기반 확보 |
+
+---
+
+## 1. 개요
+
+Phase 18 Offering Pipeline의 두 번째 Sprint. Sprint 165에서 구축한 offering-html 기반 위에
+PPTX 스킬을 본구현하고, 형상화 전체 라이프사이클을 관리하는 에이전트를 정의한다.
+코드(API/Web) 변경 없이 `.claude/skills/` + `.claude/agents/` 인프라에 집중한다.
+
+### 1.1 F-item 범위
+
+| F# | 제목 | REQ | P | 비고 |
+|----|------|-----|---|------|
+| F367 | offering-pptx SKILL.md 등록 + Cowork 연동 설계 | FX-REQ-359 | P1 | |
+| F368 | ax-bd-offering-agent — shaping-orchestrator 확장, 6 capability | FX-REQ-360 | P0 | F363 선행 |
+
+### 1.2 변경 영역
+
+```
+.claude/skills/ax-bd/shape/
+├── offering-pptx/
+│   └── SKILL.md               # F367 — stub → 본구현
+└── INDEX.md                    # F368 agent 설명 갱신 (이미 반영됨)
+
+.claude/agents/
+└── ax-bd-offering-agent.md     # F368 — 🆕 신규 에이전트 정의
+
+packages/api/src/               # F368 Skill Registry 연동 테스트
+└── (기존 test 확장 — offering-pptx 등록 테스트 1건)
+```
+
+### 1.3 의존성
+
+```
+Sprint 165 (완료)
+├── F363 offering-html SKILL.md ──→ F367 offering-pptx SKILL.md (동일 구조 대칭)
+├── F363 INDEX.md ──────────────→ F368 agent 참조 (이미 선언됨)
+└── F365 design-tokens.md ─────→ F367 PPTX 디자인 토큰 매핑
+
+기존 에이전트
+├── shaping-orchestrator ───────→ F368 확장 기반 (Phase C O-G-D 루프)
+├── ogd-orchestrator/gen/disc ──→ F368 validate_orchestration 호출 대상
+├── six-hats-moderator ────────→ F368 validate_orchestration 호출 대상
+└── expert-ta~qa (5종) ────────→ F368 validate_orchestration 호출 대상
+```
+
+---
+
+## 2. 구현 계획
+
+### Phase A: offering-pptx SKILL.md 본구현 (F367)
+
+기존 stub(v0.1)을 offering-html SKILL.md와 대칭 구조로 확장한다.
+
+1. **frontmatter 갱신**: version "0.1" → "1.0", status: stub → Active
+2. **When 섹션**: PPTX 포맷이 필요한 3가지 시나리오 명시
+   - 대외 제안용 사업기획서 (고객/파트너 제출용)
+   - 경영회의 보고용 (본부장/대표 보고)
+   - 팀 내부 검토용 (진행상황 공유)
+3. **How 섹션**: 8단계 생성 프로세스 (offering-html과 동일 단계, PPTX 특화)
+   - [1] 아이템 확인 → [2] 슬라이드 목차 확정 → [3] 핵심 정보 수집
+   - [4] 초안 생성 → [5] 피드백 반영 → [6] 교차검증
+   - [7] 보고용 마무리 → [8] 최종 확정
+4. **표준 슬라이드 목차**: 18섹션 → 슬라이드 매핑 테이블
+   - 1 섹션 = 1~3 슬라이드 원칙 (총 25~40 슬라이드)
+   - Hero → 표지, Exec Summary → 요약 2슬라이드, 본문 → 섹션당 2~3장
+5. **Cowork PPTX 연동 설계**: 공유·편집 워크플로우 정의
+   - Cowork MCP 연동 인터페이스 (향후 구현 시 참조 구조)
+   - PPTX 버전 관리 (v0.1~v1.0 흐름)
+6. **PPTX 엔진 비교표**: pptxgenjs vs python-pptx 의사결정 연기 사유 + 비교 매트릭스
+   - 최종 선택은 Sprint 172 F380 (Risk R1)
+7. **Output Format**: `AX Discovery_사업기획서_{고객명}_v{버전}_{YYMMDD}.pptx`
+
+### Phase B: ax-bd-offering-agent 에이전트 정의 (F368)
+
+shaping-orchestrator를 기반으로 형상화 전체 라이프사이클을 관리하는 신규 에이전트를 정의한다.
+
+1. **에이전트 메타데이터**:
+   - name: ax-bd-offering-agent
+   - model: opus
+   - tools: Read, Write, Edit, Glob, Grep, Agent, Bash, WebSearch
+   - role: orchestrator (shaping-orchestrator와 동일 역할군)
+2. **6 Capability 정의**:
+
+| # | Capability | 입력 | 출력 | 호출 대상 |
+|---|-----------|------|------|----------|
+| C1 | format_selection | OfferingConfig + context | format decision | 내부 로직 |
+| C2 | content_adapter | DiscoveryPackage + purpose | 톤 변환된 섹션 콘텐츠 | LLM (톤 프롬프트) |
+| C3 | structure_crud | offering_id + section_toggle | 섹션 목록 CRUD | (Sprint 167+ API) |
+| C4 | design_management | DesignTokens + overrides | 브랜드 커스텀 적용 | design-tokens.md |
+| C5 | validate_orchestration | offering draft | 검증 결과 | ogd + six-hats + expert |
+| C6 | version_guide | offering + feedback | 버전 업 가이드 | 내부 로직 |
+
+3. **실행 프로토콜**:
+   - Phase 0: DiscoveryPackage 로드 + OfferingConfig 파싱
+   - Phase 1: format_selection → content_adapter → structure_crud
+   - Phase 2: design_management → 초안 생성 (offering-html 또는 offering-pptx 스킬 호출)
+   - Phase 3: validate_orchestration (O-G-D Loop + Six Hats + Expert)
+   - Phase 4: version_guide (피드백 반영 → 재생성 루프)
+4. **기존 에이전트 위임 관계**:
+   - shaping-orchestrator: Phase C O-G-D 루프 (변경 없음, 그대로 호출)
+   - ogd-orchestrator: Offering 품질 검증 시 호출 (validate_orchestration)
+   - six-hats-moderator: Offering 교차검증 토론 (validate_orchestration)
+   - expert-ta~qa: 5인 전문가 리뷰 (validate_orchestration)
+5. **에러 처리**: 각 capability별 실패 시 fallback + 사용자 에스컬레이션 규칙
+
+### Phase C: Skill Registry 연동 + 테스트 (F367 + F368)
+
+1. offering-pptx Skill Registry 등록 테스트 추가
+   - `packages/api/src/__tests__/skill-registry-offering-pptx.test.ts` (신규)
+   - POST /api/skill-registry + GET + category filter + search 4건
+2. INDEX.md agent 섹션이 F368 반영 여부 확인 (이미 Sprint 165에서 선언됨)
+3. 기존 offering-html Skill Registry 테스트와 일관성 확인
+
+### Phase D: 검증 + 문서 정합성
+
+1. typecheck: `turbo typecheck` (테스트 파일 포함)
+2. test: `pnpm test -- --grep "offering-pptx"` (Registry 테스트)
+3. SPEC.md F367, F368 상태 갱신 (📋 → ✅)
+4. INDEX.md, SKILL.md 상호 참조 정합성 확인
+
+---
+
+## 3. 구현 순서 (Worker 매핑)
+
+**단일 구현** — API/Web 코드 변경이 최소(테스트 1건)이므로 Worker 분할 없이 직접 구현.
+
+```
+순서:
+1. F367 offering-pptx SKILL.md 본구현 (Phase A)
+2. F368 ax-bd-offering-agent.md 신규 생성 (Phase B)
+3. Skill Registry 테스트 (Phase C)
+4. 검증 + 문서 정합성 (Phase D)
+```
+
+예상 소요: 20~30분 (스킬/에이전트 정의 중심, 코드 변경 최소)
+
+---
+
+## 4. 리스크
+
+| # | 리스크 | 심각도 | 대응 |
+|---|--------|--------|------|
+| R1 | PPTX 엔진 미확정 | 🟢 | F367에서 비교표만 작성, 선택은 F380(Sprint 172)으로 연기 |
+| R2 | Agent 정의가 후속 Sprint API에 영향 | 🟢 | Agent는 스킬 파일(SKILL.md)만 호출, API 직접 의존 없음 |
+| R3 | Cowork PPTX 연동 사양 미확정 | 🟡 | 인터페이스 구조만 설계, 실구현은 Cowork 팀 확인 후 |
+
+---
+
+## 5. 참조 문서
+
+| 문서 | 경로 |
+|------|------|
+| Phase 18 PRD | `docs/specs/fx-offering-pipeline/prd-final.md` |
+| offering-html SKILL.md | `.claude/skills/ax-bd/shape/offering-html/SKILL.md` |
+| offering-pptx SKILL.md (stub) | `.claude/skills/ax-bd/shape/offering-pptx/SKILL.md` |
+| shaping-orchestrator Agent | `.claude/agents/shaping-orchestrator.md` |
+| INDEX.md (Shape Stage) | `.claude/skills/ax-bd/shape/INDEX.md` |
+| design-tokens.md | `.claude/skills/ax-bd/shape/offering-html/design-tokens.md` |
+| Sprint 165 Plan | `docs/01-plan/features/sprint-165.plan.md` |

--- a/docs/02-design/features/sprint-166.design.md
+++ b/docs/02-design/features/sprint-166.design.md
@@ -1,0 +1,414 @@
+---
+code: FX-DSGN-S166
+title: "Sprint 166: Foundation — Agent 확장 + PPTX 설계"
+version: 1.0
+status: Active
+category: DSGN
+created: 2026-04-06
+updated: 2026-04-06
+author: Sinclair Seo
+feature: sprint-166
+phase: "[[FX-PLAN-018]]"
+sprint: 166
+f_items: [F367, F368]
+plan_ref: "[[FX-PLAN-S166]]"
+---
+
+## 1. 설계 목표
+
+Sprint 165에서 구축한 offering-html 기반 위에 두 가지를 확장한다:
+1. **F367**: offering-pptx SKILL.md를 stub에서 본구현으로 승격 — 18섹션→슬라이드 매핑 + Cowork 연동 설계
+2. **F368**: ax-bd-offering-agent 에이전트 신규 생성 — 형상화 전체 라이프사이클 오케스트레이션 (6 capability)
+
+변경 범위: `.claude/skills/` + `.claude/agents/` 인프라만. API/Web 코드 변경은 테스트 1건.
+
+---
+
+## 2. F367: offering-pptx SKILL.md 본구현
+
+### 2.1 SKILL.md 구조
+
+offering-html SKILL.md와 대칭 구조. frontmatter + 5대 섹션.
+
+**frontmatter 갱신:**
+```yaml
+name: offering-pptx
+domain: ax-bd
+stage: shape
+version: "1.0"                    # 0.1 → 1.0
+description: "AX BD팀 사업기획서(PPTX) 생성 스킬 — 18섹션 표준 슬라이드, 디자인 토큰 기반"
+input_schema: DiscoveryPackage + OfferingConfig
+output_schema: OfferingPPTX
+upstream: [ax-bd/discover/packaging]
+downstream: [ax-bd/validate/gan-cross-review]
+agent: ax-bd-offering-agent
+status: Active                    # stub → Active
+triggers:
+  - 사업기획서 PPT
+  - offering pptx
+  - 형상화 PPTX
+  - business proposal pptx
+evolution:
+  track: DERIVED
+  registry_id: null
+```
+
+### 2.2 When 섹션
+
+3가지 트리거 시나리오:
+1. **대외 제안용**: 고객/파트너에게 제출하는 공식 PPTX (format="pptx", purpose="proposal")
+2. **경영회의 보고용**: 본부장/대표 보고 (format="pptx", purpose="report")
+3. **팀 내부 검토용**: 진행상황 공유 (format="pptx", purpose="review")
+
+### 2.3 How 섹션 — 8단계 생성 프로세스
+
+offering-html과 동일 8단계, PPTX 특화 사항만 다름:
+
+| 단계 | HTML과 동일 | PPTX 특화 사항 |
+|------|------------|---------------|
+| [1] 아이템 확인 | ✅ 동일 | — |
+| [2] 목차 확정 | ▲ 유사 | 18섹션 → 슬라이드 매핑 (§2.4) |
+| [3] 핵심 정보 수집 | ✅ 동일 | — |
+| [4] 초안 생성 | ▲ 다름 | PPTX 엔진으로 슬라이드 생성 |
+| [5] 피드백 반영 | ✅ 동일 | — |
+| [6] 교차검증 | ✅ 동일 | Agent가 validate_orchestration 호출 |
+| [7] 보고용 마무리 | ▲ 유사 | 발표 노트 추가 |
+| [8] 최종 확정 | ✅ 동일 | — |
+
+### 2.4 표준 슬라이드 목차 — 18섹션→슬라이드 매핑
+
+| 섹션 # | 섹션명 | 슬라이드 수 | 슬라이드 유형 | 필수 |
+|--------|--------|------------|-------------|------|
+| — | 표지 | 1 | title-slide | ● |
+| — | 목차 | 1 | toc-slide | ● |
+| 0 | Hero | 1 | hero-slide (KPI 3개 포함) | ● |
+| 0.5 | Executive Summary | 2 | exec-summary (텍스트+도표) | ● |
+| 01 | 추진 배경 및 목적 | 2 | content-slide (3축 구조) | ● |
+| 02-1~02-3 | 왜 이 문제/기술/고객 | 3 | content-slide (각 1장) | ● |
+| 02-4 | 기존 사업 현황 | 1 | data-slide (레버리지 차트) | ○ |
+| 02-5 | Gap 분석 | 1 | compare-slide (현재 vs 목표) | ○ |
+| 02-6 | 글로벌·국내 동향 | 2 | data-slide (경쟁사 매트릭스) | ● |
+| 03-1 | 솔루션 개요 | 2 | before-after-slide | ● |
+| 03-2 | 시나리오/Use Case | 2 | scenario-slide (PoC + 본사업) | ● |
+| 03-3 | 사업화 로드맵 | 1 | roadmap-slide (타임라인) | ● |
+| 04-1 | 데이터 확보 방식 | 1 | content-slide (계층별) | ● |
+| 04-2 | 시장 분석 | 2 | data-slide (TAM/SAM/SOM) | ● |
+| 04-3 | 매출 계획 | 2 | data-slide (3개년 시나리오) | ● |
+| 04-4 | 추진 체계 | 1 | org-slide (조직·비용) | ● |
+| 04-5 | 사업성 교차검증 | 2 | gan-slide (추진론/반대론) | ● |
+| 04-6 | 기대효과 | 1 | impact-slide | ● |
+| 05 | KT 연계 GTM | 2 | strategy-slide | ● |
+| — | 마무리 | 1 | closing-slide | ● |
+
+**총 슬라이드**: 필수 31장 + 선택 2장 = 33장 (최대)
+
+### 2.5 Cowork PPTX 연동 설계
+
+PPTX 공유·편집을 위한 Cowork 연동 인터페이스:
+
+```
+CoworkPPTXInterface:
+  upload(pptxBuffer: Buffer, metadata: OfferingMeta): CoworkDocId
+  share(docId: CoworkDocId, users: string[]): ShareLink
+  getComments(docId: CoworkDocId): Comment[]
+  exportVersion(docId: CoworkDocId, version: string): Buffer
+```
+
+> 실구현은 Cowork MCP 연동 시점에 확정. Sprint 166에서는 인터페이스 정의만.
+
+### 2.6 PPTX 엔진 비교 매트릭스
+
+| 기준 | pptxgenjs | python-pptx |
+|------|----------|-------------|
+| 언어 | TypeScript/JS | Python |
+| 런타임 | Node.js / Browser | Python subprocess |
+| 차트 지원 | ● 내장 | ● 내장 |
+| 슬라이드 마스터 | ○ 제한적 | ● 완전 지원 |
+| 한국어 폰트 | ● Pretendard embed 가능 | ● 가능 |
+| Workers 호환 | ✅ (ESM) | ❌ (subprocess 필요) |
+| 패키지 크기 | ~300KB | ~50MB (Python 환경) |
+| 커뮤니티 | 활발 | 매우 활발 |
+
+> **의사결정**: Sprint 172 F380에서 최종 선택. Workers 환경에서 직접 실행 가능한 pptxgenjs가 유력하나, 슬라이드 마스터 복잡도에 따라 python-pptx subprocess도 후보.
+
+### 2.7 Output Format
+
+```
+AX Discovery_사업기획서_{고객명}_v{버전}_{YYMMDD}.pptx
+```
+
+버전 관리: HTML과 동일 (v0.1 초안 → v0.5+ 보고용 → v1.0 최종).
+
+---
+
+## 3. F368: ax-bd-offering-agent 에이전트 정의
+
+### 3.1 에이전트 메타데이터
+
+```yaml
+name: ax-bd-offering-agent
+description: 형상화 라이프사이클 오케스트레이터 — DiscoveryPackage → Offering(HTML/PPTX) 전체 관리
+model: opus
+tools: [Read, Write, Edit, Glob, Grep, Agent, Bash, WebSearch]
+color: cyan
+role: orchestrator
+```
+
+### 3.2 shaping-orchestrator와의 관계
+
+```
+ax-bd-offering-agent (신규)
+├── 형상화 전체 라이프사이클 관리 (Phase 0~4)
+├── 6 capability 보유
+└── 위임 관계:
+    ├── shaping-orchestrator — Phase C O-G-D 루프 (기존, 변경 없음)
+    ├── ogd-orchestrator — Offering 품질 검증 (validate_orchestration)
+    ├── six-hats-moderator — 교차검증 토론 (validate_orchestration)
+    └── expert-ta~qa — 5인 전문가 리뷰 (validate_orchestration)
+```
+
+**핵심 차이**: shaping-orchestrator는 O-G-D 루프만 관리하고, ax-bd-offering-agent는 DiscoveryPackage 로드부터 최종 확정까지 전체 워크플로우를 관리한다.
+
+### 3.3 6 Capability 상세 설계
+
+#### C1: format_selection
+
+OfferingConfig.format + 컨텍스트에 따라 출력 포맷을 결정한다.
+
+```
+Input:
+  - OfferingConfig.format: "html" | "pptx" | "auto"
+  - context: { audience, occasion, deliveryMethod }
+
+Logic:
+  if format == "auto":
+    if audience == "external_client" → "pptx" (발표 포맷)
+    if audience == "internal_exec" → "pptx" (보고 포맷)
+    if audience == "team_review" → "html" (빠른 공유)
+    default → "html"
+  else:
+    use specified format
+
+Output: { format: "html" | "pptx", reason: string }
+```
+
+#### C2: content_adapter
+
+DiscoveryPackage에서 목적별 톤으로 콘텐츠를 변환한다.
+
+```
+Input:
+  - DiscoveryPackage (2-0 ~ 2-8 산출물)
+  - OfferingConfig.purpose: "report" | "proposal" | "review"
+
+Tone Rules:
+  report:   경영 언어 ("~를 추진", "약 XX억원"), Exec Summary 강조
+  proposal: 기술 상세 (솔루션 아키텍처, PoC 시나리오), 구현 가능성 강조
+  review:   리스크 중심 (No-Go 기준, 리스크 매트릭스), 비판적 검토
+
+Section Mapping: INDEX.md §DiscoveryPackage Schema 참조
+  2-0 item_overview → Hero, Exec Summary, §02-3
+  2-1 reference_analysis → §02-6
+  2-2 market_validation → §04-2
+  2-3 competition_analysis → §04-2, §05
+  2-4 item_derivation → §02-1~02-2
+  2-5 core_selection → §01
+  2-6 customer_profile → §02-3, §03-2
+  2-7 business_model → §04-3
+  2-8 packaging → 전체 기초 자료
+
+Output: SectionContent[] (18섹션별 톤 적용 콘텐츠)
+```
+
+#### C3: structure_crud
+
+Offering 섹션 목차를 관리한다. Sprint 167+ API 연동 전에는 로컬 파일 기반.
+
+```
+Input: offering_id + SectionToggle[]
+Operations:
+  create: 18섹션 기본 목차 초기화
+  read: 현재 목차 + 필수/선택 상태
+  update: 섹션 토글 (활성/비활성), 커스텀 섹션 추가
+  delete: 커스텀 섹션 삭제 (표준 섹션은 비활성만 가능)
+Output: SectionList (순서 + 활성 상태)
+```
+
+#### C4: design_management
+
+디자인 토큰을 적용하고 브랜드 커스터마이징을 관리한다.
+
+```
+Input:
+  - design-tokens.md (기본 39 토큰)
+  - OfferingConfig.designTokenOverrides (선택, Partial)
+
+Logic:
+  1. design-tokens.md에서 기본 토큰 로드
+  2. designTokenOverrides 병합 (존재하는 키만 오버라이드)
+  3. 안전성 검증:
+     - 변경 가능 토큰만 허용 (§7 커스터마이징 가이드 준수)
+     - typography.body 변경 시 경고
+     - animation 변경 시 접근성 경고
+  4. HTML: CSS variables로 변환 → base.html 주입
+     PPTX: 슬라이드 마스터 스타일로 변환
+
+Output: AppliedTokens (최종 적용된 토큰 세트)
+```
+
+#### C5: validate_orchestration
+
+기존 O-G-D + Six Hats + Expert 인프라를 활용해 Offering 품질을 검증한다.
+
+```
+Input: Offering draft (HTML 또는 PPTX 콘텐츠)
+
+Execution:
+  Step 1: O-G-D Loop 호출 (ogd-orchestrator → ogd-generator ↔ ogd-discriminator)
+    - Offering 콘텐츠를 PRD처럼 취급하여 추진론/반대론 생성
+    - max_rounds: 3, convergence: quality_score >= 0.85
+
+  Step 2: Six Hats 토론 (six-hats-moderator)
+    - O-G-D 결과 + Offering 콘텐츠 입력
+    - 6색 모자별 의견 수집 → 합의안 도출
+
+  Step 3: Expert 5인 리뷰 (expert-ta, aa, ca, da, qa)
+    - TA: 기술 실현성
+    - AA: 아키텍처 적합성
+    - CA: 클라우드 인프라
+    - DA: 데이터 전략
+    - QA: 품질/테스트 관점
+
+  Step 4: 종합 판정
+    - 3단계 결과 종합 → §04-5 교차검증 섹션 자동 구성
+    - Pass/Conditional/Fail 판정
+
+Output: ValidationResult { verdict, ganResult, sixHatsResult, expertResults }
+```
+
+#### C6: version_guide
+
+피드백 기반 버전 관리를 가이드한다.
+
+```
+Input: Offering + Feedback[]
+
+Logic:
+  1. 피드백 분류: 구조적 (목차 변경) / 내용적 (데이터 수정) / 어조 (톤 조정)
+  2. 영향 범위 분석: 전체 재생성 vs 부분 수정
+  3. 버전 결정:
+     - 구조적 변경 → major 버전 (v0.1 → v0.2)
+     - 내용적 변경 → minor 수정 (v0.1 내 업데이트)
+     - 어조 변경 → content_adapter 재실행
+  4. 변경 이력 기록
+
+Output: VersionPlan { nextVersion, changeScope, regenerateStrategy }
+```
+
+### 3.4 실행 프로토콜
+
+```
+Phase 0: 초기화
+  └── DiscoveryPackage 존재 확인 (2-0~2-8 산출물)
+  └── OfferingConfig 파싱 (purpose, format, sections, tokens)
+
+Phase 1: 콘텐츠 준비
+  └── C1 format_selection → 포맷 결정
+  └── C2 content_adapter → 톤 변환 콘텐츠 생성
+  └── C3 structure_crud → 목차 초기화
+
+Phase 2: 생성
+  └── C4 design_management → 토큰 적용
+  └── offering-html 또는 offering-pptx 스킬 호출 → 초안 생성 (v0.1)
+
+Phase 3: 검증 (자동)
+  └── C5 validate_orchestration → O-G-D + Six Hats + Expert
+  └── §04-5 교차검증 섹션 자동 구성
+
+Phase 4: 반복 개선
+  └── C6 version_guide → 피드백 분석 + 버전 전략
+  └── Phase 1~3 반복 (최대 4회 = v0.1~v0.4)
+  └── v0.5+ 보고용 마무리 → v1.0 최종 확정
+```
+
+### 3.5 에러 처리
+
+| 상황 | 조치 |
+|------|------|
+| DiscoveryPackage 불완전 (2-8 미완) | 부족한 단계 목록 + AskUserQuestion |
+| O-G-D Loop 수렴 실패 | shaping-orchestrator FORCED_STOP → 사용자 에스컬레이션 |
+| 디자인 토큰 오버라이드 무효 | 무효 키 무시 + 경고 메시지 |
+| Expert Agent 호출 실패 | 실패 Expert 건너뛰기 + 부분 결과 반환 |
+
+---
+
+## 4. Skill Registry 연동
+
+### 4.1 offering-pptx 등록 테스트
+
+`packages/api/src/__tests__/skill-registry-offering-pptx.test.ts` (신규):
+
+```typescript
+// 테스트 4건
+describe('Skill Registry — offering-pptx', () => {
+  it('POST /api/skill-registry — offering-pptx 등록');
+  it('GET /api/skill-registry — offering-pptx 조회');
+  it('GET /api/skill-registry?category=shape — 카테고리 필터');
+  it('GET /api/skill-registry?q=pptx — 검색');
+});
+```
+
+### 4.2 테스트 데이터
+
+```typescript
+const offeringPptxSkill = {
+  name: 'offering-pptx',
+  domain: 'ax-bd',
+  stage: 'shape',
+  version: '1.0',
+  description: 'AX BD팀 사업기획서(PPTX) 생성 스킬',
+  input_schema: 'DiscoveryPackage + OfferingConfig',
+  output_schema: 'OfferingPPTX',
+  status: 'Active',
+  evolution_track: 'DERIVED',
+};
+```
+
+---
+
+## 5. 파일 매핑
+
+| # | 파일 경로 | 동작 | F# |
+|---|----------|------|-----|
+| 1 | `.claude/skills/ax-bd/shape/offering-pptx/SKILL.md` | 수정 (stub → 본구현) | F367 |
+| 2 | `.claude/agents/ax-bd-offering-agent.md` | 🆕 신규 생성 | F368 |
+| 3 | `packages/api/src/__tests__/skill-registry-offering-pptx.test.ts` | 🆕 신규 생성 | F367 |
+
+---
+
+## 6. 검증 체크리스트
+
+- [ ] F367: offering-pptx SKILL.md version 1.0, status Active
+- [ ] F367: When/How/표준슬라이드목차/Cowork연동/엔진비교 5섹션 완비
+- [ ] F367: 18섹션→슬라이드 매핑 테이블 (31+2장)
+- [ ] F368: ax-bd-offering-agent.md 에이전트 정의 완비
+- [ ] F368: 6 capability (C1~C6) 상세 설계 포함
+- [ ] F368: 실행 프로토콜 Phase 0~4 명시
+- [ ] F368: shaping-orchestrator 위임 관계 명시
+- [ ] F368: 에러 처리 4건 명시
+- [ ] 테스트: skill-registry-offering-pptx 4건 통과
+- [ ] typecheck: `turbo typecheck` 통과
+- [ ] INDEX.md: agent 섹션이 F368 반영 여부 확인
+
+---
+
+## 7. 참조 문서
+
+| 문서 | 경로 |
+|------|------|
+| Phase 18 PRD | `docs/specs/fx-offering-pipeline/prd-final.md` |
+| Sprint 166 Plan | `docs/01-plan/features/sprint-166.plan.md` |
+| offering-html SKILL.md | `.claude/skills/ax-bd/shape/offering-html/SKILL.md` |
+| shaping-orchestrator Agent | `.claude/agents/shaping-orchestrator.md` |
+| design-tokens.md | `.claude/skills/ax-bd/shape/offering-html/design-tokens.md` |
+| INDEX.md (Shape Stage) | `.claude/skills/ax-bd/shape/INDEX.md` |

--- a/docs/03-analysis/features/sprint-166.analysis.md
+++ b/docs/03-analysis/features/sprint-166.analysis.md
@@ -1,0 +1,48 @@
+---
+code: FX-ANLS-S166
+title: "Sprint 166: Gap Analysis — Agent 확장 + PPTX 설계"
+version: 1.0
+status: Active
+category: ANLS
+created: 2026-04-06
+updated: 2026-04-06
+author: Sinclair Seo
+feature: sprint-166
+phase: "[[FX-PLAN-018]]"
+sprint: 166
+f_items: [F367, F368]
+design_ref: "[[FX-DSGN-S166]]"
+match_rate: 97
+---
+
+## 1. 분석 개요
+
+- **설계 문서**: `docs/02-design/features/sprint-166.design.md`
+- **구현 파일**: 3개 (SKILL.md, agent.md, test.ts) + INDEX.md 갱신 1건
+- **Match Rate**: **97%**
+
+## 2. 검증 체크리스트 결과
+
+| # | 체크 항목 | 결과 | 비고 |
+|---|----------|:----:|------|
+| 1 | F367: SKILL.md version 1.0, status Active | ✅ | frontmatter 확인 |
+| 2 | F367: 5섹션 완비 (When/How/목차/Cowork/엔진) | ✅ | 모두 존재 |
+| 3 | F367: 18섹션→슬라이드 매핑 (31+2장) | ✅ | 22행 테이블 |
+| 4 | F368: agent 정의 완비 | ✅ | frontmatter + 6 capability |
+| 5 | F368: C1~C6 상세 설계 | ✅ | Input/Logic/Output 포함 |
+| 6 | F368: Phase 0~4 프로토콜 | ✅ | 일치 |
+| 7 | F368: 위임 관계 명시 | ✅ | 트리 구조 |
+| 8 | F368: 에러 처리 4건+ | ✅ | 5건 (1건 추가) |
+| 9 | 테스트 4건 통과 | ✅ | skill-registry-offering-pptx 4/4 pass |
+| 10 | typecheck 통과 | ✅ | `pnpm typecheck` pass |
+| 11 | INDEX.md 갱신 | ✅ | Stub → Active 갱신 완료 |
+
+## 3. 차이점 요약
+
+- **설계 > 구현**: 없음
+- **구현 > 설계**: 슬라이드 유형별 레이아웃 테이블 15종, PPTX 특화 작성 원칙, C5 산출물 경로 상세화 — 모두 상위 호환
+- **Minor 불일치**: triggers 5개(설계 4), description "렌더링" 추가 — Low impact
+
+## 4. 판정
+
+**97% — PASS** (기준 90% 초과). 추가 iteration 불요.

--- a/docs/04-report/features/sprint-166.report.md
+++ b/docs/04-report/features/sprint-166.report.md
@@ -1,0 +1,101 @@
+---
+code: FX-RPRT-S166
+title: "Sprint 166: Completion Report — Agent 확장 + PPTX 설계"
+version: 1.0
+status: Active
+category: RPRT
+created: 2026-04-06
+updated: 2026-04-06
+author: Sinclair Seo
+feature: sprint-166
+phase: "[[FX-PLAN-018]]"
+sprint: 166
+f_items: [F367, F368]
+match_rate: 97
+---
+
+## Executive Summary
+
+| 항목 | 내용 |
+|------|------|
+| Feature | Sprint 166 — Foundation: Agent 확장 + PPTX 설계 |
+| 시작일 | 2026-04-06 |
+| 완료일 | 2026-04-06 |
+| Match Rate | 97% |
+| F-items | 2건 (F367, F368) |
+| 파일 변경 | 4건 (수정 2 + 신규 2) |
+| 테스트 | 4건 pass |
+
+### 1.3 Value Delivered (4-Perspective)
+
+| 관점 | 설명 |
+|------|------|
+| **Problem** | 형상화 단계에서 PPTX 스킬이 stub 상태, 발굴→형상화 전체 라이프사이클 오케스트레이션 에이전트 부재 |
+| **Solution** | offering-pptx SKILL.md v1.0 본구현 (18섹션→33슬라이드 매핑 + Cowork 연동 + 엔진 비교), ax-bd-offering-agent 6 capability 에이전트 신규 정의 |
+| **Function UX Effect** | PPTX 생성 프로세스가 정의되어 후속 Sprint(F380)에서 즉시 구현 가능. 형상화 전체 워크플로우(Phase 0~4)가 단일 에이전트로 관리되어 기존 14 에이전트와의 위임 관계가 명확 |
+| **Core Value** | Phase 18 Offering Pipeline의 에이전트·스킬 기반 완성 — Sprint 167~174의 API/UI 구현이 안정적으로 진행될 수 있는 Foundation 확보 |
+
+---
+
+## 2. 완료 항목
+
+### F367: offering-pptx SKILL.md 등록 (FX-REQ-359)
+
+| 항목 | 상태 |
+|------|:----:|
+| SKILL.md version 1.0, status Active | ✅ |
+| When 섹션 (3가지 트리거 시나리오) | ✅ |
+| How 섹션 (8단계 생성 프로세스) | ✅ |
+| 표준 슬라이드 목차 (31+2장) + 15종 레이아웃 | ✅ |
+| Cowork PPTX 연��� 인터페이스 + 워크플로우 | ✅ |
+| PPTX 엔진 비교 매트릭스 (pptxgenjs vs python-pptx) | ✅ |
+| 작성 원칙 (경영 언어 + PPTX 특화) | ✅ |
+| Skill Registry 테스트 4건 pass | ✅ |
+| INDEX.md Status: Stub → Active 갱신 | ✅ |
+
+### F368: ax-bd-offering-agent 확장 (FX-REQ-360)
+
+| 항목 | 상태 |
+|------|:----:|
+| 에이전트 정의 (opus, 8 tools, cyan, orchestrator) | ✅ |
+| C1 format_selection | ✅ |
+| C2 content_adapter (3톤 + 섹션 매핑) | ✅ |
+| C3 structure_crud (18섹션 CRUD) | ✅ |
+| C4 design_management (39 토큰 + 안전성 검증) | ✅ |
+| C5 validate_orchestration (O-G-D + Six Hats + Expert) | ✅ |
+| C6 version_guide (피드백 → 버전 전략) | ✅ |
+| 실행 프로토콜 Phase 0~4 | ✅ |
+| shaping-orchestrator 위임 관계 | ✅ |
+| 에러 처리 5건 | ✅ |
+
+---
+
+## 3. 파일 변경 목록
+
+| 파일 | 동작 | LOC |
+|------|------|-----|
+| `.claude/skills/ax-bd/shape/offering-pptx/SKILL.md` | 수정 (stub → v1.0) | ~200 |
+| `.claude/agents/ax-bd-offering-agent.md` | 🆕 신규 | ~280 |
+| `packages/api/src/__tests__/skill-registry-offering-pptx.test.ts` | 🆕 신규 | ~170 |
+| `.claude/skills/ax-bd/shape/INDEX.md` | 수정 (Stub → Active) | 1 |
+
+---
+
+## 4. PDCA 문서
+
+| 문서 | 경로 |
+|------|------|
+| Plan | `docs/01-plan/features/sprint-166.plan.md` |
+| Design | `docs/02-design/features/sprint-166.design.md` |
+| Analysis | `docs/03-analysis/features/sprint-166.analysis.md` |
+| Report | `docs/04-report/features/sprint-166.report.md` |
+
+---
+
+## 5. 후속 작업
+
+| Sprint | F-items | 의존성 |
+|--------|---------|--------|
+| Sprint 167 | F369 (D1 마이그레이션) + F370 (CRUD API) + F371 (Sections API) | F368 Agent 참조 |
+| Sprint 168 | F372 (Export API) + F373 (Validate API) | F368 validate_orchestration |
+| Sprint 172 | F380 (offering-pptx 구현) | F367 PPTX 엔진 선택 |

--- a/packages/api/src/__tests__/skill-registry-offering-pptx.test.ts
+++ b/packages/api/src/__tests__/skill-registry-offering-pptx.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { app } from "../app.js";
+import { createTestEnv, createAuthHeaders } from "./helpers/test-app.js";
+
+const METRIC_TABLES = `
+CREATE TABLE IF NOT EXISTS skill_executions (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  skill_id TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 1,
+  biz_item_id TEXT,
+  artifact_id TEXT,
+  model TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'completed',
+  input_tokens INTEGER NOT NULL DEFAULT 0,
+  output_tokens INTEGER NOT NULL DEFAULT 0,
+  cost_usd REAL NOT NULL DEFAULT 0,
+  duration_ms INTEGER NOT NULL DEFAULT 0,
+  error_message TEXT,
+  executed_by TEXT NOT NULL,
+  executed_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS skill_versions (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  skill_id TEXT NOT NULL,
+  version INTEGER NOT NULL,
+  prompt_hash TEXT NOT NULL,
+  model TEXT NOT NULL,
+  max_tokens INTEGER NOT NULL DEFAULT 4096,
+  changelog TEXT,
+  created_by TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(tenant_id, skill_id, version)
+);
+
+CREATE TABLE IF NOT EXISTS skill_lineage (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  parent_skill_id TEXT NOT NULL,
+  child_skill_id TEXT NOT NULL,
+  derivation_type TEXT NOT NULL DEFAULT 'manual',
+  description TEXT,
+  created_by TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS skill_audit_log (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  entity_type TEXT NOT NULL,
+  entity_id TEXT NOT NULL,
+  action TEXT NOT NULL,
+  actor_id TEXT NOT NULL,
+  details TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+`;
+
+const REGISTRY_TABLES = `
+CREATE TABLE IF NOT EXISTS skill_registry (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  skill_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  description TEXT,
+  category TEXT NOT NULL DEFAULT 'general',
+  tags TEXT,
+  status TEXT NOT NULL DEFAULT 'active',
+  safety_grade TEXT DEFAULT 'pending',
+  safety_score INTEGER DEFAULT 0,
+  safety_checked_at TEXT,
+  source_type TEXT NOT NULL DEFAULT 'marketplace',
+  source_ref TEXT,
+  prompt_template TEXT,
+  model_preference TEXT,
+  max_tokens INTEGER DEFAULT 4096,
+  token_cost_avg REAL DEFAULT 0,
+  success_rate REAL DEFAULT 0,
+  total_executions INTEGER DEFAULT 0,
+  current_version INTEGER DEFAULT 1,
+  created_by TEXT NOT NULL,
+  updated_by TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  deleted_at TEXT,
+  UNIQUE(tenant_id, skill_id)
+);
+
+CREATE TABLE IF NOT EXISTS skill_search_index (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  skill_id TEXT NOT NULL,
+  token TEXT NOT NULL,
+  weight REAL NOT NULL DEFAULT 1.0,
+  field TEXT NOT NULL DEFAULT 'name',
+  UNIQUE(tenant_id, skill_id, token, field)
+);
+`;
+
+describe("Skill Registry — offering-pptx (F367)", () => {
+  let env: ReturnType<typeof createTestEnv>;
+  let headers: Record<string, string>;
+
+  const offeringPptxSkill = {
+    skillId: "offering-pptx",
+    name: "Offering PPTX",
+    description:
+      "AX BD팀 사업기획서(PPTX) 생성 — 18섹션 표준 슬라이드, 디자인 토큰 기반",
+    category: "generation",
+    tags: ["offering", "pptx", "shape", "business-proposal"],
+    sourceType: "derived",
+    sourceRef: ".claude/skills/ax-bd/shape/offering-pptx/SKILL.md",
+    modelPreference: "opus",
+    maxTokens: 8192,
+  };
+
+  beforeEach(async () => {
+    env = createTestEnv();
+    (env.DB as any).exec(METRIC_TABLES);
+    (env.DB as any).exec(REGISTRY_TABLES);
+    headers = await createAuthHeaders();
+  });
+
+  it("registers offering-pptx skill with source_type=derived", async () => {
+    const res = await app.request(
+      "/api/skills/registry",
+      {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify(offeringPptxSkill),
+      },
+      env,
+    );
+    expect(res.status).toBe(201);
+    const data = (await res.json()) as any;
+    expect(data.skillId).toBe("offering-pptx");
+    expect(data.id).toBeDefined();
+  });
+
+  it("retrieves registered offering-pptx skill by id", async () => {
+    // Register first
+    await app.request(
+      "/api/skills/registry",
+      {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify(offeringPptxSkill),
+      },
+      env,
+    );
+
+    // Retrieve
+    const res = await app.request(
+      `/api/skills/registry/offering-pptx`,
+      { method: "GET", headers },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as any;
+    expect(data.skillId).toBe("offering-pptx");
+    expect(data.sourceType).toBe("derived");
+    expect(data.sourceRef).toBe(
+      ".claude/skills/ax-bd/shape/offering-pptx/SKILL.md",
+    );
+  });
+
+  it("filters skills by category=generation includes offering-pptx", async () => {
+    // Register offering-pptx
+    await app.request(
+      "/api/skills/registry",
+      {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify(offeringPptxSkill),
+      },
+      env,
+    );
+
+    // Register different category skill
+    await app.request(
+      "/api/skills/registry",
+      {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          skillId: "cost-model",
+          name: "Cost Model",
+          description: "AI cost model analysis",
+          category: "analysis",
+          tags: ["cost"],
+          sourceType: "marketplace",
+        }),
+      },
+      env,
+    );
+
+    // Filter by generation
+    const res = await app.request(
+      "/api/skills/registry?category=generation",
+      { method: "GET", headers },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as any;
+    const skills = data.skills || data;
+    const ids = (Array.isArray(skills) ? skills : []).map(
+      (s: any) => s.skillId,
+    );
+    expect(ids).toContain("offering-pptx");
+    expect(ids).not.toContain("cost-model");
+  });
+
+  it("finds offering-pptx via search", async () => {
+    // Register
+    await app.request(
+      "/api/skills/registry",
+      {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify(offeringPptxSkill),
+      },
+      env,
+    );
+
+    // Search
+    const res = await app.request(
+      "/api/skills/search?q=pptx",
+      { method: "GET", headers },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as any;
+    const results = data.results || data;
+    const ids = (Array.isArray(results) ? results : []).map(
+      (s: any) => s.skillId,
+    );
+    expect(ids).toContain("offering-pptx");
+  });
+});


### PR DESCRIPTION
## Summary
- **F367**: offering-pptx SKILL.md stub→v1.0 본구현 (18섹션→33슬라이드 매핑 + Cowork 연동 + 엔진 비교)
- **F368**: ax-bd-offering-agent 신규 에이전트 (6 capability + Phase 0~4 프로토콜)
- Skill Registry 테스트 4건 pass, typecheck pass
- Gap Analysis: **97% Match Rate**

## Test plan
- [x] `pnpm vitest run -t "offering-pptx"` → 4/4 pass
- [x] `pnpm typecheck` → pass
- [x] SKILL.md frontmatter version 1.0, status Active
- [x] INDEX.md offering-pptx Status: Stub → Active

🤖 Generated with [Claude Code](https://claude.com/claude-code)