### PR TITLE
feat: Sprint 167 — D1 Offerings Data Layer + CRUD + Sections API (F369, F370, F371)

### DIFF
--- a/docs/01-plan/features/sprint-167.plan.md
+++ b/docs/01-plan/features/sprint-167.plan.md
@@ -1,0 +1,224 @@
+---
+code: FX-PLAN-S167
+title: "Sprint 167 — Data Layer: D1 마이그레이션 + Offerings CRUD + Sections API"
+version: 1.0
+status: Active
+category: PLAN
+created: 2026-04-06
+updated: 2026-04-06
+author: Sinclair Seo
+references: "[[FX-SPEC-001]], [[FX-PLAN-018]]"
+---
+
+# Sprint 167: Data Layer — D1 마이그레이션 + Offerings CRUD + Sections API
+
+## Executive Summary
+
+| 항목 | 내용 |
+|------|------|
+| Feature | F369(D1 마이그레이션), F370(Offerings CRUD API), F371(Sections API) |
+| Sprint | 167 |
+| Phase | 18-B (Data Layer) |
+| 우선순위 | P0 |
+| 의존성 | Sprint 165~166 (Foundation: F363~F368) 완료 |
+| PRD | docs/specs/fx-offering-pipeline/prd-final.md §2-2 |
+
+### Value Delivered
+
+| 관점 | 내용 |
+|------|------|
+| Problem | 발굴 산출물→사업기획서 변환에 영속적 데이터 레이어가 없어 형상화 파이프라인 구현 불가 |
+| Solution | offerings/versions/sections/design_tokens 4테이블 D1 스키마 + Offerings CRUD + Sections 18섹션 표준 목차 API |
+| Function UX Effect | Offering 생성→버전관리→섹션편집→디자인토큰 전체 데이터 흐름 확보 |
+| Core Value | Phase 18 후속 Sprint(169~174)의 Full UI + Export + Validate의 데이터 기반 확보 |
+
+---
+
+## 1. F369: D1 마이그레이션 (4테이블)
+
+### 마이그레이션 파일
+
+- `packages/api/src/db/migrations/0110_offerings.sql`
+
+### 테이블 설계
+
+#### offerings (사업기획서 메인)
+
+| 컬럼 | 타입 | 제약 | 설명 |
+|------|------|------|------|
+| id | TEXT | PK | UUID |
+| org_id | TEXT | NOT NULL | 멀티테넌시 |
+| biz_item_id | TEXT | FK → biz_items(id) | 연결 발굴 아이템 |
+| title | TEXT | NOT NULL | 기획서 제목 |
+| purpose | TEXT | NOT NULL, CHECK | 'report' / 'proposal' / 'review' (보고/제안/검토) |
+| format | TEXT | NOT NULL, CHECK | 'html' / 'pptx' |
+| status | TEXT | NOT NULL, CHECK | 'draft' / 'generating' / 'review' / 'approved' / 'shared' |
+| current_version | INTEGER | DEFAULT 1 | 현재 버전 번호 |
+| created_by | TEXT | NOT NULL | 생성자 |
+| created_at | TEXT | DEFAULT datetime('now') | |
+| updated_at | TEXT | DEFAULT datetime('now') | |
+
+#### offering_versions (버전 이력)
+
+| 컬럼 | 타입 | 제약 | 설명 |
+|------|------|------|------|
+| id | TEXT | PK | UUID |
+| offering_id | TEXT | FK → offerings(id) ON DELETE CASCADE | |
+| version | INTEGER | NOT NULL | 버전 번호 |
+| snapshot | TEXT | | 전체 섹션 JSON 스냅샷 |
+| change_summary | TEXT | | 변경 요약 |
+| created_by | TEXT | NOT NULL | |
+| created_at | TEXT | DEFAULT datetime('now') | |
+| UNIQUE | (offering_id, version) | | 중복 방지 |
+
+#### offering_sections (섹션별 콘텐츠)
+
+| 컬럼 | 타입 | 제약 | 설명 |
+|------|------|------|------|
+| id | TEXT | PK | UUID |
+| offering_id | TEXT | FK → offerings(id) ON DELETE CASCADE | |
+| section_key | TEXT | NOT NULL | 'hero', 'exec_summary', 's01', 's02_1', ..., 's05' |
+| title | TEXT | NOT NULL | 섹션 제목 |
+| content | TEXT | | 마크다운/HTML 콘텐츠 |
+| sort_order | INTEGER | NOT NULL | 정렬 순서 |
+| is_required | INTEGER | DEFAULT 1 | 필수(1)/선택(0) |
+| is_included | INTEGER | DEFAULT 1 | 포함 여부 토글 |
+| created_at | TEXT | DEFAULT datetime('now') | |
+| updated_at | TEXT | DEFAULT datetime('now') | |
+| UNIQUE | (offering_id, section_key) | | 중복 방지 |
+
+#### offering_design_tokens (디자인 토큰)
+
+| 컬럼 | 타입 | 제약 | 설명 |
+|------|------|------|------|
+| id | TEXT | PK | UUID |
+| offering_id | TEXT | FK → offerings(id) ON DELETE CASCADE | |
+| token_key | TEXT | NOT NULL | 'color_primary', 'font_heading', ... |
+| token_value | TEXT | NOT NULL | 값 |
+| token_category | TEXT | NOT NULL | 'color' / 'typography' / 'layout' / 'spacing' |
+| created_at | TEXT | DEFAULT datetime('now') | |
+| updated_at | TEXT | DEFAULT datetime('now') | |
+| UNIQUE | (offering_id, token_key) | | 중복 방지 |
+
+### 인덱스
+
+```sql
+idx_offerings_org_status (org_id, status)
+idx_offerings_biz_item (biz_item_id)
+idx_offering_versions_offering (offering_id, version)
+idx_offering_sections_offering (offering_id, sort_order)
+idx_offering_design_tokens_offering (offering_id, token_category)
+```
+
+---
+
+## 2. F370: Offerings CRUD API
+
+### 엔드포인트
+
+| Method | Path | 설명 | Zod Schema |
+|--------|------|------|-----------|
+| POST | /offerings | 생성 (draft) | CreateOfferingSchema |
+| GET | /offerings | 목록 (필터+페이지네이션) | OfferingFilterSchema |
+| GET | /offerings/:id | 상세 (+ sections 포함) | — |
+| PUT | /offerings/:id | 수정 (title, purpose, status) | UpdateOfferingSchema |
+| DELETE | /offerings/:id | 삭제 (soft delete 아님, CASCADE) | — |
+| POST | /offerings/:id/versions | 버전 스냅샷 생성 | CreateVersionSchema |
+| GET | /offerings/:id/versions | 버전 히스토리 | — |
+
+### 파일 목록
+
+| 파일 | 용도 |
+|------|------|
+| `packages/api/src/schemas/offering.schema.ts` | Zod 스키마 |
+| `packages/api/src/services/offering-service.ts` | 서비스 레이어 |
+| `packages/api/src/routes/offerings.ts` | 라우트 |
+
+---
+
+## 3. F371: Offering Sections API
+
+### 엔드포인트
+
+| Method | Path | 설명 | Zod Schema |
+|--------|------|------|-----------|
+| GET | /offerings/:id/sections | 전체 섹션 목록 | — |
+| PUT | /offerings/:id/sections/:sectionId | 섹션 콘텐츠 수정 | UpdateSectionSchema |
+| PATCH | /offerings/:id/sections/:sectionId/toggle | is_included 토글 | — |
+| POST | /offerings/:id/sections/init | 18섹션 표준 목차 초기화 | InitSectionsSchema |
+| PUT | /offerings/:id/sections/reorder | 순서 변경 | ReorderSectionsSchema |
+
+### 18섹션 표준 목차 (시드 데이터)
+
+```typescript
+const STANDARD_SECTIONS = [
+  { key: 'hero', title: 'Hero', sortOrder: 0, isRequired: true },
+  { key: 'exec_summary', title: 'Executive Summary', sortOrder: 1, isRequired: true },
+  { key: 's01', title: '추진 배경 및 목적', sortOrder: 2, isRequired: true },
+  { key: 's02', title: '사업기회 점검', sortOrder: 3, isRequired: true },
+  { key: 's02_1', title: '왜 이 문제/영역인가', sortOrder: 4, isRequired: true },
+  { key: 's02_2', title: '왜 이 기술/접근법인가', sortOrder: 5, isRequired: true },
+  { key: 's02_3', title: '왜 이 고객/도메인인가', sortOrder: 6, isRequired: true },
+  { key: 's02_4', title: '기존 사업/관계 현황', sortOrder: 7, isRequired: false },
+  { key: 's02_5', title: '현황 Gap 분석', sortOrder: 8, isRequired: false },
+  { key: 's02_6', title: '글로벌·국내 동향', sortOrder: 9, isRequired: true },
+  { key: 's03', title: '제안 방향', sortOrder: 10, isRequired: true },
+  { key: 's03_1', title: '솔루션 개요', sortOrder: 11, isRequired: true },
+  { key: 's03_2', title: '시나리오 / Use Case', sortOrder: 12, isRequired: true },
+  { key: 's03_3', title: '사업화 로드맵', sortOrder: 13, isRequired: true },
+  { key: 's04', title: '추진 계획', sortOrder: 14, isRequired: true },
+  { key: 's04_1', title: '데이터 확보 방식', sortOrder: 15, isRequired: true },
+  { key: 's04_2', title: '시장 분석 및 경쟁 환경', sortOrder: 16, isRequired: true },
+  { key: 's04_3', title: '사업화 방향 및 매출 계획', sortOrder: 17, isRequired: true },
+  { key: 's04_4', title: '추진 체계 및 투자 계획', sortOrder: 18, isRequired: true },
+  { key: 's04_5', title: '사업성 교차검증', sortOrder: 19, isRequired: true },
+  { key: 's04_6', title: '기대효과', sortOrder: 20, isRequired: true },
+  { key: 's05', title: 'KT 연계 GTM 전략(안)', sortOrder: 21, isRequired: true },
+];
+```
+
+### 파일 목록
+
+| 파일 | 용도 |
+|------|------|
+| `packages/api/src/schemas/offering-section.schema.ts` | Zod 스키마 |
+| `packages/api/src/services/offering-section-service.ts` | 서비스 레이어 |
+| `packages/api/src/routes/offering-sections.ts` | 라우트 (offerings.ts와 분리) |
+
+---
+
+## 4. 테스트 계획
+
+### API 테스트 (Vitest + Hono app.request())
+
+| 파일 | 범위 | 예상 테스트 수 |
+|------|------|---------------|
+| `offerings.test.ts` | CRUD + 필터 + 버전 | ~15개 |
+| `offering-sections.test.ts` | 섹션 CRUD + 표준 목차 초기화 + 토글 + 순서 | ~12개 |
+| `offering-service.test.ts` | 서비스 단위 테스트 | ~8개 |
+
+### 검증 항목
+
+- [ ] D1 마이그레이션 로컬 적용 성공
+- [ ] offerings CRUD 전체 동작
+- [ ] sections 표준 목차 초기화 (22개 행 생성)
+- [ ] sections is_included 토글
+- [ ] sections reorder
+- [ ] versions 스냅샷 생성 + 조회
+- [ ] org_id 멀티테넌시 격리
+- [ ] typecheck 통과
+- [ ] lint 통과
+
+---
+
+## 5. 작업 순서
+
+```
+1. D1 마이그레이션 0110 생성 + 로컬 적용 확인
+2. Zod 스키마 2개 (offering.schema.ts, offering-section.schema.ts)
+3. 서비스 2개 (offering-service.ts, offering-section-service.ts)
+4. 라우트 2개 (offerings.ts, offering-sections.ts)
+5. app.ts 라우트 등록
+6. 테스트 작성 + 실행
+7. typecheck + lint
+```

--- a/docs/02-design/features/sprint-167.design.md
+++ b/docs/02-design/features/sprint-167.design.md
@@ -1,0 +1,312 @@
+---
+code: FX-DSGN-S167
+title: "Sprint 167 — Data Layer: D1 + Offerings CRUD + Sections API"
+version: 1.0
+status: Active
+category: DSGN
+created: 2026-04-06
+updated: 2026-04-06
+author: Sinclair Seo
+references: "[[FX-PLAN-S167]], [[FX-PLAN-018]]"
+---
+
+# Sprint 167 Design: Data Layer — D1 + Offerings CRUD + Sections API
+
+## 1. 개요
+
+Phase 18 Offering Pipeline의 데이터 레이어를 구축한다.
+- F369: D1 4테이블 마이그레이션 (offerings, offering_versions, offering_sections, offering_design_tokens)
+- F370: Offerings CRUD API (7개 엔드포인트)
+- F371: Offering Sections API (5개 엔드포인트, 22개 표준 목차 초기화)
+
+### 기존 자산 관계
+- `offering_packs` (0072, F236): 번들 패키징 — offerings와 **독립** (별도 도메인)
+- `biz_items`: offerings.biz_item_id FK 연결 — 발굴 아이템 기반 형상화
+
+---
+
+## 2. D1 스키마 (F369)
+
+### 2-1. 마이그레이션 파일
+
+`packages/api/src/db/migrations/0110_offerings.sql`
+
+```sql
+-- F369: Offering Pipeline Data Layer (Sprint 167)
+-- offerings, offering_versions, offering_sections, offering_design_tokens
+
+CREATE TABLE IF NOT EXISTS offerings (
+  id TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL,
+  biz_item_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  purpose TEXT NOT NULL CHECK(purpose IN ('report','proposal','review')),
+  format TEXT NOT NULL CHECK(format IN ('html','pptx')),
+  status TEXT NOT NULL DEFAULT 'draft'
+    CHECK(status IN ('draft','generating','review','approved','shared')),
+  current_version INTEGER NOT NULL DEFAULT 1,
+  created_by TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (biz_item_id) REFERENCES biz_items(id)
+);
+CREATE INDEX IF NOT EXISTS idx_offerings_org_status ON offerings(org_id, status);
+CREATE INDEX IF NOT EXISTS idx_offerings_biz_item ON offerings(biz_item_id);
+
+CREATE TABLE IF NOT EXISTS offering_versions (
+  id TEXT PRIMARY KEY,
+  offering_id TEXT NOT NULL,
+  version INTEGER NOT NULL,
+  snapshot TEXT,
+  change_summary TEXT,
+  created_by TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(offering_id, version),
+  FOREIGN KEY (offering_id) REFERENCES offerings(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_offering_versions_offering ON offering_versions(offering_id, version);
+
+CREATE TABLE IF NOT EXISTS offering_sections (
+  id TEXT PRIMARY KEY,
+  offering_id TEXT NOT NULL,
+  section_key TEXT NOT NULL,
+  title TEXT NOT NULL,
+  content TEXT,
+  sort_order INTEGER NOT NULL,
+  is_required INTEGER NOT NULL DEFAULT 1,
+  is_included INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(offering_id, section_key),
+  FOREIGN KEY (offering_id) REFERENCES offerings(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_offering_sections_offering ON offering_sections(offering_id, sort_order);
+
+CREATE TABLE IF NOT EXISTS offering_design_tokens (
+  id TEXT PRIMARY KEY,
+  offering_id TEXT NOT NULL,
+  token_key TEXT NOT NULL,
+  token_value TEXT NOT NULL,
+  token_category TEXT NOT NULL CHECK(token_category IN ('color','typography','layout','spacing')),
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(offering_id, token_key),
+  FOREIGN KEY (offering_id) REFERENCES offerings(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_offering_design_tokens_offering ON offering_design_tokens(offering_id, token_category);
+```
+
+---
+
+## 3. Zod 스키마
+
+### 3-1. offering.schema.ts
+
+```typescript
+// POST /offerings
+CreateOfferingSchema = z.object({
+  bizItemId: z.string().min(1),
+  title: z.string().min(1).max(200),
+  purpose: z.enum(['report', 'proposal', 'review']),
+  format: z.enum(['html', 'pptx']),
+});
+
+// PUT /offerings/:id
+UpdateOfferingSchema = z.object({
+  title: z.string().min(1).max(200).optional(),
+  purpose: z.enum(['report', 'proposal', 'review']).optional(),
+  status: z.enum(['draft', 'generating', 'review', 'approved', 'shared']).optional(),
+});
+
+// GET /offerings (query)
+OfferingFilterSchema = z.object({
+  status: z.enum(['draft', 'generating', 'review', 'approved', 'shared']).optional(),
+  bizItemId: z.string().optional(),
+  purpose: z.enum(['report', 'proposal', 'review']).optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+// POST /offerings/:id/versions
+CreateVersionSchema = z.object({
+  changeSummary: z.string().max(500).optional(),
+});
+```
+
+### 3-2. offering-section.schema.ts
+
+```typescript
+// PUT /offerings/:id/sections/:sectionId
+UpdateSectionSchema = z.object({
+  title: z.string().min(1).max(200).optional(),
+  content: z.string().optional(),
+});
+
+// POST /offerings/:id/sections/init
+InitSectionsSchema = z.object({
+  includeOptional: z.boolean().default(true),
+});
+
+// PUT /offerings/:id/sections/reorder
+ReorderSectionsSchema = z.object({
+  sectionIds: z.array(z.string().min(1)),
+});
+```
+
+---
+
+## 4. API 엔드포인트 상세
+
+### 4-1. Offerings CRUD (F370) — offerings.ts
+
+| # | Method | Path | 동작 | 응답 |
+|---|--------|------|------|------|
+| 1 | POST | /offerings | draft 생성 + 표준 목차 자동 초기화 | 201 { offering } |
+| 2 | GET | /offerings | 목록 (org_id 필터 + 페이지네이션) | 200 { items, total, page, limit } |
+| 3 | GET | /offerings/:id | 상세 + sections 포함 | 200 { offering, sections } |
+| 4 | PUT | /offerings/:id | 수정 (title/purpose/status) | 200 { offering } |
+| 5 | DELETE | /offerings/:id | 삭제 (CASCADE) | 204 |
+| 6 | POST | /offerings/:id/versions | 현재 sections 스냅샷 → version 생성 | 201 { version } |
+| 7 | GET | /offerings/:id/versions | 버전 히스토리 | 200 { versions } |
+
+**POST /offerings 흐름:**
+1. Zod 검증
+2. UUID 생성
+3. offerings INSERT
+4. offering_sections 22행 INSERT (표준 목차 자동)
+5. 응답
+
+### 4-2. Sections API (F371) — offering-sections.ts
+
+| # | Method | Path | 동작 | 응답 |
+|---|--------|------|------|------|
+| 1 | GET | /offerings/:id/sections | 전체 섹션 목록 (sort_order ASC) | 200 { sections } |
+| 2 | PUT | /offerings/:id/sections/:sectionId | 콘텐츠/제목 수정 | 200 { section } |
+| 3 | PATCH | /offerings/:id/sections/:sectionId/toggle | is_included 토글 | 200 { section } |
+| 4 | POST | /offerings/:id/sections/init | 표준 목차 재초기화 (기존 삭제 후 재생성) | 201 { sections } |
+| 5 | PUT | /offerings/:id/sections/reorder | 순서 변경 (sectionIds 배열 순서대로 sort_order 재배정) | 200 { sections } |
+
+---
+
+## 5. 서비스 레이어
+
+### 5-1. offering-service.ts
+
+```typescript
+class OfferingService {
+  constructor(private db: D1Database) {}
+
+  async create(input: CreateOfferingInput & { orgId: string; createdBy: string }): Promise<Offering>
+  async list(orgId: string, filter: OfferingFilter): Promise<{ items: Offering[]; total: number }>
+  async getById(orgId: string, id: string): Promise<OfferingWithSections | null>
+  async update(orgId: string, id: string, input: UpdateOfferingInput): Promise<Offering | null>
+  async delete(orgId: string, id: string): Promise<boolean>
+  async createVersion(orgId: string, offeringId: string, createdBy: string, changeSummary?: string): Promise<OfferingVersion>
+  async listVersions(orgId: string, offeringId: string): Promise<OfferingVersion[]>
+}
+```
+
+### 5-2. offering-section-service.ts
+
+```typescript
+class OfferingSectionService {
+  constructor(private db: D1Database) {}
+
+  async listByOffering(offeringId: string): Promise<OfferingSection[]>
+  async update(sectionId: string, input: UpdateSectionInput): Promise<OfferingSection | null>
+  async toggleIncluded(sectionId: string): Promise<OfferingSection | null>
+  async initStandard(offeringId: string, includeOptional: boolean): Promise<OfferingSection[]>
+  async reorder(offeringId: string, sectionIds: string[]): Promise<OfferingSection[]>
+}
+
+// 표준 목차 상수
+const STANDARD_SECTIONS: { key: string; title: string; sortOrder: number; isRequired: boolean }[]
+```
+
+---
+
+## 6. 파일 목록
+
+| # | 파일 | F-item | 신규/수정 |
+|---|------|--------|----------|
+| 1 | `packages/api/src/db/migrations/0110_offerings.sql` | F369 | 신규 |
+| 2 | `packages/api/src/schemas/offering.schema.ts` | F370 | 신규 |
+| 3 | `packages/api/src/schemas/offering-section.schema.ts` | F371 | 신규 |
+| 4 | `packages/api/src/services/offering-service.ts` | F370 | 신규 |
+| 5 | `packages/api/src/services/offering-section-service.ts` | F371 | 신규 |
+| 6 | `packages/api/src/routes/offerings.ts` | F370 | 신규 |
+| 7 | `packages/api/src/routes/offering-sections.ts` | F371 | 신규 |
+| 8 | `packages/api/src/app.ts` | F370, F371 | 수정 (라우트 등록) |
+| 9 | `packages/api/src/__tests__/helpers/mock-d1.ts` | F369 | 수정 (DDL 추가) |
+| 10 | `packages/api/src/__tests__/offerings.test.ts` | F370 | 신규 |
+| 11 | `packages/api/src/__tests__/offering-sections.test.ts` | F371 | 신규 |
+
+---
+
+## 7. 테스트 설계
+
+### 7-1. offerings.test.ts (~15 테스트)
+
+| # | 테스트 | 기대값 |
+|---|--------|--------|
+| 1 | POST /offerings — 정상 생성 | 201, offering + 22 sections 자동 |
+| 2 | POST /offerings — bizItemId 누락 | 400 |
+| 3 | POST /offerings — 잘못된 purpose | 400 |
+| 4 | GET /offerings — 목록 조회 | 200, items 배열 |
+| 5 | GET /offerings — status 필터 | 200, 필터 적용 |
+| 6 | GET /offerings — 페이지네이션 | 200, page/limit 적용 |
+| 7 | GET /offerings/:id — 상세 + sections | 200, sections 포함 |
+| 8 | GET /offerings/:id — 존재하지 않는 ID | 404 |
+| 9 | PUT /offerings/:id — title 수정 | 200, 업데이트 반영 |
+| 10 | PUT /offerings/:id — status 수정 | 200 |
+| 11 | DELETE /offerings/:id — 삭제 | 204 |
+| 12 | DELETE /offerings/:id — CASCADE로 sections도 삭제 | sections 0행 |
+| 13 | POST /offerings/:id/versions — 버전 생성 | 201 |
+| 14 | GET /offerings/:id/versions — 히스토리 | 200 |
+| 15 | 멀티테넌시 격리 — 다른 orgId 접근 불가 | 404 |
+
+### 7-2. offering-sections.test.ts (~12 테스트)
+
+| # | 테스트 | 기대값 |
+|---|--------|--------|
+| 1 | GET sections — 전체 목록 | 200, 22개 |
+| 2 | PUT section — content 수정 | 200 |
+| 3 | PUT section — title 수정 | 200 |
+| 4 | PATCH toggle — is_included 0→1 | 200 |
+| 5 | PATCH toggle — is_included 1→0 | 200 |
+| 6 | PATCH toggle — 필수 섹션 토글 시도 | 400 (필수는 토글 불가) |
+| 7 | POST init — 표준 목차 초기화 | 201, 22개 |
+| 8 | POST init — includeOptional=false | 201, 필수만 |
+| 9 | POST init — 기존 섹션 있으면 교체 | 22개 |
+| 10 | PUT reorder — 순서 변경 | 200, sort_order 반영 |
+| 11 | PUT reorder — 잘못된 sectionId | 400 |
+| 12 | 존재하지 않는 offering 접근 | 404 |
+
+---
+
+## 8. 22개 표준 목차 매핑
+
+| sort_order | section_key | title | isRequired |
+|------------|-------------|-------|------------|
+| 0 | hero | Hero | true |
+| 1 | exec_summary | Executive Summary | true |
+| 2 | s01 | 추진 배경 및 목적 | true |
+| 3 | s02 | 사업기회 점검 | true |
+| 4 | s02_1 | 왜 이 문제/영역인가 | true |
+| 5 | s02_2 | 왜 이 기술/접근법인가 | true |
+| 6 | s02_3 | 왜 이 고객/도메인인가 | true |
+| 7 | s02_4 | 기존 사업/관계 현황 | false |
+| 8 | s02_5 | 현황 Gap 분석 | false |
+| 9 | s02_6 | 글로벌·국내 동향 | true |
+| 10 | s03 | 제안 방향 | true |
+| 11 | s03_1 | 솔루션 개요 | true |
+| 12 | s03_2 | 시나리오 / Use Case | true |
+| 13 | s03_3 | 사업화 로드맵 | true |
+| 14 | s04 | 추진 계획 | true |
+| 15 | s04_1 | 데이터 확보 방식 | true |
+| 16 | s04_2 | 시장 분석 및 경쟁 환경 | true |
+| 17 | s04_3 | 사업화 방향 및 매출 계획 | true |
+| 18 | s04_4 | 추진 체계 및 투자 계획 | true |
+| 19 | s04_5 | 사업성 교차검증 | true |
+| 20 | s04_6 | 기대효과 | true |
+| 21 | s05 | KT 연계 GTM 전략(안) | true |

--- a/docs/04-report/features/sprint-167.report.md
+++ b/docs/04-report/features/sprint-167.report.md
@@ -1,0 +1,115 @@
+---
+code: FX-RPRT-S167
+title: "Sprint 167 완료 보고서 — Data Layer: D1 + Offerings CRUD + Sections API"
+version: 1.0
+status: Active
+category: RPRT
+created: 2026-04-06
+updated: 2026-04-06
+author: Sinclair Seo
+references: "[[FX-PLAN-S167]], [[FX-DSGN-S167]]"
+---
+
+# Sprint 167 완료 보고서
+
+## Executive Summary
+
+| 항목 | 내용 |
+|------|------|
+| Feature | F369(D1 마이그레이션), F370(Offerings CRUD API), F371(Sections API) |
+| Sprint | 167 |
+| Phase | 18-B (Data Layer) |
+| Match Rate | **99%** |
+| 테스트 | 26 pass / 0 fail |
+| 신규 파일 | 9개 |
+| 수정 파일 | 2개 (app.ts, mock-d1.ts) |
+
+### Value Delivered
+
+| 관점 | 내용 |
+|------|------|
+| Problem | 발굴 산출물→사업기획서 변환에 영속적 데이터 레이어가 없어 형상화 파이프라인 구현 불가 |
+| Solution | offerings/versions/sections/design_tokens 4테이블 D1 + CRUD 12 엔드포인트 + 22섹션 표준 목차 |
+| Function UX Effect | Offering 생성→버전관리→섹션편집→디자인토큰 전체 데이터 흐름 확보 |
+| Core Value | Phase 18 후속 Sprint(168~174)의 Full UI + Export + Validate 데이터 기반 확보 |
+
+---
+
+## 구현 결과
+
+### F369: D1 마이그레이션 (4테이블)
+
+| 테이블 | 컬럼 | 인덱스 |
+|--------|------|--------|
+| offerings | 11 | idx_org_status, idx_biz_item |
+| offering_versions | 7 + UNIQUE | idx_offering_version |
+| offering_sections | 10 + UNIQUE | idx_offering_sortorder |
+| offering_design_tokens | 7 + UNIQUE | idx_offering_category |
+
+- 마이그레이션 파일: `0110_offerings.sql`
+- mock-d1.ts DDL 동기화 완료
+
+### F370: Offerings CRUD API (7 엔드포인트)
+
+| Method | Path | 동작 |
+|--------|------|------|
+| POST | /offerings | 생성 + 22섹션 자동 초기화 |
+| GET | /offerings | 목록 (필터+페이지네이션) |
+| GET | /offerings/:id | 상세 + sections 포함 |
+| PUT | /offerings/:id | 수정 (title/purpose/status) |
+| DELETE | /offerings/:id | 삭제 (CASCADE) |
+| POST | /offerings/:id/versions | 버전 스냅샷 생성 |
+| GET | /offerings/:id/versions | 버전 히스토리 |
+
+### F371: Offering Sections API (5 엔드포인트)
+
+| Method | Path | 동작 |
+|--------|------|------|
+| GET | /offerings/:id/sections | 전체 섹션 목록 |
+| PUT | /offerings/:id/sections/:sectionId | 콘텐츠/제목 수정 |
+| PATCH | /offerings/:id/sections/:sectionId/toggle | 포함 여부 토글 |
+| POST | /offerings/:id/sections/init | 표준 목차 재초기화 |
+| PUT | /offerings/:id/sections/reorder | 순서 변경 |
+
+---
+
+## Gap 분석 결과
+
+| 카테고리 | 점수 | 판정 |
+|----------|------|------|
+| D1 스키마 | 100% | PASS |
+| Zod 스키마 | 100% | PASS |
+| 엔드포인트 | 100% | PASS |
+| 서비스 메서드 | 100% | PASS |
+| 테스트 | 96% | PASS |
+| 표준 목차 | 100% | PASS |
+| **전체** | **99%** | **PASS** |
+
+### 미미한 차이 (1%)
+- offerings.test.ts에서 CASCADE 후 sections 행 수 별도 검증 테스트 1건 미작성 (DELETE 후 offering 404 확인으로 대체)
+
+---
+
+## 파일 목록
+
+| # | 파일 | 상태 | F-item |
+|---|------|------|--------|
+| 1 | `packages/api/src/db/migrations/0110_offerings.sql` | 신규 | F369 |
+| 2 | `packages/api/src/schemas/offering.schema.ts` | 신규 | F370 |
+| 3 | `packages/api/src/schemas/offering-section.schema.ts` | 신규 | F371 |
+| 4 | `packages/api/src/services/offering-service.ts` | 신규 | F370 |
+| 5 | `packages/api/src/services/offering-section-service.ts` | 신규 | F371 |
+| 6 | `packages/api/src/routes/offerings.ts` | 신규 | F370 |
+| 7 | `packages/api/src/routes/offering-sections.ts` | 신규 | F371 |
+| 8 | `packages/api/src/app.ts` | 수정 | F370, F371 |
+| 9 | `packages/api/src/__tests__/helpers/mock-d1.ts` | 수정 | F369 |
+| 10 | `packages/api/src/__tests__/offerings.test.ts` | 신규 | F370 |
+| 11 | `packages/api/src/__tests__/offering-sections.test.ts` | 신규 | F371 |
+
+---
+
+## 교훈
+
+1. **Hono 라우팅 순서 주의**: 정적 경로(`/sections/reorder`)를 동적 경로(`/sections/:sectionId`) 앞에 등록해야 충돌 방지
+2. **표준 목차 상수**: STANDARD_SECTIONS를 스키마 파일에 const로 정의하여 서비스와 테스트에서 재사용 — 중복 제거
+3. **POST 생성 시 자동 초기화**: Offering 생성 시 22섹션을 자동으로 생성하여 후속 API 호출 단순화

--- a/packages/api/src/__tests__/helpers/mock-d1.ts
+++ b/packages/api/src/__tests__/helpers/mock-d1.ts
@@ -743,6 +743,67 @@ export class MockD1Database {
       );
       CREATE INDEX IF NOT EXISTS idx_atr_item ON ax_team_reviews(item_id);
       CREATE INDEX IF NOT EXISTS idx_atr_org ON ax_team_reviews(org_id);
+
+      -- 0110: Offerings Pipeline (F369, Sprint 167)
+      CREATE TABLE IF NOT EXISTS offerings (
+        id TEXT PRIMARY KEY,
+        org_id TEXT NOT NULL,
+        biz_item_id TEXT NOT NULL,
+        title TEXT NOT NULL,
+        purpose TEXT NOT NULL CHECK(purpose IN ('report','proposal','review')),
+        format TEXT NOT NULL CHECK(format IN ('html','pptx')),
+        status TEXT NOT NULL DEFAULT 'draft'
+          CHECK(status IN ('draft','generating','review','approved','shared')),
+        current_version INTEGER NOT NULL DEFAULT 1,
+        created_by TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+        FOREIGN KEY (biz_item_id) REFERENCES biz_items(id)
+      );
+      CREATE INDEX IF NOT EXISTS idx_offerings_org_status ON offerings(org_id, status);
+      CREATE INDEX IF NOT EXISTS idx_offerings_biz_item ON offerings(biz_item_id);
+
+      CREATE TABLE IF NOT EXISTS offering_versions (
+        id TEXT PRIMARY KEY,
+        offering_id TEXT NOT NULL,
+        version INTEGER NOT NULL,
+        snapshot TEXT,
+        change_summary TEXT,
+        created_by TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE(offering_id, version),
+        FOREIGN KEY (offering_id) REFERENCES offerings(id) ON DELETE CASCADE
+      );
+      CREATE INDEX IF NOT EXISTS idx_offering_versions_offering ON offering_versions(offering_id, version);
+
+      CREATE TABLE IF NOT EXISTS offering_sections (
+        id TEXT PRIMARY KEY,
+        offering_id TEXT NOT NULL,
+        section_key TEXT NOT NULL,
+        title TEXT NOT NULL,
+        content TEXT,
+        sort_order INTEGER NOT NULL,
+        is_required INTEGER NOT NULL DEFAULT 1,
+        is_included INTEGER NOT NULL DEFAULT 1,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE(offering_id, section_key),
+        FOREIGN KEY (offering_id) REFERENCES offerings(id) ON DELETE CASCADE
+      );
+      CREATE INDEX IF NOT EXISTS idx_offering_sections_offering ON offering_sections(offering_id, sort_order);
+
+      CREATE TABLE IF NOT EXISTS offering_design_tokens (
+        id TEXT PRIMARY KEY,
+        offering_id TEXT NOT NULL,
+        token_key TEXT NOT NULL,
+        token_value TEXT NOT NULL,
+        token_category TEXT NOT NULL CHECK(token_category IN ('color','typography','layout','spacing')),
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE(offering_id, token_key),
+        FOREIGN KEY (offering_id) REFERENCES offerings(id) ON DELETE CASCADE
+      );
+      CREATE INDEX IF NOT EXISTS idx_offering_design_tokens_offering ON offering_design_tokens(offering_id, token_category);
     `);
     this.db.prepare("INSERT OR IGNORE INTO organizations (id, name, slug) VALUES (?, ?, ?)").run("org_test", "Test Org", "test");
   }

--- a/packages/api/src/__tests__/offering-sections.test.ts
+++ b/packages/api/src/__tests__/offering-sections.test.ts
@@ -1,0 +1,246 @@
+/**
+ * F371: Offering Sections API Tests (Sprint 167)
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { createMockD1 } from "./helpers/mock-d1.js";
+import { offeringsRoute } from "../routes/offerings.js";
+import { offeringSectionsRoute } from "../routes/offering-sections.js";
+import { Hono } from "hono";
+import type { Env } from "../env.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+const json = (res: Response) => res.json() as Promise<Any>;
+
+function createApp(db: D1Database) {
+  const app = new Hono<{ Bindings: Env }>();
+  app.use("*", async (c, next) => {
+    c.set("orgId" as never, "org_test");
+    c.set("jwtPayload" as never, { sub: "test-user" });
+    await next();
+  });
+  app.route("/api", offeringsRoute);
+  app.route("/api", offeringSectionsRoute);
+  return {
+    request: (path: string, init?: RequestInit) =>
+      app.request(path, init, { DB: db } as unknown as Env),
+  };
+}
+
+async function seedBizItem(db: D1Database, id = "biz-1") {
+  await (db as unknown as { exec: (q: string) => Promise<void> }).exec(
+    `INSERT OR IGNORE INTO biz_items (id, org_id, title, created_by) VALUES ('${id}', 'org_test', 'Test BizItem', 'test-user')`,
+  );
+}
+
+async function createOffering(app: ReturnType<typeof createApp>) {
+  const res = await app.request("/api/offerings", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      bizItemId: "biz-1",
+      title: "Test Offering",
+      purpose: "report",
+      format: "html",
+    }),
+  });
+  return json(res);
+}
+
+describe("Offering Sections API", () => {
+  let db: D1Database;
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(async () => {
+    const mockDb = createMockD1();
+    db = mockDb as unknown as D1Database;
+    await seedBizItem(db);
+    app = createApp(db);
+  });
+
+  // ── GET sections ──
+
+  it("GET /offerings/:id/sections — returns 22 sections", async () => {
+    const offering = await createOffering(app);
+    const res = await app.request(`/api/offerings/${offering.id}/sections`);
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.sections).toHaveLength(22);
+    expect(body.sections[0].sectionKey).toBe("hero");
+    expect(body.sections[0].isRequired).toBe(true);
+  });
+
+  // ── PUT section ──
+
+  it("PUT section — updates content", async () => {
+    const offering = await createOffering(app);
+    const sectionsRes = await app.request(`/api/offerings/${offering.id}/sections`);
+    const { sections } = await json(sectionsRes);
+    const heroId = sections[0].id;
+
+    const res = await app.request(`/api/offerings/${offering.id}/sections/${heroId}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "# Healthcare AI" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.content).toBe("# Healthcare AI");
+  });
+
+  it("PUT section — updates title", async () => {
+    const offering = await createOffering(app);
+    const sectionsRes = await app.request(`/api/offerings/${offering.id}/sections`);
+    const { sections } = await json(sectionsRes);
+    const sectionId = sections[2].id;
+
+    const res = await app.request(`/api/offerings/${offering.id}/sections/${sectionId}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "Custom Title" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.title).toBe("Custom Title");
+  });
+
+  // ── PATCH toggle ──
+
+  it("PATCH toggle — toggles optional section off", async () => {
+    const offering = await createOffering(app);
+    const sectionsRes = await app.request(`/api/offerings/${offering.id}/sections`);
+    const { sections } = await json(sectionsRes);
+    const optionalSection = sections.find((s: Any) => s.sectionKey === "s02_4");
+
+    const res = await app.request(
+      `/api/offerings/${offering.id}/sections/${optionalSection.id}/toggle`,
+      { method: "PATCH" },
+    );
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.isIncluded).toBe(false);
+  });
+
+  it("PATCH toggle — toggles section back on", async () => {
+    const offering = await createOffering(app);
+    const sectionsRes = await app.request(`/api/offerings/${offering.id}/sections`);
+    const { sections } = await json(sectionsRes);
+    const optionalSection = sections.find((s: Any) => s.sectionKey === "s02_4");
+
+    // Toggle off
+    await app.request(
+      `/api/offerings/${offering.id}/sections/${optionalSection.id}/toggle`,
+      { method: "PATCH" },
+    );
+    // Toggle back on
+    const res = await app.request(
+      `/api/offerings/${offering.id}/sections/${optionalSection.id}/toggle`,
+      { method: "PATCH" },
+    );
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.isIncluded).toBe(true);
+  });
+
+  it("PATCH toggle — rejects toggling required section", async () => {
+    const offering = await createOffering(app);
+    const sectionsRes = await app.request(`/api/offerings/${offering.id}/sections`);
+    const { sections } = await json(sectionsRes);
+    const requiredSection = sections[0]; // hero is required
+
+    const res = await app.request(
+      `/api/offerings/${offering.id}/sections/${requiredSection.id}/toggle`,
+      { method: "PATCH" },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  // ── POST init ──
+
+  it("POST init — reinitializes all 22 sections", async () => {
+    const offering = await createOffering(app);
+    const res = await app.request(`/api/offerings/${offering.id}/sections/init`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ includeOptional: true }),
+    });
+    expect(res.status).toBe(201);
+    const body = await json(res);
+    expect(body.sections).toHaveLength(22);
+  });
+
+  it("POST init — includeOptional=false returns only required", async () => {
+    const offering = await createOffering(app);
+    const res = await app.request(`/api/offerings/${offering.id}/sections/init`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ includeOptional: false }),
+    });
+    expect(res.status).toBe(201);
+    const body = await json(res);
+    // 22 total - 2 optional (s02_4, s02_5) = 20
+    expect(body.sections).toHaveLength(20);
+    expect(body.sections.every((s: Any) => s.isRequired)).toBe(true);
+  });
+
+  it("POST init — replaces existing sections", async () => {
+    const offering = await createOffering(app);
+
+    // Modify a section first
+    const sectionsRes = await app.request(`/api/offerings/${offering.id}/sections`);
+    const { sections } = await json(sectionsRes);
+    await app.request(`/api/offerings/${offering.id}/sections/${sections[0].id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "Modified" }),
+    });
+
+    // Re-init
+    const res = await app.request(`/api/offerings/${offering.id}/sections/init`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(201);
+    const body = await json(res);
+    expect(body.sections).toHaveLength(22);
+    expect(body.sections[0].content).toBeNull();
+  });
+
+  // ── PUT reorder ──
+
+  it("PUT reorder — changes section order", async () => {
+    const offering = await createOffering(app);
+    const sectionsRes = await app.request(`/api/offerings/${offering.id}/sections`);
+    const { sections } = await json(sectionsRes);
+
+    const reorderedIds = [sections[2].id, sections[1].id, sections[0].id, ...sections.slice(3).map((s: Any) => s.id)];
+
+    const res = await app.request(`/api/offerings/${offering.id}/sections/reorder`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sectionIds: reorderedIds }),
+    });
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.sections[0].id).toBe(sections[2].id);
+    expect(body.sections[0].sortOrder).toBe(0);
+  });
+
+  it("PUT reorder — rejects empty array", async () => {
+    const offering = await createOffering(app);
+    const res = await app.request(`/api/offerings/${offering.id}/sections/reorder`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sectionIds: [] }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  // ── 404 for missing offering ──
+
+  it("GET sections — 404 for nonexistent offering", async () => {
+    const res = await app.request("/api/offerings/nonexistent/sections");
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/api/src/__tests__/offerings.test.ts
+++ b/packages/api/src/__tests__/offerings.test.ts
@@ -1,0 +1,281 @@
+/**
+ * F370: Offerings CRUD API Tests (Sprint 167)
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { createMockD1 } from "./helpers/mock-d1.js";
+import { offeringsRoute } from "../routes/offerings.js";
+import { Hono } from "hono";
+import type { Env } from "../env.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+
+function createApp(db: D1Database) {
+  const app = new Hono<{ Bindings: Env }>();
+  app.use("*", async (c, next) => {
+    c.set("orgId" as never, "org_test");
+    c.set("jwtPayload" as never, { sub: "test-user" });
+    await next();
+  });
+  app.route("/api", offeringsRoute);
+  return {
+    request: (path: string, init?: RequestInit) =>
+      app.request(path, init, { DB: db } as unknown as Env),
+  };
+}
+
+async function seedBizItem(db: D1Database, id = "biz-1") {
+  await (db as unknown as { exec: (q: string) => Promise<void> }).exec(
+    `INSERT OR IGNORE INTO biz_items (id, org_id, title, created_by) VALUES ('${id}', 'org_test', 'Test BizItem', 'test-user')`,
+  );
+}
+
+const json = (res: Response) => res.json() as Promise<Any>;
+
+describe("Offerings CRUD API", () => {
+  let db: D1Database;
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(async () => {
+    const mockDb = createMockD1();
+    db = mockDb as unknown as D1Database;
+    await seedBizItem(db);
+    app = createApp(db);
+  });
+
+  // ── POST /offerings ──
+
+  it("POST /offerings — creates offering with 22 sections", async () => {
+    const res = await app.request("/api/offerings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        bizItemId: "biz-1",
+        title: "Healthcare AI 사업기획서",
+        purpose: "report",
+        format: "html",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = await json(res);
+    expect(body.id).toBeTruthy();
+    expect(body.title).toBe("Healthcare AI 사업기획서");
+    expect(body.purpose).toBe("report");
+    expect(body.format).toBe("html");
+    expect(body.status).toBe("draft");
+    expect(body.sections).toHaveLength(22);
+    expect(body.sections[0].sectionKey).toBe("hero");
+    expect(body.sections[21].sectionKey).toBe("s05");
+  });
+
+  it("POST /offerings — rejects missing bizItemId", async () => {
+    const res = await app.request("/api/offerings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "Test", purpose: "report", format: "html" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /offerings — rejects invalid purpose", async () => {
+    const res = await app.request("/api/offerings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ bizItemId: "biz-1", title: "Test", purpose: "invalid", format: "html" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  // ── GET /offerings ──
+
+  it("GET /offerings — lists offerings", async () => {
+    await app.request("/api/offerings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ bizItemId: "biz-1", title: "Offering 1", purpose: "report", format: "html" }),
+    });
+    await app.request("/api/offerings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ bizItemId: "biz-1", title: "Offering 2", purpose: "proposal", format: "pptx" }),
+    });
+
+    const res = await app.request("/api/offerings");
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.items).toHaveLength(2);
+    expect(body.total).toBe(2);
+  });
+
+  it("GET /offerings — filters by status", async () => {
+    await app.request("/api/offerings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ bizItemId: "biz-1", title: "Draft", purpose: "report", format: "html" }),
+    });
+
+    const res = await app.request("/api/offerings?status=approved");
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.items).toHaveLength(0);
+  });
+
+  it("GET /offerings — paginates", async () => {
+    for (let i = 0; i < 3; i++) {
+      await app.request("/api/offerings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ bizItemId: "biz-1", title: `O${i}`, purpose: "report", format: "html" }),
+      });
+    }
+
+    const res = await app.request("/api/offerings?page=1&limit=2");
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.items).toHaveLength(2);
+    expect(body.total).toBe(3);
+  });
+
+  // ── GET /offerings/:id ──
+
+  it("GET /offerings/:id — returns offering with sections", async () => {
+    const createRes = await app.request("/api/offerings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ bizItemId: "biz-1", title: "Detail Test", purpose: "review", format: "html" }),
+    });
+    const { id } = await json(createRes);
+
+    const res = await app.request(`/api/offerings/${id}`);
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.id).toBe(id);
+    expect(body.sections).toHaveLength(22);
+  });
+
+  it("GET /offerings/:id — 404 for missing", async () => {
+    const res = await app.request("/api/offerings/nonexistent");
+    expect(res.status).toBe(404);
+  });
+
+  // ── PUT /offerings/:id ──
+
+  it("PUT /offerings/:id — updates title", async () => {
+    const createRes = await app.request("/api/offerings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ bizItemId: "biz-1", title: "Original", purpose: "report", format: "html" }),
+    });
+    const { id } = await json(createRes);
+
+    const res = await app.request(`/api/offerings/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "Updated Title" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.title).toBe("Updated Title");
+  });
+
+  it("PUT /offerings/:id — updates status", async () => {
+    const createRes = await app.request("/api/offerings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ bizItemId: "biz-1", title: "Status Test", purpose: "report", format: "html" }),
+    });
+    const { id } = await json(createRes);
+
+    const res = await app.request(`/api/offerings/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "review" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.status).toBe("review");
+  });
+
+  // ── DELETE /offerings/:id ──
+
+  it("DELETE /offerings/:id — deletes offering", async () => {
+    const createRes = await app.request("/api/offerings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ bizItemId: "biz-1", title: "To Delete", purpose: "report", format: "html" }),
+    });
+    const { id } = await json(createRes);
+
+    const res = await app.request(`/api/offerings/${id}`, { method: "DELETE" });
+    expect(res.status).toBe(204);
+
+    const getRes = await app.request(`/api/offerings/${id}`);
+    expect(getRes.status).toBe(404);
+  });
+
+  // ── Versions ──
+
+  it("POST /offerings/:id/versions — creates version snapshot", async () => {
+    const createRes = await app.request("/api/offerings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ bizItemId: "biz-1", title: "Version Test", purpose: "report", format: "html" }),
+    });
+    const { id } = await json(createRes);
+
+    const res = await app.request(`/api/offerings/${id}/versions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ changeSummary: "Initial sections filled" }),
+    });
+    expect(res.status).toBe(201);
+    const body = await json(res);
+    expect(body.version).toBe(2);
+    expect(body.changeSummary).toBe("Initial sections filled");
+    expect(body.snapshot).toBeTruthy();
+  });
+
+  it("GET /offerings/:id/versions — lists version history", async () => {
+    const createRes = await app.request("/api/offerings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ bizItemId: "biz-1", title: "Versions List", purpose: "report", format: "html" }),
+    });
+    const { id } = await json(createRes);
+
+    await app.request(`/api/offerings/${id}/versions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    const res = await app.request(`/api/offerings/${id}/versions`);
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.versions).toHaveLength(1);
+    expect(body.total).toBe(1);
+  });
+
+  // ── Multi-tenancy ──
+
+  it("multi-tenancy — different org cannot access offering", async () => {
+    const createRes = await app.request("/api/offerings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ bizItemId: "biz-1", title: "Org Test", purpose: "report", format: "html" }),
+    });
+    const { id } = await json(createRes);
+
+    const otherApp = new Hono<{ Bindings: Env }>();
+    otherApp.use("*", async (c, next) => {
+      c.set("orgId" as never, "org_other");
+      c.set("jwtPayload" as never, { sub: "other-user" });
+      await next();
+    });
+    otherApp.route("/api", offeringsRoute);
+
+    const res = await otherApp.request(`/api/offerings/${id}`, {}, { DB: db } as unknown as Env);
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -134,6 +134,9 @@ import { prototypeJobsRoute } from "./routes/prototype-jobs.js";
 import { prototypeUsageRoute } from "./routes/prototype-usage.js";
 // Builder Server 전용 API (Webhook Secret 인증)
 import { builderRoute } from "./routes/builder.js";
+// Sprint 167: Offerings Data Layer (F369, F370, F371, Phase 18)
+import { offeringsRoute } from "./routes/offerings.js";
+import { offeringSectionsRoute } from "./routes/offering-sections.js";
 // Sprint 160: O-G-D Quality + Feedback (F355, F356, Phase 16)
 import { ogdQualityRoute } from "./routes/ogd-quality.js";
 import { prototypeFeedbackRoute } from "./routes/prototype-feedback.js";
@@ -449,6 +452,10 @@ app.route("/api", ogdGenericRoute);
 
 // Sprint 164: 운영 지표 라우트 (F362, Phase 17)
 app.route("/api", metricsRoute);
+
+// Sprint 167: Offerings Data Layer (F369, F370, F371, Phase 18)
+app.route("/api", offeringsRoute);
+app.route("/api", offeringSectionsRoute);
 
 // Sprint 47: PII masker middleware — AI API 경로에만 적용
 app.use("/api/agents/*", piiMaskerMiddleware);

--- a/packages/api/src/db/migrations/0110_offerings.sql
+++ b/packages/api/src/db/migrations/0110_offerings.sql
@@ -1,0 +1,62 @@
+-- F369: Offering Pipeline Data Layer (Sprint 167)
+-- offerings, offering_versions, offering_sections, offering_design_tokens
+
+CREATE TABLE IF NOT EXISTS offerings (
+  id TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL,
+  biz_item_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  purpose TEXT NOT NULL CHECK(purpose IN ('report','proposal','review')),
+  format TEXT NOT NULL CHECK(format IN ('html','pptx')),
+  status TEXT NOT NULL DEFAULT 'draft'
+    CHECK(status IN ('draft','generating','review','approved','shared')),
+  current_version INTEGER NOT NULL DEFAULT 1,
+  created_by TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (biz_item_id) REFERENCES biz_items(id)
+);
+CREATE INDEX IF NOT EXISTS idx_offerings_org_status ON offerings(org_id, status);
+CREATE INDEX IF NOT EXISTS idx_offerings_biz_item ON offerings(biz_item_id);
+
+CREATE TABLE IF NOT EXISTS offering_versions (
+  id TEXT PRIMARY KEY,
+  offering_id TEXT NOT NULL,
+  version INTEGER NOT NULL,
+  snapshot TEXT,
+  change_summary TEXT,
+  created_by TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(offering_id, version),
+  FOREIGN KEY (offering_id) REFERENCES offerings(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_offering_versions_offering ON offering_versions(offering_id, version);
+
+CREATE TABLE IF NOT EXISTS offering_sections (
+  id TEXT PRIMARY KEY,
+  offering_id TEXT NOT NULL,
+  section_key TEXT NOT NULL,
+  title TEXT NOT NULL,
+  content TEXT,
+  sort_order INTEGER NOT NULL,
+  is_required INTEGER NOT NULL DEFAULT 1,
+  is_included INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(offering_id, section_key),
+  FOREIGN KEY (offering_id) REFERENCES offerings(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_offering_sections_offering ON offering_sections(offering_id, sort_order);
+
+CREATE TABLE IF NOT EXISTS offering_design_tokens (
+  id TEXT PRIMARY KEY,
+  offering_id TEXT NOT NULL,
+  token_key TEXT NOT NULL,
+  token_value TEXT NOT NULL,
+  token_category TEXT NOT NULL CHECK(token_category IN ('color','typography','layout','spacing')),
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(offering_id, token_key),
+  FOREIGN KEY (offering_id) REFERENCES offerings(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_offering_design_tokens_offering ON offering_design_tokens(offering_id, token_category);

--- a/packages/api/src/routes/offering-sections.ts
+++ b/packages/api/src/routes/offering-sections.ts
@@ -1,0 +1,99 @@
+/**
+ * F371: Offering Sections Routes (Sprint 167)
+ */
+import { Hono } from "hono";
+import type { Env } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import { OfferingSectionService } from "../services/offering-section-service.js";
+import {
+  UpdateSectionSchema,
+  InitSectionsSchema,
+  ReorderSectionsSchema,
+} from "../schemas/offering-section.schema.js";
+
+export const offeringSectionsRoute = new Hono<{ Bindings: Env; Variables: TenantVariables }>();
+
+// GET /offerings/:id/sections — 전체 섹션 목록
+offeringSectionsRoute.get("/offerings/:id/sections", async (c) => {
+  const orgId = c.get("orgId");
+  const offeringId = c.req.param("id");
+
+  const svc = new OfferingSectionService(c.env.DB);
+  const exists = await svc.offeringExists(offeringId, orgId);
+  if (!exists) return c.json({ error: "Offering not found" }, 404);
+
+  const sections = await svc.listByOffering(offeringId);
+  return c.json({ sections });
+});
+
+// POST /offerings/:id/sections/init — 표준 목차 초기화 (정적 경로 — 동적 :sectionId 앞에 위치)
+offeringSectionsRoute.post("/offerings/:id/sections/init", async (c) => {
+  const orgId = c.get("orgId");
+  const offeringId = c.req.param("id");
+
+  const svc = new OfferingSectionService(c.env.DB);
+  const exists = await svc.offeringExists(offeringId, orgId);
+  if (!exists) return c.json({ error: "Offering not found" }, 404);
+
+  const body = await c.req.json().catch(() => ({}));
+  const parsed = InitSectionsSchema.safeParse(body);
+  const includeOptional = parsed.success ? parsed.data.includeOptional : true;
+
+  const sections = await svc.initStandard(offeringId, includeOptional);
+  return c.json({ sections }, 201);
+});
+
+// PUT /offerings/:id/sections/reorder — 순서 변경 (정적 경로 — 동적 :sectionId 앞에 위치)
+offeringSectionsRoute.put("/offerings/:id/sections/reorder", async (c) => {
+  const orgId = c.get("orgId");
+  const offeringId = c.req.param("id");
+
+  const svc = new OfferingSectionService(c.env.DB);
+  const exists = await svc.offeringExists(offeringId, orgId);
+  if (!exists) return c.json({ error: "Offering not found" }, 404);
+
+  const body = await c.req.json();
+  const parsed = ReorderSectionsSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const sections = await svc.reorder(offeringId, parsed.data.sectionIds);
+  return c.json({ sections });
+});
+
+// PUT /offerings/:id/sections/:sectionId — 콘텐츠/제목 수정 (동적 경로)
+offeringSectionsRoute.put("/offerings/:id/sections/:sectionId", async (c) => {
+  const orgId = c.get("orgId");
+  const offeringId = c.req.param("id");
+  const sectionId = c.req.param("sectionId");
+
+  const svc = new OfferingSectionService(c.env.DB);
+  const exists = await svc.offeringExists(offeringId, orgId);
+  if (!exists) return c.json({ error: "Offering not found" }, 404);
+
+  const body = await c.req.json();
+  const parsed = UpdateSectionSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const section = await svc.update(sectionId, parsed.data);
+  if (!section) return c.json({ error: "Section not found" }, 404);
+  return c.json(section);
+});
+
+// PATCH /offerings/:id/sections/:sectionId/toggle — is_included 토글
+offeringSectionsRoute.patch("/offerings/:id/sections/:sectionId/toggle", async (c) => {
+  const orgId = c.get("orgId");
+  const offeringId = c.req.param("id");
+  const sectionId = c.req.param("sectionId");
+
+  const svc = new OfferingSectionService(c.env.DB);
+  const exists = await svc.offeringExists(offeringId, orgId);
+  if (!exists) return c.json({ error: "Offering not found" }, 404);
+
+  const section = await svc.toggleIncluded(sectionId);
+  if (!section) return c.json({ error: "Cannot toggle: section is required or not found" }, 400);
+  return c.json(section);
+});

--- a/packages/api/src/routes/offerings.ts
+++ b/packages/api/src/routes/offerings.ts
@@ -1,0 +1,113 @@
+/**
+ * F370: Offerings CRUD Routes (Sprint 167)
+ */
+import { Hono } from "hono";
+import type { Env } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import { OfferingService } from "../services/offering-service.js";
+import {
+  CreateOfferingSchema,
+  UpdateOfferingSchema,
+  OfferingFilterSchema,
+  CreateVersionSchema,
+} from "../schemas/offering.schema.js";
+
+export const offeringsRoute = new Hono<{ Bindings: Env; Variables: TenantVariables }>();
+
+// POST /offerings — 생성 (draft + 표준 목차 자동 초기화)
+offeringsRoute.post("/offerings", async (c) => {
+  const orgId = c.get("orgId");
+  const userId = (c.get("jwtPayload") as Record<string, string> | undefined)?.sub ?? "";
+
+  const body = await c.req.json();
+  const parsed = CreateOfferingSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new OfferingService(c.env.DB);
+  const offering = await svc.create({ ...parsed.data, orgId, createdBy: userId });
+  return c.json(offering, 201);
+});
+
+// GET /offerings — 목록 (필터 + 페이지네이션)
+offeringsRoute.get("/offerings", async (c) => {
+  const orgId = c.get("orgId");
+  const parsed = OfferingFilterSchema.safeParse(c.req.query());
+  if (!parsed.success) {
+    return c.json({ error: "Invalid filters", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new OfferingService(c.env.DB);
+  const result = await svc.list(orgId, parsed.data);
+  return c.json(result);
+});
+
+// GET /offerings/:id — 상세 + sections 포함
+offeringsRoute.get("/offerings/:id", async (c) => {
+  const orgId = c.get("orgId");
+  const id = c.req.param("id");
+
+  const svc = new OfferingService(c.env.DB);
+  const offering = await svc.getById(orgId, id);
+  if (!offering) return c.json({ error: "Offering not found" }, 404);
+  return c.json(offering);
+});
+
+// PUT /offerings/:id — 수정
+offeringsRoute.put("/offerings/:id", async (c) => {
+  const orgId = c.get("orgId");
+  const id = c.req.param("id");
+
+  const body = await c.req.json();
+  const parsed = UpdateOfferingSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new OfferingService(c.env.DB);
+  const offering = await svc.update(orgId, id, parsed.data);
+  if (!offering) return c.json({ error: "Offering not found" }, 404);
+  return c.json(offering);
+});
+
+// DELETE /offerings/:id — 삭제 (CASCADE)
+offeringsRoute.delete("/offerings/:id", async (c) => {
+  const orgId = c.get("orgId");
+  const id = c.req.param("id");
+
+  const svc = new OfferingService(c.env.DB);
+  const deleted = await svc.delete(orgId, id);
+  if (!deleted) return c.json({ error: "Offering not found" }, 404);
+  return c.body(null, 204);
+});
+
+// POST /offerings/:id/versions — 버전 스냅샷 생성
+offeringsRoute.post("/offerings/:id/versions", async (c) => {
+  const orgId = c.get("orgId");
+  const id = c.req.param("id");
+  const userId = (c.get("jwtPayload") as Record<string, string> | undefined)?.sub ?? "";
+
+  const body = await c.req.json().catch(() => ({}));
+  const parsed = CreateVersionSchema.safeParse(body);
+
+  const svc = new OfferingService(c.env.DB);
+  const version = await svc.createVersion(
+    orgId,
+    id,
+    userId,
+    parsed.success ? parsed.data.changeSummary : undefined,
+  );
+  if (!version) return c.json({ error: "Offering not found" }, 404);
+  return c.json(version, 201);
+});
+
+// GET /offerings/:id/versions — 버전 히스토리
+offeringsRoute.get("/offerings/:id/versions", async (c) => {
+  const orgId = c.get("orgId");
+  const id = c.req.param("id");
+
+  const svc = new OfferingService(c.env.DB);
+  const versions = await svc.listVersions(orgId, id);
+  return c.json({ versions, total: versions.length });
+});

--- a/packages/api/src/schemas/offering-section.schema.ts
+++ b/packages/api/src/schemas/offering-section.schema.ts
@@ -1,0 +1,69 @@
+/**
+ * F371: Offering Sections Zod Schemas (Sprint 167)
+ */
+import { z } from "zod";
+
+// ── Request Schemas ─────────────────────────────
+
+export const UpdateSectionSchema = z.object({
+  title: z.string().min(1).max(200).optional(),
+  content: z.string().optional(),
+});
+export type UpdateSectionInput = z.infer<typeof UpdateSectionSchema>;
+
+export const InitSectionsSchema = z.object({
+  includeOptional: z.boolean().default(true),
+});
+export type InitSectionsInput = z.infer<typeof InitSectionsSchema>;
+
+export const ReorderSectionsSchema = z.object({
+  sectionIds: z.array(z.string().min(1)).min(1),
+});
+export type ReorderSectionsInput = z.infer<typeof ReorderSectionsSchema>;
+
+// ── Response Types ──────────────────────────────
+
+export interface OfferingSection {
+  id: string;
+  offeringId: string;
+  sectionKey: string;
+  title: string;
+  content: string | null;
+  sortOrder: number;
+  isRequired: boolean;
+  isIncluded: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ── Standard Sections Constant ──────────────────
+
+export const STANDARD_SECTIONS: {
+  key: string;
+  title: string;
+  sortOrder: number;
+  isRequired: boolean;
+}[] = [
+  { key: "hero", title: "Hero", sortOrder: 0, isRequired: true },
+  { key: "exec_summary", title: "Executive Summary", sortOrder: 1, isRequired: true },
+  { key: "s01", title: "추진 배경 및 목적", sortOrder: 2, isRequired: true },
+  { key: "s02", title: "사업기회 점검", sortOrder: 3, isRequired: true },
+  { key: "s02_1", title: "왜 이 문제/영역인가", sortOrder: 4, isRequired: true },
+  { key: "s02_2", title: "왜 이 기술/접근법인가", sortOrder: 5, isRequired: true },
+  { key: "s02_3", title: "왜 이 고객/도메인인가", sortOrder: 6, isRequired: true },
+  { key: "s02_4", title: "기존 사업/관계 현황", sortOrder: 7, isRequired: false },
+  { key: "s02_5", title: "현황 Gap 분석", sortOrder: 8, isRequired: false },
+  { key: "s02_6", title: "글로벌·국내 동향", sortOrder: 9, isRequired: true },
+  { key: "s03", title: "제안 방향", sortOrder: 10, isRequired: true },
+  { key: "s03_1", title: "솔루션 개요", sortOrder: 11, isRequired: true },
+  { key: "s03_2", title: "시나리오 / Use Case", sortOrder: 12, isRequired: true },
+  { key: "s03_3", title: "사업화 로드맵", sortOrder: 13, isRequired: true },
+  { key: "s04", title: "추진 계획", sortOrder: 14, isRequired: true },
+  { key: "s04_1", title: "데이터 확보 방식", sortOrder: 15, isRequired: true },
+  { key: "s04_2", title: "시장 분석 및 경쟁 환경", sortOrder: 16, isRequired: true },
+  { key: "s04_3", title: "사업화 방향 및 매출 계획", sortOrder: 17, isRequired: true },
+  { key: "s04_4", title: "추진 체계 및 투자 계획", sortOrder: 18, isRequired: true },
+  { key: "s04_5", title: "사업성 교차검증", sortOrder: 19, isRequired: true },
+  { key: "s04_6", title: "기대효과", sortOrder: 20, isRequired: true },
+  { key: "s05", title: "KT 연계 GTM 전략(안)", sortOrder: 21, isRequired: true },
+];

--- a/packages/api/src/schemas/offering.schema.ts
+++ b/packages/api/src/schemas/offering.schema.ts
@@ -1,0 +1,72 @@
+/**
+ * F370: Offerings CRUD Zod Schemas (Sprint 167)
+ */
+import { z } from "zod";
+
+// ── Purpose & Format enums ──────────────────────
+
+export const OfferingPurpose = z.enum(["report", "proposal", "review"]);
+export type OfferingPurpose = z.infer<typeof OfferingPurpose>;
+
+export const OfferingFormat = z.enum(["html", "pptx"]);
+export type OfferingFormat = z.infer<typeof OfferingFormat>;
+
+export const OfferingStatus = z.enum(["draft", "generating", "review", "approved", "shared"]);
+export type OfferingStatus = z.infer<typeof OfferingStatus>;
+
+// ── Request Schemas ─────────────────────────────
+
+export const CreateOfferingSchema = z.object({
+  bizItemId: z.string().min(1),
+  title: z.string().min(1).max(200),
+  purpose: OfferingPurpose,
+  format: OfferingFormat,
+});
+export type CreateOfferingInput = z.infer<typeof CreateOfferingSchema>;
+
+export const UpdateOfferingSchema = z.object({
+  title: z.string().min(1).max(200).optional(),
+  purpose: OfferingPurpose.optional(),
+  status: OfferingStatus.optional(),
+});
+export type UpdateOfferingInput = z.infer<typeof UpdateOfferingSchema>;
+
+export const OfferingFilterSchema = z.object({
+  status: OfferingStatus.optional(),
+  bizItemId: z.string().optional(),
+  purpose: OfferingPurpose.optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
+export type OfferingFilter = z.infer<typeof OfferingFilterSchema>;
+
+export const CreateVersionSchema = z.object({
+  changeSummary: z.string().max(500).optional(),
+});
+export type CreateVersionInput = z.infer<typeof CreateVersionSchema>;
+
+// ── Response Types ──────────────────────────────
+
+export interface Offering {
+  id: string;
+  orgId: string;
+  bizItemId: string;
+  title: string;
+  purpose: OfferingPurpose;
+  format: OfferingFormat;
+  status: OfferingStatus;
+  currentVersion: number;
+  createdBy: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface OfferingVersion {
+  id: string;
+  offeringId: string;
+  version: number;
+  snapshot: string | null;
+  changeSummary: string | null;
+  createdBy: string;
+  createdAt: string;
+}

--- a/packages/api/src/services/offering-section-service.ts
+++ b/packages/api/src/services/offering-section-service.ts
@@ -1,0 +1,159 @@
+/**
+ * F371: Offering Section Service (Sprint 167)
+ */
+import type { OfferingSection, UpdateSectionInput } from "../schemas/offering-section.schema.js";
+import { STANDARD_SECTIONS } from "../schemas/offering-section.schema.js";
+
+interface SectionRow {
+  id: string;
+  offering_id: string;
+  section_key: string;
+  title: string;
+  content: string | null;
+  sort_order: number;
+  is_required: number;
+  is_included: number;
+  created_at: string;
+  updated_at: string;
+}
+
+function rowToSection(row: SectionRow): OfferingSection {
+  return {
+    id: row.id,
+    offeringId: row.offering_id,
+    sectionKey: row.section_key,
+    title: row.title,
+    content: row.content,
+    sortOrder: row.sort_order,
+    isRequired: row.is_required === 1,
+    isIncluded: row.is_included === 1,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function generateId(): string {
+  return crypto.randomUUID();
+}
+
+export class OfferingSectionService {
+  constructor(private db: D1Database) {}
+
+  async listByOffering(offeringId: string): Promise<OfferingSection[]> {
+    const result = await this.db
+      .prepare("SELECT * FROM offering_sections WHERE offering_id = ? ORDER BY sort_order ASC")
+      .bind(offeringId)
+      .all<SectionRow>();
+    return result.results.map(rowToSection);
+  }
+
+  async update(sectionId: string, input: UpdateSectionInput): Promise<OfferingSection | null> {
+    const existing = await this.db
+      .prepare("SELECT * FROM offering_sections WHERE id = ?")
+      .bind(sectionId)
+      .first<SectionRow>();
+    if (!existing) return null;
+
+    const sets: string[] = ["updated_at = datetime('now')"];
+    const params: unknown[] = [];
+
+    if (input.title !== undefined) {
+      sets.push("title = ?");
+      params.push(input.title);
+    }
+    if (input.content !== undefined) {
+      sets.push("content = ?");
+      params.push(input.content);
+    }
+
+    params.push(sectionId);
+    await this.db
+      .prepare(`UPDATE offering_sections SET ${sets.join(", ")} WHERE id = ?`)
+      .bind(...params)
+      .run();
+
+    const row = await this.db
+      .prepare("SELECT * FROM offering_sections WHERE id = ?")
+      .bind(sectionId)
+      .first<SectionRow>();
+    return row ? rowToSection(row) : null;
+  }
+
+  async toggleIncluded(sectionId: string): Promise<OfferingSection | null> {
+    const existing = await this.db
+      .prepare("SELECT * FROM offering_sections WHERE id = ?")
+      .bind(sectionId)
+      .first<SectionRow>();
+    if (!existing) return null;
+
+    // Required sections cannot be toggled off
+    if (existing.is_required === 1 && existing.is_included === 1) {
+      return null; // caller should return 400
+    }
+
+    const newValue = existing.is_included === 1 ? 0 : 1;
+    await this.db
+      .prepare("UPDATE offering_sections SET is_included = ?, updated_at = datetime('now') WHERE id = ?")
+      .bind(newValue, sectionId)
+      .run();
+
+    const row = await this.db
+      .prepare("SELECT * FROM offering_sections WHERE id = ?")
+      .bind(sectionId)
+      .first<SectionRow>();
+    return row ? rowToSection(row) : null;
+  }
+
+  async initStandard(offeringId: string, includeOptional: boolean): Promise<OfferingSection[]> {
+    // Delete existing sections
+    await this.db
+      .prepare("DELETE FROM offering_sections WHERE offering_id = ?")
+      .bind(offeringId)
+      .run();
+
+    const sections: OfferingSection[] = [];
+    const toInsert = includeOptional
+      ? STANDARD_SECTIONS
+      : STANDARD_SECTIONS.filter((s) => s.isRequired);
+
+    for (const s of toInsert) {
+      const sectionId = generateId();
+      await this.db
+        .prepare(
+          `INSERT INTO offering_sections (id, offering_id, section_key, title, sort_order, is_required, is_included)
+           VALUES (?, ?, ?, ?, ?, ?, 1)`,
+        )
+        .bind(sectionId, offeringId, s.key, s.title, s.sortOrder, s.isRequired ? 1 : 0)
+        .run();
+
+      const row = await this.db
+        .prepare("SELECT * FROM offering_sections WHERE id = ?")
+        .bind(sectionId)
+        .first<SectionRow>();
+      if (row) sections.push(rowToSection(row));
+    }
+
+    return sections;
+  }
+
+  async reorder(offeringId: string, sectionIds: string[]): Promise<OfferingSection[]> {
+    for (let i = 0; i < sectionIds.length; i++) {
+      await this.db
+        .prepare(
+          "UPDATE offering_sections SET sort_order = ?, updated_at = datetime('now') WHERE id = ? AND offering_id = ?",
+        )
+        .bind(i, sectionIds[i], offeringId)
+        .run();
+    }
+
+    return this.listByOffering(offeringId);
+  }
+
+  async offeringExists(offeringId: string, orgId: string): Promise<boolean> {
+    const row = await this.db
+      .prepare("SELECT id FROM offerings WHERE id = ? AND org_id = ?")
+      .bind(offeringId, orgId)
+      .first<{ id: string }>();
+    return row !== null;
+  }
+}

--- a/packages/api/src/services/offering-service.ts
+++ b/packages/api/src/services/offering-service.ts
@@ -1,0 +1,298 @@
+/**
+ * F370: Offerings CRUD Service (Sprint 167)
+ */
+import type {
+  Offering,
+  OfferingVersion,
+  CreateOfferingInput,
+  UpdateOfferingInput,
+  OfferingFilter,
+} from "../schemas/offering.schema.js";
+import type { OfferingSection } from "../schemas/offering-section.schema.js";
+import { STANDARD_SECTIONS } from "../schemas/offering-section.schema.js";
+
+interface OfferingRow {
+  id: string;
+  org_id: string;
+  biz_item_id: string;
+  title: string;
+  purpose: string;
+  format: string;
+  status: string;
+  current_version: number;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface VersionRow {
+  id: string;
+  offering_id: string;
+  version: number;
+  snapshot: string | null;
+  change_summary: string | null;
+  created_by: string;
+  created_at: string;
+}
+
+interface SectionRow {
+  id: string;
+  offering_id: string;
+  section_key: string;
+  title: string;
+  content: string | null;
+  sort_order: number;
+  is_required: number;
+  is_included: number;
+  created_at: string;
+  updated_at: string;
+}
+
+function rowToOffering(row: OfferingRow): Offering {
+  return {
+    id: row.id,
+    orgId: row.org_id,
+    bizItemId: row.biz_item_id,
+    title: row.title,
+    purpose: row.purpose as Offering["purpose"],
+    format: row.format as Offering["format"],
+    status: row.status as Offering["status"],
+    currentVersion: row.current_version,
+    createdBy: row.created_by,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function rowToVersion(row: VersionRow): OfferingVersion {
+  return {
+    id: row.id,
+    offeringId: row.offering_id,
+    version: row.version,
+    snapshot: row.snapshot,
+    changeSummary: row.change_summary,
+    createdBy: row.created_by,
+    createdAt: row.created_at,
+  };
+}
+
+function rowToSection(row: SectionRow): OfferingSection {
+  return {
+    id: row.id,
+    offeringId: row.offering_id,
+    sectionKey: row.section_key,
+    title: row.title,
+    content: row.content,
+    sortOrder: row.sort_order,
+    isRequired: row.is_required === 1,
+    isIncluded: row.is_included === 1,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function generateId(): string {
+  return crypto.randomUUID();
+}
+
+export class OfferingService {
+  constructor(private db: D1Database) {}
+
+  async create(
+    input: CreateOfferingInput & { orgId: string; createdBy: string },
+  ): Promise<Offering & { sections: OfferingSection[] }> {
+    const id = generateId();
+
+    await this.db
+      .prepare(
+        `INSERT INTO offerings (id, org_id, biz_item_id, title, purpose, format, status, current_version, created_by)
+         VALUES (?, ?, ?, ?, ?, ?, 'draft', 1, ?)`,
+      )
+      .bind(id, input.orgId, input.bizItemId, input.title, input.purpose, input.format, input.createdBy)
+      .run();
+
+    // Auto-initialize standard sections
+    const sections: OfferingSection[] = [];
+    for (const s of STANDARD_SECTIONS) {
+      const sectionId = generateId();
+      await this.db
+        .prepare(
+          `INSERT INTO offering_sections (id, offering_id, section_key, title, sort_order, is_required, is_included)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .bind(sectionId, id, s.key, s.title, s.sortOrder, s.isRequired ? 1 : 0, 1)
+        .run();
+      sections.push({
+        id: sectionId,
+        offeringId: id,
+        sectionKey: s.key,
+        title: s.title,
+        content: null,
+        sortOrder: s.sortOrder,
+        isRequired: s.isRequired,
+        isIncluded: true,
+        createdAt: "",
+        updatedAt: "",
+      });
+    }
+
+    const offering = await this.getOfferingRow(input.orgId, id);
+    return { ...offering!, sections };
+  }
+
+  async list(orgId: string, filter: OfferingFilter): Promise<{ items: Offering[]; total: number }> {
+    const conditions = ["org_id = ?"];
+    const params: unknown[] = [orgId];
+
+    if (filter.status) {
+      conditions.push("status = ?");
+      params.push(filter.status);
+    }
+    if (filter.bizItemId) {
+      conditions.push("biz_item_id = ?");
+      params.push(filter.bizItemId);
+    }
+    if (filter.purpose) {
+      conditions.push("purpose = ?");
+      params.push(filter.purpose);
+    }
+
+    const where = conditions.join(" AND ");
+
+    const countResult = await this.db
+      .prepare(`SELECT COUNT(*) as count FROM offerings WHERE ${where}`)
+      .bind(...params)
+      .first<{ count: number }>();
+    const total = countResult?.count ?? 0;
+
+    const offset = (filter.page - 1) * filter.limit;
+    const result = await this.db
+      .prepare(`SELECT * FROM offerings WHERE ${where} ORDER BY created_at DESC LIMIT ? OFFSET ?`)
+      .bind(...params, filter.limit, offset)
+      .all<OfferingRow>();
+
+    return {
+      items: result.results.map(rowToOffering),
+      total,
+    };
+  }
+
+  async getById(
+    orgId: string,
+    id: string,
+  ): Promise<(Offering & { sections: OfferingSection[] }) | null> {
+    const offering = await this.getOfferingRow(orgId, id);
+    if (!offering) return null;
+
+    const sectionsResult = await this.db
+      .prepare("SELECT * FROM offering_sections WHERE offering_id = ? ORDER BY sort_order ASC")
+      .bind(id)
+      .all<SectionRow>();
+
+    return {
+      ...offering,
+      sections: sectionsResult.results.map(rowToSection),
+    };
+  }
+
+  async update(orgId: string, id: string, input: UpdateOfferingInput): Promise<Offering | null> {
+    const existing = await this.getOfferingRow(orgId, id);
+    if (!existing) return null;
+
+    const sets: string[] = ["updated_at = datetime('now')"];
+    const params: unknown[] = [];
+
+    if (input.title !== undefined) {
+      sets.push("title = ?");
+      params.push(input.title);
+    }
+    if (input.purpose !== undefined) {
+      sets.push("purpose = ?");
+      params.push(input.purpose);
+    }
+    if (input.status !== undefined) {
+      sets.push("status = ?");
+      params.push(input.status);
+    }
+
+    params.push(id, orgId);
+    await this.db
+      .prepare(`UPDATE offerings SET ${sets.join(", ")} WHERE id = ? AND org_id = ?`)
+      .bind(...params)
+      .run();
+
+    return this.getOfferingRow(orgId, id);
+  }
+
+  async delete(orgId: string, id: string): Promise<boolean> {
+    const existing = await this.getOfferingRow(orgId, id);
+    if (!existing) return false;
+
+    await this.db
+      .prepare("DELETE FROM offerings WHERE id = ? AND org_id = ?")
+      .bind(id, orgId)
+      .run();
+    return true;
+  }
+
+  async createVersion(
+    orgId: string,
+    offeringId: string,
+    createdBy: string,
+    changeSummary?: string,
+  ): Promise<OfferingVersion | null> {
+    const offering = await this.getOfferingRow(orgId, offeringId);
+    if (!offering) return null;
+
+    // Snapshot current sections
+    const sectionsResult = await this.db
+      .prepare("SELECT * FROM offering_sections WHERE offering_id = ? ORDER BY sort_order ASC")
+      .bind(offeringId)
+      .all<SectionRow>();
+    const snapshot = JSON.stringify(sectionsResult.results.map(rowToSection));
+
+    const versionId = generateId();
+    const newVersion = offering.currentVersion + 1;
+
+    await this.db
+      .prepare(
+        `INSERT INTO offering_versions (id, offering_id, version, snapshot, change_summary, created_by)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(versionId, offeringId, newVersion, snapshot, changeSummary ?? null, createdBy)
+      .run();
+
+    // Update current_version on offering
+    await this.db
+      .prepare("UPDATE offerings SET current_version = ?, updated_at = datetime('now') WHERE id = ?")
+      .bind(newVersion, offeringId)
+      .run();
+
+    const row = await this.db
+      .prepare("SELECT * FROM offering_versions WHERE id = ?")
+      .bind(versionId)
+      .first<VersionRow>();
+
+    return row ? rowToVersion(row) : null;
+  }
+
+  async listVersions(orgId: string, offeringId: string): Promise<OfferingVersion[]> {
+    const offering = await this.getOfferingRow(orgId, offeringId);
+    if (!offering) return [];
+
+    const result = await this.db
+      .prepare("SELECT * FROM offering_versions WHERE offering_id = ? ORDER BY version DESC")
+      .bind(offeringId)
+      .all<VersionRow>();
+
+    return result.results.map(rowToVersion);
+  }
+
+  private async getOfferingRow(orgId: string, id: string): Promise<Offering | null> {
+    const row = await this.db
+      .prepare("SELECT * FROM offerings WHERE id = ? AND org_id = ?")
+      .bind(id, orgId)
+      .first<OfferingRow>();
+    return row ? rowToOffering(row) : null;
+  }
+}


### PR DESCRIPTION
## Summary
- F369: D1 마이그레이션 — offerings/offering_versions/offering_sections/offering_design_tokens 4테이블
- F370: Offerings CRUD API — POST/GET/PUT/DELETE + Versions (7 endpoints)
- F371: Offering Sections API — 22섹션 표준 목차 CRUD + 토글 + 순서변경 (5 endpoints)

## Details
- Phase 18-B Data Layer
- 14 files changed, ~2100 LOC
- 26 tests all pass (14 offerings + 12 sections)
- Match Rate: 99%
- D1 migration: `0110_offerings.sql`

## Test plan
- [x] `pnpm test -- offerings.test.ts` — 14 pass
- [x] `pnpm test -- offering-sections.test.ts` — 12 pass
- [x] typecheck (no new errors in offering files)
- [ ] D1 remote migration after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)