### PR TITLE
feat: Sprint 178 — M4 Builder Quality Dashboard (F390+F391)

### DIFF
--- a/docs/01-plan/features/sprint-178.plan.md
+++ b/docs/01-plan/features/sprint-178.plan.md
@@ -1,0 +1,111 @@
+---
+code: FX-PLAN-S178
+title: "Sprint 178 — M4: Builder Quality 대시보드 + 사용자 피드백 루프"
+version: "1.0"
+status: Active
+category: PLAN
+created: 2026-04-06
+updated: 2026-04-06
+author: Claude Autopilot
+sprint: 178
+features: [F390, F391]
+---
+
+# Sprint 178 Plan — M4: Builder Quality 대시보드 + 사용자 피드백 루프
+
+## Executive Summary
+
+| 항목 | 내용 |
+|------|------|
+| Feature | F390 Builder Quality 대시보드 + F391 사용자 피드백 루프 |
+| Sprint | 178 |
+| Phase | Phase 19 — Builder Evolution |
+| 선행 Sprint | Sprint 176 (F386+F387 5차원 스코어링), Sprint 177 (F388+F389 CLI 듀얼 모드 + Enhanced O-G-D) |
+| 예상 산출물 | API 3 routes + 3 services + 3 schemas + Web 2 pages + D1 2 migrations + 15+ tests |
+
+| 관점 | 내용 |
+|------|------|
+| Problem | 5차원 품질 점수가 DB에 저장되지만 시각적 대시보드가 없어 BD팀이 품질 현황을 파악할 수 없음. 자동 점수와 실제 고객 피드백 간 상관관계가 불명확함 |
+| Solution | Builder Quality 전용 페이지에 스코어 카드 + 레이더 차트 + 개선 추이 그래프를 제공하고, 수동 평가 데이터 수집 + 자동-수동 상관관계 분석 시스템 구축 |
+| Function UX Effect | BD팀이 프로토타입 품질을 한눈에 파악하고, 고객 피드백이 자동 점수 개선에 반영됨 |
+| Core Value | 프로토타입 품질의 정량적 관리와 지속적 캘리브레이션으로 "고객 데모 가능" 수준 자동 보장 |
+
+## §1 목표
+
+### F390: Builder Quality 대시보드
+- **점수 카드**: 전체 프로토타입 평균 점수, 80점+ 비율, 비용 절감 효과
+- **레이더 차트**: 5차원(Build/UI/Functional/PRD/Code) 차원별 평균 분포
+- **개선 추이**: 라운드별 점수 변화 타임라인 (전체 + 개별 Job)
+- **비용 비교**: CLI vs API 모드 사용 비율 + 절감액
+
+### F391: 사용자 피드백 루프
+- **수동 평가 수집**: BD팀/고객이 프로토타입에 대해 5차원 수동 점수(1~5) 부여
+- **상관관계 분석**: 자동 5차원 점수 vs 수동 평가 간 Pearson/Spearman 상관계수 산출
+- **캘리브레이션 히스토리**: 시간에 따른 자동-수동 갭 추이 시각화
+- **임계값 자동 조정 제안**: 상관관계가 낮은 차원에 대해 가중치 조정 권고
+
+## §2 기술 접근
+
+### API (packages/api)
+1. **quality-dashboard route** — 대시보드 전용 집계 API
+   - `GET /quality-dashboard/summary` — 전체 통계 (기존 `getStats()` 확장)
+   - `GET /quality-dashboard/dimensions` — 5차원 평균 분포
+   - `GET /quality-dashboard/trend` — 시간별 추이 (최근 30일)
+2. **user-evaluation route** — 사용자 수동 평가 CRUD
+   - `POST /user-evaluations` — 수동 평가 등록
+   - `GET /user-evaluations/:jobId` — Job별 평가 목록
+   - `GET /user-evaluations/correlation` — 자동-수동 상관관계
+3. **D1 migration** — `user_evaluations` 테이블 신규
+4. **calibration-service** — 상관관계 계산 + 캘리브레이션 로직
+
+### Web (packages/web)
+1. **builder-quality 페이지** — `/builder-quality` 라우트
+   - ScoreCardGrid: 4개 KPI 카드 (평균점수, 80점+%, 비용절감, 총 프로토타입)
+   - DimensionRadar: 5축 레이더 차트 (SVG)
+   - TrendChart: 시간별 점수 추이 라인 차트 (SVG)
+   - CostComparison: CLI/API 모드 비율 파이 차트
+2. **evaluation 모달** — prototype-detail 페이지에 수동 평가 폼 추가
+   - 5차원 슬라이더 (1~5점)
+   - 코멘트 텍스트 필드
+   - 평가자 역할 선택 (BD팀/고객/경영진)
+3. **correlation 뷰** — 자동-수동 상관관계 시각화
+   - 차원별 산점도 (자동 vs 수동)
+   - 상관계수 배지
+
+## §3 선행 코드 활용
+
+| 기존 코드 | 활용 방식 |
+|-----------|-----------|
+| `PrototypeQualityService.getStats()` | 대시보드 summary API의 기반 |
+| `QualityScoreChart` 컴포넌트 | TrendChart 구현 시 참조 |
+| `prototype_quality` D1 테이블 | 자동 점수 소스 |
+| `submitPrototypeFeedback` API | 기존 피드백과 수동 평가 구분 |
+| `InsertQualitySchema` | 검증 패턴 참조 |
+
+## §4 구현 순서
+
+| 단계 | 작업 | 산출물 |
+|------|------|--------|
+| 1 | D1 마이그레이션 (user_evaluations 테이블) | 1 migration |
+| 2 | API schemas + services (quality-dashboard, user-evaluation, calibration) | 3 schemas, 3 services |
+| 3 | API routes (quality-dashboard, user-evaluation) | 2 routes |
+| 4 | Web builder-quality 페이지 (스코어 카드 + 레이더 + 추이) | 1 page + 4 components |
+| 5 | Web 수동 평가 모달 + 상관관계 뷰 | 1 modal + 1 component |
+| 6 | 테스트 (API + Web) | 15+ tests |
+| 7 | 라우터 등록 + 사이드바 네비게이션 추가 | router.tsx + sidebar |
+
+## §5 리스크
+
+| 리스크 | 대응 |
+|--------|------|
+| 수동 평가 데이터 부족 (초기) | 최소 3개 이상 평가 시에만 상관계수 산출 |
+| 상관관계 낮을 시 의미 | 차원별 가중치 조정 권고 UI 제공 |
+| 레이더 차트 라이브러리 의존 | 라이브러리 없이 순수 SVG 구현 (기존 패턴) |
+
+## §6 완료 기준
+
+- [ ] Builder Quality 대시보드 4개 섹션 (스코어카드, 레이더, 추이, 비용) 동작
+- [ ] 수동 평가 CRUD (등록/조회)
+- [ ] 자동-수동 상관관계 계산 + 시각화
+- [ ] API 테스트 15개 이상 pass
+- [ ] typecheck + lint 통과

--- a/docs/02-design/features/sprint-178.design.md
+++ b/docs/02-design/features/sprint-178.design.md
@@ -1,0 +1,302 @@
+---
+code: FX-DSGN-S178
+title: "Sprint 178 Design — M4: Builder Quality 대시보드 + 사용자 피드백 루프"
+version: "1.0"
+status: Active
+category: DSGN
+created: 2026-04-06
+updated: 2026-04-06
+author: Claude Autopilot
+sprint: 178
+features: [F390, F391]
+plan: "[[FX-PLAN-S178]]"
+---
+
+# Sprint 178 Design — M4: Builder Quality 대시보드 + 사용자 피드백 루프
+
+## §1 개요
+
+Sprint 178은 Phase 19 Builder Evolution의 마지막 마일스톤(M4)으로, 5차원 품질 점수를 시각화하는 대시보드(F390)와 사용자 수동 평가 + 자동-수동 상관관계 캘리브레이션(F391)을 구현해요.
+
+**선행 코드**: Sprint 176의 `prototype_quality` D1 테이블 + `PrototypeQualityService`, Sprint 177의 Enhanced O-G-D 루프.
+
+## §2 D1 마이그레이션
+
+### 0112_user_evaluations.sql
+
+```sql
+-- Sprint 178: F391 — 사용자 수동 평가 테이블
+CREATE TABLE IF NOT EXISTS user_evaluations (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  job_id TEXT NOT NULL REFERENCES prototype_jobs(id) ON DELETE CASCADE,
+  org_id TEXT NOT NULL,
+  evaluator_role TEXT NOT NULL DEFAULT 'bd_team',
+  build_score INTEGER NOT NULL CHECK(build_score BETWEEN 1 AND 5),
+  ui_score INTEGER NOT NULL CHECK(ui_score BETWEEN 1 AND 5),
+  functional_score INTEGER NOT NULL CHECK(functional_score BETWEEN 1 AND 5),
+  prd_score INTEGER NOT NULL CHECK(prd_score BETWEEN 1 AND 5),
+  code_score INTEGER NOT NULL CHECK(code_score BETWEEN 1 AND 5),
+  overall_score INTEGER NOT NULL CHECK(overall_score BETWEEN 1 AND 5),
+  comment TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_ue_job_id ON user_evaluations(job_id);
+CREATE INDEX IF NOT EXISTS idx_ue_org_id ON user_evaluations(org_id);
+```
+
+**설계 결정**: 수동 평가는 1~5 정수 스케일 (자동 점수의 0~1 실수와 매핑: 수동 1→자동 0.2, 수동 5→자동 1.0). `evaluator_role`은 `bd_team`, `customer`, `executive` 3종.
+
+## §3 API Schema
+
+### quality-dashboard-schema.ts
+
+```typescript
+import { z } from "zod";
+
+export const QualityDashboardSummarySchema = z.object({
+  totalPrototypes: z.number(),
+  averageScore: z.number(),
+  above80Count: z.number(),
+  above80Pct: z.number(),
+  totalCostSaved: z.number(),
+  generationModes: z.record(z.string(), z.number()),
+});
+
+export const DimensionAverageSchema = z.object({
+  build: z.number(),
+  ui: z.number(),
+  functional: z.number(),
+  prd: z.number(),
+  code: z.number(),
+});
+
+export const TrendPointSchema = z.object({
+  date: z.string(),
+  avgScore: z.number(),
+  count: z.number(),
+});
+
+export const QualityTrendSchema = z.object({
+  points: z.array(TrendPointSchema),
+  period: z.string(),
+});
+```
+
+### user-evaluation-schema.ts
+
+```typescript
+import { z } from "zod";
+
+export const EVALUATOR_ROLES = ["bd_team", "customer", "executive"] as const;
+
+export const CreateUserEvaluationSchema = z.object({
+  jobId: z.string().min(1),
+  evaluatorRole: z.enum(EVALUATOR_ROLES).default("bd_team"),
+  buildScore: z.number().int().min(1).max(5),
+  uiScore: z.number().int().min(1).max(5),
+  functionalScore: z.number().int().min(1).max(5),
+  prdScore: z.number().int().min(1).max(5),
+  codeScore: z.number().int().min(1).max(5),
+  overallScore: z.number().int().min(1).max(5),
+  comment: z.string().optional(),
+});
+
+export type CreateUserEvaluationInput = z.infer<typeof CreateUserEvaluationSchema>;
+
+export const CorrelationResultSchema = z.object({
+  dimension: z.string(),
+  pearson: z.number(),
+  sampleSize: z.number(),
+  autoMean: z.number(),
+  manualMean: z.number(),
+});
+
+export const CorrelationSummarySchema = z.object({
+  correlations: z.array(CorrelationResultSchema),
+  overallPearson: z.number(),
+  totalEvaluations: z.number(),
+  calibrationStatus: z.enum(["good", "needs_attention", "insufficient_data"]),
+});
+```
+
+## §4 API Services
+
+### quality-dashboard-service.ts
+
+기존 `PrototypeQualityService.getStats()` 확장. 추가 메서드:
+
+| 메서드 | 설명 |
+|--------|------|
+| `getSummary()` | 전체 통계 + 80점+ 비율 |
+| `getDimensionAverages()` | 5차원 평균 (최신 라운드 기준) |
+| `getTrend(days: number)` | 일별 평균 점수 추이 |
+
+### user-evaluation-service.ts
+
+| 메서드 | 설명 |
+|--------|------|
+| `create(orgId, input)` | 수동 평가 저장 |
+| `listByJob(orgId, jobId)` | Job별 평가 목록 |
+| `listAll(orgId)` | 전체 평가 (상관관계 계산용) |
+
+### calibration-service.ts
+
+| 메서드 | 설명 |
+|--------|------|
+| `computeCorrelation(orgId)` | 자동-수동 5차원 + overall Pearson 상관관계 + calibrationStatus 판정 |
+
+**상관관계 계산**: Pearson r = Σ[(xi-x̄)(yi-ȳ)] / √[Σ(xi-x̄)²·Σ(yi-ȳ)²]. 최소 3쌍 이상에서만 계산.
+
+**수동→자동 스케일 변환**: `(manualScore - 1) / 4` (1→0, 5→1)
+
+## §5 API Routes
+
+### quality-dashboard.ts
+
+| Method | Path | 설명 |
+|--------|------|------|
+| GET | `/quality-dashboard/summary` | 전체 통계 (점수카드용) |
+| GET | `/quality-dashboard/dimensions` | 5차원 평균 (레이더차트용) |
+| GET | `/quality-dashboard/trend?days=30` | 시간별 추이 |
+
+### user-evaluations.ts
+
+| Method | Path | 설명 |
+|--------|------|------|
+| POST | `/user-evaluations` | 수동 평가 등록 |
+| GET | `/user-evaluations/:jobId` | Job별 수동 평가 목록 |
+| GET | `/user-evaluations/correlation` | 자동-수동 상관관계 |
+
+## §6 Web 컴포넌트
+
+### 페이지: builder-quality.tsx (신규)
+
+라우트: `/builder-quality` — 사이드바 "Prototype" 하위에 "Quality" 추가.
+
+**레이아웃 구성:**
+```
+┌──────────────────────────────────────┐
+│  Builder Quality Dashboard    [F390] │
+├──────────┬──────────┬────────┬───────┤
+│ 평균점수 │ 80점+%  │ 절감액 │ 총 N  │  ← ScoreCardGrid (4칸)
+├──────────┴──────────┴────────┴───────┤
+│  [5차원 레이더]    │  [점수 추이]    │  ← 2-column
+├────────────────────┴─────────────────┤
+│  [비용 비교 CLI/API]                 │  ← CostComparison
+├──────────────────────────────────────┤
+│  [상관관계 분석]   [F391]            │  ← CorrelationPanel
+└──────────────────────────────────────┘
+```
+
+### 컴포넌트 목록
+
+| 컴포넌트 | 파일 | 설명 |
+|----------|------|------|
+| ScoreCardGrid | `components/feature/builder/ScoreCardGrid.tsx` | 4개 KPI 카드 |
+| DimensionRadar | `components/feature/builder/DimensionRadar.tsx` | 5축 SVG 레이더 차트 |
+| QualityTrendLine | `components/feature/builder/QualityTrendLine.tsx` | 일별 추이 SVG 라인 차트 |
+| CostComparison | `components/feature/builder/CostComparison.tsx` | CLI/API 모드 비율 바 |
+| CorrelationPanel | `components/feature/builder/CorrelationPanel.tsx` | 자동-수동 상관관계 표 |
+| UserEvaluationModal | `components/feature/builder/UserEvaluationModal.tsx` | 5차원 수동 평가 폼 (prototype-detail에서 호출) |
+
+### prototype-detail.tsx 수정
+
+- "평가하기" 버튼 추가 → `UserEvaluationModal` 열기
+- 수동 평가 목록 탭 추가 (기존 피드백 탭 옆)
+
+### api-client.ts 추가 함수
+
+```typescript
+// F390 Quality Dashboard
+export async function fetchQualityDashboardSummary() { ... }
+export async function fetchQualityDimensions() { ... }
+export async function fetchQualityTrend(days?: number) { ... }
+
+// F391 User Evaluations
+export async function submitUserEvaluation(data: CreateUserEvaluationInput) { ... }
+export async function fetchUserEvaluations(jobId: string) { ... }
+export async function fetchCorrelation() { ... }
+```
+
+### router.tsx 추가
+
+```typescript
+{ path: "builder-quality", lazy: () => import("@/routes/builder-quality") },
+```
+
+### sidebar.tsx 추가
+
+"Prototype" 아래에 `{ href: "/builder-quality", label: "Quality", icon: BarChart3 }` 추가.
+
+## §7 테스트 계획
+
+### API 테스트
+
+| 파일 | 테스트 내용 | 수 |
+|------|-----------|-----|
+| `quality-dashboard.test.ts` | summary/dimensions/trend API | 4 |
+| `user-evaluations.test.ts` | CRUD + 유효성 검증 | 5 |
+| `calibration-service.test.ts` | 상관관계 계산 정확성 | 4 |
+
+### Web 테스트
+
+| 파일 | 테스트 내용 | 수 |
+|------|-----------|-----|
+| `builder-quality.test.tsx` | 대시보드 렌더링 | 3 |
+| `user-evaluation-modal.test.tsx` | 수동 평가 폼 | 2 |
+
+**총 18개 테스트 예상**
+
+## §8 파일 변경 매핑
+
+### 신규 파일
+
+| 패키지 | 파일 | 용도 |
+|--------|------|------|
+| api | `src/db/migrations/0112_user_evaluations.sql` | D1 마이그레이션 |
+| api | `src/schemas/quality-dashboard-schema.ts` | 대시보드 Zod 스키마 |
+| api | `src/schemas/user-evaluation-schema.ts` | 수동 평가 Zod 스키마 |
+| api | `src/services/quality-dashboard-service.ts` | 대시보드 집계 서비스 |
+| api | `src/services/user-evaluation-service.ts` | 수동 평가 CRUD 서비스 |
+| api | `src/services/calibration-service.ts` | 상관관계 계산 서비스 |
+| api | `src/routes/quality-dashboard.ts` | 대시보드 API 라우트 |
+| api | `src/routes/user-evaluations.ts` | 수동 평가 API 라우트 |
+| api | `src/__tests__/quality-dashboard.test.ts` | 대시보드 API 테스트 |
+| api | `src/__tests__/user-evaluations.test.ts` | 수동 평가 API 테스트 |
+| api | `src/__tests__/calibration-service.test.ts` | 상관관계 계산 테스트 |
+| web | `src/routes/builder-quality.tsx` | 대시보드 페이지 |
+| web | `src/components/feature/builder/ScoreCardGrid.tsx` | KPI 카드 |
+| web | `src/components/feature/builder/DimensionRadar.tsx` | 레이더 차트 |
+| web | `src/components/feature/builder/QualityTrendLine.tsx` | 추이 차트 |
+| web | `src/components/feature/builder/CostComparison.tsx` | 비용 비교 |
+| web | `src/components/feature/builder/CorrelationPanel.tsx` | 상관관계 패널 |
+| web | `src/components/feature/builder/UserEvaluationModal.tsx` | 수동 평가 폼 |
+| web | `src/__tests__/builder-quality.test.tsx` | 대시보드 테스트 |
+
+### 수정 파일
+
+| 패키지 | 파일 | 변경 내용 |
+|--------|------|-----------|
+| api | `src/app.ts` | 2 route 등록 |
+| web | `src/router.tsx` | builder-quality 라우트 추가 |
+| web | `src/components/sidebar.tsx` | Quality 메뉴 항목 추가 |
+| web | `src/lib/api-client.ts` | 6 함수 추가 |
+| web | `src/routes/prototype-detail.tsx` | 평가하기 버튼 + 수동 평가 탭 |
+
+## §9 E2E Skip 항목
+
+해당 없음 — 모든 기능이 코드로 구현 가능.
+
+## §10 완료 기준 체크리스트
+
+- [ ] D1 마이그레이션 `0112_user_evaluations.sql` 생성
+- [ ] API: quality-dashboard route (3 endpoints) 동작
+- [ ] API: user-evaluations route (3 endpoints) 동작
+- [ ] API: calibration-service 상관관계 계산 정확
+- [ ] Web: builder-quality 페이지 4섹션 렌더링
+- [ ] Web: UserEvaluationModal 수동 평가 등록
+- [ ] Web: CorrelationPanel 상관관계 시각화
+- [ ] 18개+ 테스트 전부 pass
+- [ ] typecheck 통과
+- [ ] lint 통과

--- a/docs/04-report/features/sprint-178.report.md
+++ b/docs/04-report/features/sprint-178.report.md
@@ -1,0 +1,106 @@
+---
+code: FX-RPRT-S178
+title: "Sprint 178 완료 보고서 — M4: Builder Quality 대시보드 + 사용자 피드백 루프"
+version: "1.0"
+status: Active
+category: RPRT
+created: 2026-04-06
+updated: 2026-04-06
+author: Claude Autopilot
+sprint: 178
+features: [F390, F391]
+plan: "[[FX-PLAN-S178]]"
+design: "[[FX-DSGN-S178]]"
+---
+
+# Sprint 178 완료 보고서
+
+## Executive Summary
+
+| 항목 | 내용 |
+|------|------|
+| Feature | F390 Builder Quality 대시보드 + F391 사용자 피드백 루프 |
+| Sprint | 178 |
+| Phase | Phase 19 — Builder Evolution (M4: 품질 대시보드) |
+| Match Rate | **95%** (90% 기준 초과) |
+| 산출물 | API 2 routes (6 endpoints) + 3 services + 2 schemas + Web 1 page + 6 components + 1 D1 migration + 18 tests |
+
+| 관점 | 내용 |
+|------|------|
+| Problem | 5차원 품질 점수가 DB에 존재하나 시각화 대시보드 부재, 자동-수동 평가 상관관계 미검증 |
+| Solution | ScoreCard + Radar + Trend 대시보드 + 수동 5차원 평가 + Pearson 상관관계 캘리브레이션 |
+| Function UX Effect | BD팀이 품질 현황을 한눈에 파악, 고객 피드백이 자동 점수 신뢰성 검증에 활용됨 |
+| Core Value | 프로토타입 품질의 정량적 관리와 자동-수동 캘리브레이션 기반 신뢰성 확보 |
+
+## 구현 결과
+
+### API (packages/api)
+
+| 유형 | 파일 | 내용 |
+|------|------|------|
+| Migration | `0112_user_evaluations.sql` | 수동 평가 테이블 (6차원 1~5점 + evaluator_role) |
+| Schema | `quality-dashboard-schema.ts` | Summary + DimensionAverage + Trend 스키마 |
+| Schema | `user-evaluation-schema.ts` | CreateUserEvaluation + Correlation 스키마 |
+| Service | `quality-dashboard-service.ts` | getSummary + getDimensionAverages + getTrend |
+| Service | `user-evaluation-service.ts` | create + listByJob + listAll |
+| Service | `calibration-service.ts` | Pearson r 상관관계 계산 + calibrationStatus 판정 |
+| Route | `quality-dashboard.ts` | GET summary / dimensions / trend |
+| Route | `user-evaluations.ts` | POST create / GET by job / GET correlation |
+
+### Web (packages/web)
+
+| 유형 | 파일 | 내용 |
+|------|------|------|
+| Page | `builder-quality.tsx` | 4섹션 대시보드 (ScoreCard + Radar + Trend + Correlation) |
+| Component | `builder/ScoreCardGrid.tsx` | 4개 KPI 카드 (평균점수/80+%/절감액/총 수) |
+| Component | `builder/DimensionRadar.tsx` | 5축 SVG 레이더 차트 |
+| Component | `builder/QualityTrendLine.tsx` | 일별 점수 추이 SVG 라인 차트 |
+| Component | `builder/CostComparison.tsx` | CLI/API 모드 비율 바 + 절감액 |
+| Component | `builder/CorrelationPanel.tsx` | 자동-수동 상관관계 테이블 |
+| Component | `builder/UserEvaluationModal.tsx` | 5차원 수동 평가 폼 (1~5점 버튼) |
+
+### 수정 파일
+
+| 파일 | 변경 |
+|------|------|
+| `app.ts` | qualityDashboardRoute + userEvaluationsRoute 등록 |
+| `router.tsx` | `/builder-quality` 라우트 추가 |
+| `sidebar.tsx` | "Quality" 메뉴 항목 추가 |
+| `api-client.ts` | 6개 API 함수 + 인터페이스 추가 |
+| `prototype-detail.tsx` | 수동 평가 버튼 + 수동 평가 탭 |
+
+### 테스트
+
+| 파일 | Tests | Pass |
+|------|-------|------|
+| `quality-dashboard.test.ts` | 4 | 4 ✅ |
+| `user-evaluations.test.ts` | 5 | 5 ✅ |
+| `calibration-service.test.ts` | 4 | 4 ✅ |
+| `builder-quality.test.tsx` | 3 | (Web) |
+| `user-evaluation-modal.test.tsx` | 2 | (Web) |
+| **합계** | **18** | **13 API ✅** |
+
+## Gap Analysis 결과
+
+| 카테고리 | 점수 |
+|----------|------|
+| Design Match | 94% |
+| Architecture Compliance | 100% |
+| Convention Compliance | 100% |
+| **Overall** | **95%** |
+
+### 의도적 변경 (Design 역갱신)
+
+- `CorrelationResultSchema.spearman` 필드 제거 → Pearson r만으로 충분
+- `calibration-service.ts`: 2개 메서드를 1개로 통합 (status가 computeCorrelation 반환값에 포함)
+
+## Phase 19 마일스톤 진행률
+
+| 마일스톤 | Sprint | F-items | 상태 |
+|----------|--------|---------|------|
+| M0: 검증 PoC | 175 | F384+F385 | ✅ |
+| M1: 5차원 스코어링 엔진 | 176 | F386+F387 | ✅ |
+| M2+M3: CLI 통합 + 자동 개선 | 177 | F388+F389 | ✅ |
+| **M4: 품질 대시보드** | **178** | **F390+F391** | **✅** |
+
+**Phase 19 Builder Evolution 전체 완료 (8/8 F-items)**

--- a/packages/api/src/__tests__/calibration-service.test.ts
+++ b/packages/api/src/__tests__/calibration-service.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createMockD1 } from "./helpers/mock-d1.js";
+import { CalibrationService } from "../services/calibration-service.js";
+
+const JOBS_SCHEMA = `
+  CREATE TABLE IF NOT EXISTS prototype_jobs (
+    id TEXT PRIMARY KEY,
+    org_id TEXT NOT NULL,
+    prd_content TEXT NOT NULL,
+    prd_title TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL DEFAULT 'queued',
+    builder_type TEXT NOT NULL DEFAULT 'cli',
+    pages_project TEXT,
+    pages_url TEXT,
+    build_log TEXT DEFAULT '',
+    error_message TEXT,
+    cost_input_tokens INTEGER DEFAULT 0,
+    cost_output_tokens INTEGER DEFAULT 0,
+    cost_usd REAL DEFAULT 0.0,
+    model_used TEXT DEFAULT 'haiku',
+    fallback_used INTEGER DEFAULT 0,
+    retry_count INTEGER DEFAULT 0,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    started_at INTEGER,
+    completed_at INTEGER
+  );
+`;
+
+const QUALITY_SCHEMA = `
+  CREATE TABLE IF NOT EXISTS prototype_quality (
+    id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+    job_id TEXT NOT NULL REFERENCES prototype_jobs(id) ON DELETE CASCADE,
+    round INTEGER NOT NULL DEFAULT 0,
+    total_score REAL NOT NULL,
+    build_score REAL NOT NULL,
+    ui_score REAL NOT NULL,
+    functional_score REAL NOT NULL,
+    prd_score REAL NOT NULL,
+    code_score REAL NOT NULL,
+    generation_mode TEXT NOT NULL DEFAULT 'api',
+    cost_usd REAL NOT NULL DEFAULT 0,
+    feedback TEXT,
+    details TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+`;
+
+const EVAL_SCHEMA = `
+  CREATE TABLE IF NOT EXISTS user_evaluations (
+    id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+    job_id TEXT NOT NULL REFERENCES prototype_jobs(id) ON DELETE CASCADE,
+    org_id TEXT NOT NULL,
+    evaluator_role TEXT NOT NULL DEFAULT 'bd_team',
+    build_score INTEGER NOT NULL CHECK(build_score BETWEEN 1 AND 5),
+    ui_score INTEGER NOT NULL CHECK(ui_score BETWEEN 1 AND 5),
+    functional_score INTEGER NOT NULL CHECK(functional_score BETWEEN 1 AND 5),
+    prd_score INTEGER NOT NULL CHECK(prd_score BETWEEN 1 AND 5),
+    code_score INTEGER NOT NULL CHECK(code_score BETWEEN 1 AND 5),
+    overall_score INTEGER NOT NULL CHECK(overall_score BETWEEN 1 AND 5),
+    comment TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+`;
+
+function setupDb() {
+  const db = createMockD1();
+  void db.exec(JOBS_SCHEMA);
+  void db.exec(QUALITY_SCHEMA);
+  void db.exec(EVAL_SCHEMA);
+  return db;
+}
+
+async function seedJob(db: ReturnType<typeof createMockD1>, id: string) {
+  await db
+    .prepare("INSERT INTO prototype_jobs (id, org_id, prd_content, prd_title) VALUES (?, ?, ?, ?)")
+    .bind(id, "org-1", "# PRD\nTest", "Test PRD")
+    .run();
+}
+
+async function seedQuality(db: ReturnType<typeof createMockD1>, jobId: string, scores: number[]) {
+  await db
+    .prepare(
+      `INSERT INTO prototype_quality (id, job_id, round, total_score, build_score, ui_score, functional_score, prd_score, code_score, generation_mode, cost_usd)
+       VALUES (?, ?, 0, ?, ?, ?, ?, ?, ?, 'api', 0)`,
+    )
+    .bind(`pq-${jobId}`, jobId, scores[0], scores[1], scores[2], scores[3], scores[4], scores[5])
+    .run();
+}
+
+async function seedEval(db: ReturnType<typeof createMockD1>, jobId: string, scores: number[]) {
+  const id = `ue-${jobId}-${Date.now()}`;
+  await db
+    .prepare(
+      `INSERT INTO user_evaluations (id, job_id, org_id, evaluator_role, build_score, ui_score, functional_score, prd_score, code_score, overall_score)
+       VALUES (?, ?, 'org-1', 'bd_team', ?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(id, jobId, scores[0], scores[1], scores[2], scores[3], scores[4], scores[5])
+    .run();
+}
+
+describe("CalibrationService", () => {
+  let db: ReturnType<typeof createMockD1>;
+  let svc: CalibrationService;
+
+  beforeEach(() => {
+    db = setupDb();
+    svc = new CalibrationService(db as unknown as D1Database);
+  });
+
+  it("데이터 부족 시 insufficient_data를 반환해요", async () => {
+    const result = await svc.computeCorrelation("org-1");
+    expect(result.calibrationStatus).toBe("insufficient_data");
+    expect(result.correlations).toEqual([]);
+    expect(result.totalEvaluations).toBe(0);
+  });
+
+  it("매칭 데이터가 3쌍 미만이면 insufficient_data예요", async () => {
+    await seedJob(db, "job-1");
+    await seedJob(db, "job-2");
+    await seedQuality(db, "job-1", [80, 0.9, 0.7, 0.8, 0.6, 0.9]);
+    await seedQuality(db, "job-2", [70, 0.8, 0.5, 0.7, 0.5, 0.8]);
+    await seedEval(db, "job-1", [4, 3, 4, 3, 4, 4]);
+    await seedEval(db, "job-2", [3, 2, 3, 2, 3, 3]);
+
+    const result = await svc.computeCorrelation("org-1");
+    expect(result.calibrationStatus).toBe("insufficient_data");
+  });
+
+  it("3쌍 이상이면 상관계수를 계산해요", async () => {
+    // 3개 job, 자동 점수가 높을수록 수동 점수도 높은 양의 상관관계
+    await seedJob(db, "job-1");
+    await seedJob(db, "job-2");
+    await seedJob(db, "job-3");
+
+    // 자동: 높은 → 중간 → 낮은
+    await seedQuality(db, "job-1", [90, 0.9, 0.8, 0.9, 0.8, 0.9]);
+    await seedQuality(db, "job-2", [60, 0.6, 0.5, 0.6, 0.5, 0.6]);
+    await seedQuality(db, "job-3", [30, 0.3, 0.2, 0.3, 0.2, 0.3]);
+
+    // 수동: 높은 → 중간 → 낮은 (양의 상관)
+    await seedEval(db, "job-1", [5, 4, 5, 4, 5, 5]);
+    await seedEval(db, "job-2", [3, 3, 3, 3, 3, 3]);
+    await seedEval(db, "job-3", [1, 1, 1, 1, 1, 1]);
+
+    const result = await svc.computeCorrelation("org-1");
+    expect(result.calibrationStatus).not.toBe("insufficient_data");
+    expect(result.correlations.length).toBe(5);
+    expect(result.totalEvaluations).toBe(3);
+
+    // 강한 양의 상관관계
+    for (const c of result.correlations) {
+      expect(c.pearson).toBeGreaterThan(0.9);
+      expect(c.sampleSize).toBe(3);
+    }
+    expect(result.overallPearson).toBeGreaterThan(0.9);
+  });
+
+  it("다른 org의 데이터는 포함하지 않아요", async () => {
+    await seedJob(db, "job-1");
+    await seedQuality(db, "job-1", [80, 0.9, 0.7, 0.8, 0.6, 0.9]);
+
+    // org-1이 아닌 org-other로 등록
+    await db
+      .prepare(
+        `INSERT INTO user_evaluations (id, job_id, org_id, evaluator_role, build_score, ui_score, functional_score, prd_score, code_score, overall_score)
+         VALUES ('ue-other', 'job-1', 'org-other', 'bd_team', 4, 3, 4, 3, 4, 4)`,
+      )
+      .run();
+
+    const result = await svc.computeCorrelation("org-1");
+    expect(result.totalEvaluations).toBe(0);
+  });
+});

--- a/packages/api/src/__tests__/quality-dashboard.test.ts
+++ b/packages/api/src/__tests__/quality-dashboard.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createMockD1 } from "./helpers/mock-d1.js";
+import { QualityDashboardService } from "../services/quality-dashboard-service.js";
+
+const JOBS_SCHEMA = `
+  CREATE TABLE IF NOT EXISTS prototype_jobs (
+    id TEXT PRIMARY KEY,
+    org_id TEXT NOT NULL,
+    prd_content TEXT NOT NULL,
+    prd_title TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL DEFAULT 'queued',
+    builder_type TEXT NOT NULL DEFAULT 'cli',
+    pages_project TEXT,
+    pages_url TEXT,
+    build_log TEXT DEFAULT '',
+    error_message TEXT,
+    cost_input_tokens INTEGER DEFAULT 0,
+    cost_output_tokens INTEGER DEFAULT 0,
+    cost_usd REAL DEFAULT 0.0,
+    model_used TEXT DEFAULT 'haiku',
+    fallback_used INTEGER DEFAULT 0,
+    retry_count INTEGER DEFAULT 0,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    started_at INTEGER,
+    completed_at INTEGER
+  );
+`;
+
+const QUALITY_SCHEMA = `
+  CREATE TABLE IF NOT EXISTS prototype_quality (
+    id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+    job_id TEXT NOT NULL REFERENCES prototype_jobs(id) ON DELETE CASCADE,
+    round INTEGER NOT NULL DEFAULT 0,
+    total_score REAL NOT NULL,
+    build_score REAL NOT NULL,
+    ui_score REAL NOT NULL,
+    functional_score REAL NOT NULL,
+    prd_score REAL NOT NULL,
+    code_score REAL NOT NULL,
+    generation_mode TEXT NOT NULL DEFAULT 'api',
+    cost_usd REAL NOT NULL DEFAULT 0,
+    feedback TEXT,
+    details TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+`;
+
+function setupDb() {
+  const db = createMockD1();
+  void db.exec(JOBS_SCHEMA);
+  void db.exec(QUALITY_SCHEMA);
+  return db;
+}
+
+async function seedJob(db: ReturnType<typeof createMockD1>, id: string) {
+  await db
+    .prepare("INSERT INTO prototype_jobs (id, org_id, prd_content, prd_title) VALUES (?, ?, ?, ?)")
+    .bind(id, "org-1", "# PRD\nTest content", "Test PRD")
+    .run();
+}
+
+async function seedQuality(
+  db: ReturnType<typeof createMockD1>,
+  jobId: string,
+  round: number,
+  totalScore: number,
+  mode = "api",
+  costUsd = 0.48,
+) {
+  await db
+    .prepare(
+      `INSERT INTO prototype_quality (id, job_id, round, total_score, build_score, ui_score, functional_score, prd_score, code_score, generation_mode, cost_usd)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(`pq-${jobId}-${round}`, jobId, round, totalScore, 0.8, 0.6, 0.7, 0.5, 0.9, mode, costUsd)
+    .run();
+}
+
+describe("QualityDashboardService", () => {
+  let db: ReturnType<typeof createMockD1>;
+  let svc: QualityDashboardService;
+
+  beforeEach(async () => {
+    db = setupDb();
+    svc = new QualityDashboardService(db as unknown as D1Database);
+    await seedJob(db, "job-1");
+    await seedJob(db, "job-2");
+    await seedQuality(db, "job-1", 0, 60, "api", 0.48);
+    await seedQuality(db, "job-1", 1, 85, "max-cli", 0);
+    await seedQuality(db, "job-2", 0, 75, "max-cli", 0);
+  });
+
+  it("getSummary — 최신 라운드 기준 통계를 반환해요", async () => {
+    const summary = await svc.getSummary();
+    expect(summary.totalPrototypes).toBe(2);
+    // job-1 최신 = 85, job-2 최신 = 75 → avg = 80
+    expect(summary.averageScore).toBe(80);
+    expect(summary.above80Count).toBe(1); // 85만 80+
+    expect(summary.above80Pct).toBe(50);
+    expect(summary.generationModes.cli).toBeGreaterThanOrEqual(0);
+  });
+
+  it("getDimensionAverages — 5차원 평균을 반환해요", async () => {
+    const dims = await svc.getDimensionAverages();
+    expect(dims.build).toBeGreaterThan(0);
+    expect(dims.ui).toBeGreaterThan(0);
+    expect(dims.functional).toBeGreaterThan(0);
+    expect(dims.prd).toBeGreaterThan(0);
+    expect(dims.code).toBeGreaterThan(0);
+  });
+
+  it("getTrend — 일별 추이를 반환해요", async () => {
+    const trend = await svc.getTrend(30);
+    expect(trend.period).toBe("30d");
+    expect(Array.isArray(trend.points)).toBe(true);
+    // 오늘 날짜의 데이터가 있어야 함
+    expect(trend.points.length).toBeGreaterThanOrEqual(1);
+    expect(trend.points[0]!.avgScore).toBeGreaterThan(0);
+  });
+
+  it("빈 DB에서도 에러 없이 동작해요", async () => {
+    const emptyDb = setupDb();
+    const emptySvc = new QualityDashboardService(emptyDb as unknown as D1Database);
+    const summary = await emptySvc.getSummary();
+    expect(summary.totalPrototypes).toBe(0);
+    expect(summary.averageScore).toBe(0);
+  });
+});

--- a/packages/api/src/__tests__/user-evaluations.test.ts
+++ b/packages/api/src/__tests__/user-evaluations.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createMockD1 } from "./helpers/mock-d1.js";
+import { UserEvaluationService } from "../services/user-evaluation-service.js";
+
+const JOBS_SCHEMA = `
+  CREATE TABLE IF NOT EXISTS prototype_jobs (
+    id TEXT PRIMARY KEY,
+    org_id TEXT NOT NULL,
+    prd_content TEXT NOT NULL,
+    prd_title TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL DEFAULT 'queued',
+    builder_type TEXT NOT NULL DEFAULT 'cli',
+    pages_project TEXT,
+    pages_url TEXT,
+    build_log TEXT DEFAULT '',
+    error_message TEXT,
+    cost_input_tokens INTEGER DEFAULT 0,
+    cost_output_tokens INTEGER DEFAULT 0,
+    cost_usd REAL DEFAULT 0.0,
+    model_used TEXT DEFAULT 'haiku',
+    fallback_used INTEGER DEFAULT 0,
+    retry_count INTEGER DEFAULT 0,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    started_at INTEGER,
+    completed_at INTEGER
+  );
+`;
+
+const EVAL_SCHEMA = `
+  CREATE TABLE IF NOT EXISTS user_evaluations (
+    id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+    job_id TEXT NOT NULL REFERENCES prototype_jobs(id) ON DELETE CASCADE,
+    org_id TEXT NOT NULL,
+    evaluator_role TEXT NOT NULL DEFAULT 'bd_team',
+    build_score INTEGER NOT NULL CHECK(build_score BETWEEN 1 AND 5),
+    ui_score INTEGER NOT NULL CHECK(ui_score BETWEEN 1 AND 5),
+    functional_score INTEGER NOT NULL CHECK(functional_score BETWEEN 1 AND 5),
+    prd_score INTEGER NOT NULL CHECK(prd_score BETWEEN 1 AND 5),
+    code_score INTEGER NOT NULL CHECK(code_score BETWEEN 1 AND 5),
+    overall_score INTEGER NOT NULL CHECK(overall_score BETWEEN 1 AND 5),
+    comment TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+`;
+
+function setupDb() {
+  const db = createMockD1();
+  void db.exec(JOBS_SCHEMA);
+  void db.exec(EVAL_SCHEMA);
+  return db;
+}
+
+async function seedJob(db: ReturnType<typeof createMockD1>, id = "job-1") {
+  await db
+    .prepare("INSERT INTO prototype_jobs (id, org_id, prd_content, prd_title) VALUES (?, ?, ?, ?)")
+    .bind(id, "org-1", "# PRD\nTest", "Test PRD")
+    .run();
+}
+
+describe("UserEvaluationService", () => {
+  let db: ReturnType<typeof createMockD1>;
+  let svc: UserEvaluationService;
+
+  beforeEach(async () => {
+    db = setupDb();
+    svc = new UserEvaluationService(db as unknown as D1Database);
+    await seedJob(db);
+  });
+
+  it("수동 평가를 저장하고 반환해요", async () => {
+    const record = await svc.create("org-1", {
+      jobId: "job-1",
+      evaluatorRole: "bd_team",
+      buildScore: 4,
+      uiScore: 3,
+      functionalScore: 5,
+      prdScore: 4,
+      codeScore: 3,
+      overallScore: 4,
+      comment: "UI 개선 필요",
+    });
+
+    expect(record.jobId).toBe("job-1");
+    expect(record.evaluatorRole).toBe("bd_team");
+    expect(record.buildScore).toBe(4);
+    expect(record.uiScore).toBe(3);
+    expect(record.overallScore).toBe(4);
+    expect(record.comment).toBe("UI 개선 필요");
+  });
+
+  it("Job별 평가 목록을 반환해요", async () => {
+    await svc.create("org-1", {
+      jobId: "job-1",
+      evaluatorRole: "bd_team",
+      buildScore: 4,
+      uiScore: 3,
+      functionalScore: 5,
+      prdScore: 4,
+      codeScore: 3,
+      overallScore: 4,
+    });
+    await svc.create("org-1", {
+      jobId: "job-1",
+      evaluatorRole: "customer",
+      buildScore: 3,
+      uiScore: 2,
+      functionalScore: 4,
+      prdScore: 3,
+      codeScore: 2,
+      overallScore: 3,
+    });
+
+    const items = await svc.listByJob("org-1", "job-1");
+    expect(items.length).toBe(2);
+  });
+
+  it("다른 org의 평가는 보이지 않아요", async () => {
+    await svc.create("org-1", {
+      jobId: "job-1",
+      evaluatorRole: "bd_team",
+      buildScore: 4,
+      uiScore: 3,
+      functionalScore: 5,
+      prdScore: 4,
+      codeScore: 3,
+      overallScore: 4,
+    });
+
+    const items = await svc.listByJob("org-other", "job-1");
+    expect(items.length).toBe(0);
+  });
+
+  it("전체 평가 목록을 반환해요", async () => {
+    await seedJob(db, "job-2");
+    await svc.create("org-1", {
+      jobId: "job-1",
+      evaluatorRole: "bd_team",
+      buildScore: 4,
+      uiScore: 3,
+      functionalScore: 5,
+      prdScore: 4,
+      codeScore: 3,
+      overallScore: 4,
+    });
+    await svc.create("org-1", {
+      jobId: "job-2",
+      evaluatorRole: "customer",
+      buildScore: 3,
+      uiScore: 2,
+      functionalScore: 4,
+      prdScore: 3,
+      codeScore: 2,
+      overallScore: 3,
+    });
+
+    const all = await svc.listAll("org-1");
+    expect(all.length).toBe(2);
+  });
+
+  it("comment 없이도 저장돼요", async () => {
+    const record = await svc.create("org-1", {
+      jobId: "job-1",
+      evaluatorRole: "executive",
+      buildScore: 5,
+      uiScore: 5,
+      functionalScore: 5,
+      prdScore: 5,
+      codeScore: 5,
+      overallScore: 5,
+    });
+
+    expect(record.comment).toBeNull();
+  });
+});

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -149,6 +149,9 @@ import { guardRailRoute } from "./routes/guard-rail.js";
 import { ogdGenericRoute } from "./routes/ogd-generic.js";
 // Sprint 164: 운영 지표 — 활용률 + 재사용률 + Rule 효과 (F361, F362, Phase 17)
 import { metricsRoute } from "./routes/metrics.js";
+// Sprint 178: Builder Quality Dashboard + User Evaluations (F390, F391, Phase 19)
+import { qualityDashboardRoute } from "./routes/quality-dashboard.js";
+import { userEvaluationsRoute } from "./routes/user-evaluations.js";
 import { handleScheduled } from "./scheduled.js";
 import { authMiddleware } from "./middleware/auth.js";
 import { piiMaskerMiddleware } from "./middleware/pii-masker.middleware.js";
@@ -463,6 +466,10 @@ app.route("/api", offeringSectionsRoute);
 // Sprint 168: Offering Export + Validate (F372, F373, Phase 18)
 app.route("/api", offeringExportRoute);
 app.route("/api", offeringValidateRoute);
+
+// Sprint 178: Builder Quality Dashboard + User Evaluations (F390, F391, Phase 19)
+app.route("/api", qualityDashboardRoute);
+app.route("/api", userEvaluationsRoute);
 
 // Sprint 47: PII masker middleware — AI API 경로에만 적용
 app.use("/api/agents/*", piiMaskerMiddleware);

--- a/packages/api/src/db/migrations/0112_user_evaluations.sql
+++ b/packages/api/src/db/migrations/0112_user_evaluations.sql
@@ -1,0 +1,20 @@
+-- Sprint 178: F391 — 사용자 수동 평가 테이블
+-- prototype_jobs 1:N user_evaluations (BD팀/고객/경영진 수동 5차원 평가)
+
+CREATE TABLE IF NOT EXISTS user_evaluations (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  job_id TEXT NOT NULL REFERENCES prototype_jobs(id) ON DELETE CASCADE,
+  org_id TEXT NOT NULL,
+  evaluator_role TEXT NOT NULL DEFAULT 'bd_team',
+  build_score INTEGER NOT NULL CHECK(build_score BETWEEN 1 AND 5),
+  ui_score INTEGER NOT NULL CHECK(ui_score BETWEEN 1 AND 5),
+  functional_score INTEGER NOT NULL CHECK(functional_score BETWEEN 1 AND 5),
+  prd_score INTEGER NOT NULL CHECK(prd_score BETWEEN 1 AND 5),
+  code_score INTEGER NOT NULL CHECK(code_score BETWEEN 1 AND 5),
+  overall_score INTEGER NOT NULL CHECK(overall_score BETWEEN 1 AND 5),
+  comment TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_ue_job_id ON user_evaluations(job_id);
+CREATE INDEX IF NOT EXISTS idx_ue_org_id ON user_evaluations(org_id);

--- a/packages/api/src/routes/quality-dashboard.ts
+++ b/packages/api/src/routes/quality-dashboard.ts
@@ -1,0 +1,33 @@
+// ─── F390: Quality Dashboard Routes (Sprint 178) ───
+
+import { Hono } from "hono";
+import { QualityDashboardService } from "../services/quality-dashboard-service.js";
+import type { Env } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+
+export const qualityDashboardRoute = new Hono<{
+  Bindings: Env;
+  Variables: TenantVariables;
+}>();
+
+// GET /quality-dashboard/summary — 전체 통계 (점수카드용)
+qualityDashboardRoute.get("/quality-dashboard/summary", async (c) => {
+  const svc = new QualityDashboardService(c.env.DB);
+  const summary = await svc.getSummary();
+  return c.json({ summary });
+});
+
+// GET /quality-dashboard/dimensions — 5차원 평균 (레이더차트용)
+qualityDashboardRoute.get("/quality-dashboard/dimensions", async (c) => {
+  const svc = new QualityDashboardService(c.env.DB);
+  const dimensions = await svc.getDimensionAverages();
+  return c.json({ dimensions });
+});
+
+// GET /quality-dashboard/trend — 시간별 추이
+qualityDashboardRoute.get("/quality-dashboard/trend", async (c) => {
+  const days = Number(c.req.query("days") ?? 30);
+  const svc = new QualityDashboardService(c.env.DB);
+  const trend = await svc.getTrend(days);
+  return c.json({ trend });
+});

--- a/packages/api/src/routes/user-evaluations.ts
+++ b/packages/api/src/routes/user-evaluations.ts
@@ -1,0 +1,43 @@
+// ─── F391: User Evaluations Routes (Sprint 178) ───
+
+import { Hono } from "hono";
+import { CreateUserEvaluationSchema } from "../schemas/user-evaluation-schema.js";
+import { UserEvaluationService } from "../services/user-evaluation-service.js";
+import { CalibrationService } from "../services/calibration-service.js";
+import type { Env } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+
+export const userEvaluationsRoute = new Hono<{
+  Bindings: Env;
+  Variables: TenantVariables;
+}>();
+
+// POST /user-evaluations — 수동 평가 등록
+userEvaluationsRoute.post("/user-evaluations", async (c) => {
+  const orgId = c.get("orgId");
+  const raw = await c.req.json();
+  const parsed = CreateUserEvaluationSchema.safeParse(raw);
+  if (!parsed.success) return c.json({ error: parsed.error.flatten() }, 400);
+
+  const svc = new UserEvaluationService(c.env.DB);
+  const evaluation = await svc.create(orgId, parsed.data);
+  return c.json({ evaluation }, 201);
+});
+
+// GET /user-evaluations/correlation — 자동-수동 상관관계
+// NOTE: 이 라우트를 /:jobId보다 먼저 등록해야 함
+userEvaluationsRoute.get("/user-evaluations/correlation", async (c) => {
+  const orgId = c.get("orgId");
+  const svc = new CalibrationService(c.env.DB);
+  const correlation = await svc.computeCorrelation(orgId);
+  return c.json({ correlation });
+});
+
+// GET /user-evaluations/:jobId — Job별 수동 평가 목록
+userEvaluationsRoute.get("/user-evaluations/:jobId", async (c) => {
+  const orgId = c.get("orgId");
+  const jobId = c.req.param("jobId");
+  const svc = new UserEvaluationService(c.env.DB);
+  const items = await svc.listByJob(orgId, jobId);
+  return c.json({ items });
+});

--- a/packages/api/src/schemas/quality-dashboard-schema.ts
+++ b/packages/api/src/schemas/quality-dashboard-schema.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+export const QualityDashboardSummarySchema = z.object({
+  totalPrototypes: z.number(),
+  averageScore: z.number(),
+  above80Count: z.number(),
+  above80Pct: z.number(),
+  totalCostSaved: z.number(),
+  generationModes: z.record(z.string(), z.number()),
+});
+
+export type QualityDashboardSummary = z.infer<typeof QualityDashboardSummarySchema>;
+
+export const DimensionAverageSchema = z.object({
+  build: z.number(),
+  ui: z.number(),
+  functional: z.number(),
+  prd: z.number(),
+  code: z.number(),
+});
+
+export type DimensionAverage = z.infer<typeof DimensionAverageSchema>;
+
+export const TrendPointSchema = z.object({
+  date: z.string(),
+  avgScore: z.number(),
+  count: z.number(),
+});
+
+export const QualityTrendSchema = z.object({
+  points: z.array(TrendPointSchema),
+  period: z.string(),
+});
+
+export type QualityTrend = z.infer<typeof QualityTrendSchema>;

--- a/packages/api/src/schemas/user-evaluation-schema.ts
+++ b/packages/api/src/schemas/user-evaluation-schema.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+export const EVALUATOR_ROLES = ["bd_team", "customer", "executive"] as const;
+
+export const CreateUserEvaluationSchema = z.object({
+  jobId: z.string().min(1),
+  evaluatorRole: z.enum(EVALUATOR_ROLES).default("bd_team"),
+  buildScore: z.number().int().min(1).max(5),
+  uiScore: z.number().int().min(1).max(5),
+  functionalScore: z.number().int().min(1).max(5),
+  prdScore: z.number().int().min(1).max(5),
+  codeScore: z.number().int().min(1).max(5),
+  overallScore: z.number().int().min(1).max(5),
+  comment: z.string().optional(),
+});
+
+export type CreateUserEvaluationInput = z.infer<typeof CreateUserEvaluationSchema>;
+
+export const CorrelationResultSchema = z.object({
+  dimension: z.string(),
+  pearson: z.number(),
+  sampleSize: z.number(),
+  autoMean: z.number(),
+  manualMean: z.number(),
+});
+
+export type CorrelationResult = z.infer<typeof CorrelationResultSchema>;
+
+export const CorrelationSummarySchema = z.object({
+  correlations: z.array(CorrelationResultSchema),
+  overallPearson: z.number(),
+  totalEvaluations: z.number(),
+  calibrationStatus: z.enum(["good", "needs_attention", "insufficient_data"]),
+});
+
+export type CorrelationSummary = z.infer<typeof CorrelationSummarySchema>;

--- a/packages/api/src/services/calibration-service.ts
+++ b/packages/api/src/services/calibration-service.ts
@@ -1,0 +1,163 @@
+// ─── F391: Calibration Service (Sprint 178) ───
+// 자동 5차원 점수와 수동 사용자 평가 간 Pearson 상관관계 계산
+
+import type { CorrelationResult, CorrelationSummary } from "../schemas/user-evaluation-schema.js";
+
+interface AutoScore {
+  jobId: string;
+  build: number;
+  ui: number;
+  functional: number;
+  prd: number;
+  code: number;
+  total: number;
+}
+
+interface ManualScore {
+  jobId: string;
+  build: number;
+  ui: number;
+  functional: number;
+  prd: number;
+  code: number;
+  overall: number;
+}
+
+function pearsonR(xs: number[], ys: number[]): number {
+  const n = xs.length;
+  if (n < 3) return 0;
+
+  const meanX = xs.reduce((a, b) => a + b, 0) / n;
+  const meanY = ys.reduce((a, b) => a + b, 0) / n;
+
+  let num = 0;
+  let denomX = 0;
+  let denomY = 0;
+
+  for (let i = 0; i < n; i++) {
+    const dx = xs[i]! - meanX;
+    const dy = ys[i]! - meanY;
+    num += dx * dy;
+    denomX += dx * dx;
+    denomY += dy * dy;
+  }
+
+  const denom = Math.sqrt(denomX * denomY);
+  return denom === 0 ? 0 : Math.round((num / denom) * 1000) / 1000;
+}
+
+function mean(arr: number[]): number {
+  return arr.length > 0 ? Math.round((arr.reduce((a, b) => a + b, 0) / arr.length) * 1000) / 1000 : 0;
+}
+
+// 수동 1~5 → 자동 0~1 스케일 변환
+function manualToAutoScale(score: number): number {
+  return (score - 1) / 4;
+}
+
+export class CalibrationService {
+  constructor(private db: D1Database) {}
+
+  async computeCorrelation(orgId: string): Promise<CorrelationSummary> {
+    // 자동 점수: 각 job의 최신 라운드
+    const { results: autoRows } = await this.db
+      .prepare(
+        `SELECT pq.job_id, pq.build_score, pq.ui_score, pq.functional_score,
+                pq.prd_score, pq.code_score, pq.total_score
+         FROM prototype_quality pq
+         JOIN prototype_jobs pj ON pq.job_id = pj.id
+         WHERE pj.org_id = ?
+           AND pq.round = (SELECT MAX(pq2.round) FROM prototype_quality pq2 WHERE pq2.job_id = pq.job_id)`,
+      )
+      .bind(orgId)
+      .all<{ job_id: string; build_score: number; ui_score: number; functional_score: number; prd_score: number; code_score: number; total_score: number }>();
+
+    // 수동 평가: 각 job별 평균 (여러 평가자 평균)
+    const { results: manualRows } = await this.db
+      .prepare(
+        `SELECT job_id,
+                AVG(build_score) AS build, AVG(ui_score) AS ui,
+                AVG(functional_score) AS functional, AVG(prd_score) AS prd,
+                AVG(code_score) AS code, AVG(overall_score) AS overall
+         FROM user_evaluations
+         WHERE org_id = ?
+         GROUP BY job_id`,
+      )
+      .bind(orgId)
+      .all<{ job_id: string; build: number; ui: number; functional: number; prd: number; code: number; overall: number }>();
+
+    const autoMap = new Map<string, AutoScore>();
+    for (const r of autoRows ?? []) {
+      autoMap.set(r.job_id, {
+        jobId: r.job_id,
+        build: r.build_score,
+        ui: r.ui_score,
+        functional: r.functional_score,
+        prd: r.prd_score,
+        code: r.code_score,
+        total: r.total_score,
+      });
+    }
+
+    const manualMap = new Map<string, ManualScore>();
+    for (const r of manualRows ?? []) {
+      manualMap.set(r.job_id, {
+        jobId: r.job_id,
+        build: r.build,
+        ui: r.ui,
+        functional: r.functional,
+        prd: r.prd,
+        code: r.code,
+        overall: r.overall,
+      });
+    }
+
+    // 양쪽 데이터가 있는 job만 매칭
+    const matchedJobs = [...autoMap.keys()].filter((id) => manualMap.has(id));
+    const totalEvaluations = (manualRows ?? []).length;
+
+    if (matchedJobs.length < 3) {
+      return {
+        correlations: [],
+        overallPearson: 0,
+        totalEvaluations,
+        calibrationStatus: "insufficient_data",
+      };
+    }
+
+    const dimensions: Array<{ name: string; autoKey: keyof AutoScore; manualKey: keyof ManualScore }> = [
+      { name: "build", autoKey: "build", manualKey: "build" },
+      { name: "ui", autoKey: "ui", manualKey: "ui" },
+      { name: "functional", autoKey: "functional", manualKey: "functional" },
+      { name: "prd", autoKey: "prd", manualKey: "prd" },
+      { name: "code", autoKey: "code", manualKey: "code" },
+    ];
+
+    const correlations: CorrelationResult[] = dimensions.map((dim) => {
+      const autoValues = matchedJobs.map((id) => autoMap.get(id)![dim.autoKey] as number);
+      const manualValues = matchedJobs.map((id) => manualToAutoScale(manualMap.get(id)![dim.manualKey] as number));
+      return {
+        dimension: dim.name,
+        pearson: pearsonR(autoValues, manualValues),
+        sampleSize: matchedJobs.length,
+        autoMean: mean(autoValues),
+        manualMean: mean(manualValues),
+      };
+    });
+
+    // overall: total_score (0~100) vs overall (1~5 → 0~1 → 0~100)
+    const autoTotals = matchedJobs.map((id) => autoMap.get(id)!.total);
+    const manualOveralls = matchedJobs.map((id) => manualToAutoScale(manualMap.get(id)!.overall) * 100);
+    const overallPearson = pearsonR(autoTotals, manualOveralls);
+
+    const avgPearson = correlations.reduce((s, c) => s + Math.abs(c.pearson), 0) / correlations.length;
+    const calibrationStatus = avgPearson >= 0.7 ? "good" : avgPearson >= 0.4 ? "needs_attention" : "insufficient_data";
+
+    return {
+      correlations,
+      overallPearson,
+      totalEvaluations,
+      calibrationStatus,
+    };
+  }
+}

--- a/packages/api/src/services/quality-dashboard-service.ts
+++ b/packages/api/src/services/quality-dashboard-service.ts
@@ -1,0 +1,101 @@
+// ─── F390: Quality Dashboard Service (Sprint 178) ───
+
+import type { QualityDashboardSummary, DimensionAverage, QualityTrend } from "../schemas/quality-dashboard-schema.js";
+
+export class QualityDashboardService {
+  constructor(private db: D1Database) {}
+
+  async getSummary(): Promise<QualityDashboardSummary> {
+    // 각 job의 최신 라운드만 집계
+    const scoreRow = await this.db
+      .prepare(
+        `SELECT
+           COUNT(DISTINCT job_id) AS total,
+           AVG(total_score) AS avg_score,
+           SUM(CASE WHEN total_score >= 80 THEN 1 ELSE 0 END) AS above_80
+         FROM prototype_quality pq
+         WHERE pq.round = (
+           SELECT MAX(pq2.round) FROM prototype_quality pq2 WHERE pq2.job_id = pq.job_id
+         )`,
+      )
+      .first<{ total: number; avg_score: number | null; above_80: number }>();
+
+    const costRow = await this.db
+      .prepare(
+        `SELECT
+           SUM(CASE WHEN generation_mode IN ('cli', 'max-cli') THEN 1 ELSE 0 END) AS cli_count,
+           SUM(CASE WHEN generation_mode = 'api' THEN 1 ELSE 0 END) AS api_count,
+           SUM(CASE WHEN generation_mode = 'api' THEN cost_usd ELSE 0 END) AS total_api_cost
+         FROM prototype_quality`,
+      )
+      .first<{ cli_count: number; api_count: number; total_api_cost: number }>();
+
+    const total = scoreRow?.total ?? 0;
+    const avgApiCost =
+      costRow && costRow.api_count > 0
+        ? costRow.total_api_cost / costRow.api_count
+        : 0.48;
+
+    return {
+      totalPrototypes: total,
+      averageScore: Math.round((scoreRow?.avg_score ?? 0) * 10) / 10,
+      above80Count: scoreRow?.above_80 ?? 0,
+      above80Pct: total > 0 ? Math.round(((scoreRow?.above_80 ?? 0) / total) * 1000) / 10 : 0,
+      totalCostSaved: Math.round((costRow?.cli_count ?? 0) * avgApiCost * 100) / 100,
+      generationModes: {
+        cli: costRow?.cli_count ?? 0,
+        api: costRow?.api_count ?? 0,
+      },
+    };
+  }
+
+  async getDimensionAverages(): Promise<DimensionAverage> {
+    const row = await this.db
+      .prepare(
+        `SELECT
+           AVG(build_score) AS build,
+           AVG(ui_score) AS ui,
+           AVG(functional_score) AS functional,
+           AVG(prd_score) AS prd,
+           AVG(code_score) AS code
+         FROM prototype_quality pq
+         WHERE pq.round = (
+           SELECT MAX(pq2.round) FROM prototype_quality pq2 WHERE pq2.job_id = pq.job_id
+         )`,
+      )
+      .first<{ build: number | null; ui: number | null; functional: number | null; prd: number | null; code: number | null }>();
+
+    return {
+      build: Math.round((row?.build ?? 0) * 1000) / 1000,
+      ui: Math.round((row?.ui ?? 0) * 1000) / 1000,
+      functional: Math.round((row?.functional ?? 0) * 1000) / 1000,
+      prd: Math.round((row?.prd ?? 0) * 1000) / 1000,
+      code: Math.round((row?.code ?? 0) * 1000) / 1000,
+    };
+  }
+
+  async getTrend(days: number = 30): Promise<QualityTrend> {
+    const { results } = await this.db
+      .prepare(
+        `SELECT
+           date(created_at) AS date,
+           AVG(total_score) AS avg_score,
+           COUNT(*) AS count
+         FROM prototype_quality
+         WHERE created_at >= datetime('now', '-' || ? || ' days')
+         GROUP BY date(created_at)
+         ORDER BY date ASC`,
+      )
+      .bind(days)
+      .all<{ date: string; avg_score: number; count: number }>();
+
+    return {
+      points: (results ?? []).map((r) => ({
+        date: r.date,
+        avgScore: Math.round(r.avg_score * 10) / 10,
+        count: r.count,
+      })),
+      period: `${days}d`,
+    };
+  }
+}

--- a/packages/api/src/services/user-evaluation-service.ts
+++ b/packages/api/src/services/user-evaluation-service.ts
@@ -1,0 +1,105 @@
+// ─── F391: User Evaluation Service (Sprint 178) ───
+
+import type { CreateUserEvaluationInput } from "../schemas/user-evaluation-schema.js";
+
+export interface UserEvaluationRecord {
+  id: string;
+  jobId: string;
+  orgId: string;
+  evaluatorRole: string;
+  buildScore: number;
+  uiScore: number;
+  functionalScore: number;
+  prdScore: number;
+  codeScore: number;
+  overallScore: number;
+  comment: string | null;
+  createdAt: string;
+}
+
+interface EvalRow {
+  id: string;
+  job_id: string;
+  org_id: string;
+  evaluator_role: string;
+  build_score: number;
+  ui_score: number;
+  functional_score: number;
+  prd_score: number;
+  code_score: number;
+  overall_score: number;
+  comment: string | null;
+  created_at: string;
+}
+
+function toRecord(row: EvalRow): UserEvaluationRecord {
+  return {
+    id: row.id,
+    jobId: row.job_id,
+    orgId: row.org_id,
+    evaluatorRole: row.evaluator_role,
+    buildScore: row.build_score,
+    uiScore: row.ui_score,
+    functionalScore: row.functional_score,
+    prdScore: row.prd_score,
+    codeScore: row.code_score,
+    overallScore: row.overall_score,
+    comment: row.comment,
+    createdAt: row.created_at,
+  };
+}
+
+export class UserEvaluationService {
+  constructor(private db: D1Database) {}
+
+  async create(orgId: string, input: CreateUserEvaluationInput): Promise<UserEvaluationRecord> {
+    const id = crypto.randomUUID().replace(/-/g, "");
+    await this.db
+      .prepare(
+        `INSERT INTO user_evaluations
+         (id, job_id, org_id, evaluator_role, build_score, ui_score, functional_score, prd_score, code_score, overall_score, comment)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        id,
+        input.jobId,
+        orgId,
+        input.evaluatorRole,
+        input.buildScore,
+        input.uiScore,
+        input.functionalScore,
+        input.prdScore,
+        input.codeScore,
+        input.overallScore,
+        input.comment ?? null,
+      )
+      .run();
+
+    const row = await this.db
+      .prepare("SELECT * FROM user_evaluations WHERE id = ?")
+      .bind(id)
+      .first<EvalRow>();
+    if (!row) throw new Error("Insert failed");
+    return toRecord(row);
+  }
+
+  async listByJob(orgId: string, jobId: string): Promise<UserEvaluationRecord[]> {
+    const { results } = await this.db
+      .prepare(
+        "SELECT * FROM user_evaluations WHERE org_id = ? AND job_id = ? ORDER BY created_at DESC",
+      )
+      .bind(orgId, jobId)
+      .all<EvalRow>();
+    return (results ?? []).map(toRecord);
+  }
+
+  async listAll(orgId: string): Promise<UserEvaluationRecord[]> {
+    const { results } = await this.db
+      .prepare(
+        "SELECT * FROM user_evaluations WHERE org_id = ? ORDER BY created_at DESC",
+      )
+      .bind(orgId)
+      .all<EvalRow>();
+    return (results ?? []).map(toRecord);
+  }
+}

--- a/packages/web/src/__tests__/builder-quality.test.tsx
+++ b/packages/web/src/__tests__/builder-quality.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { Component as BuilderQuality } from "../routes/builder-quality";
+
+// Mock API calls
+vi.mock("@/lib/api-client", () => ({
+  fetchQualityDashboardSummary: vi.fn().mockResolvedValue({
+    totalPrototypes: 5,
+    averageScore: 72.5,
+    above80Count: 2,
+    above80Pct: 40,
+    totalCostSaved: 3.84,
+    generationModes: { cli: 3, api: 2 },
+  }),
+  fetchQualityDimensions: vi.fn().mockResolvedValue({
+    build: 0.85,
+    ui: 0.6,
+    functional: 0.72,
+    prd: 0.55,
+    code: 0.81,
+  }),
+  fetchQualityTrend: vi.fn().mockResolvedValue({
+    points: [
+      { date: "2026-04-01", avgScore: 65, count: 2 },
+      { date: "2026-04-06", avgScore: 80, count: 3 },
+    ],
+    period: "30d",
+  }),
+  fetchCorrelation: vi.fn().mockResolvedValue({
+    correlations: [
+      { dimension: "build", pearson: 0.85, sampleSize: 3, autoMean: 0.8, manualMean: 0.75 },
+    ],
+    overallPearson: 0.82,
+    totalEvaluations: 5,
+    calibrationStatus: "good",
+  }),
+}));
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <BuilderQuality />
+    </MemoryRouter>,
+  );
+}
+
+describe("BuilderQuality page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("대시보드 제목을 렌더링해요", async () => {
+    renderPage();
+    expect(await screen.findByText("Builder Quality Dashboard")).toBeTruthy();
+  });
+
+  it("스코어 카드에 평균 점수를 표시해요", async () => {
+    renderPage();
+    expect(await screen.findByText("72.5")).toBeTruthy();
+  });
+
+  it("상관관계 패널에 양호 배지를 표시해요", async () => {
+    renderPage();
+    expect(await screen.findByText("양호")).toBeTruthy();
+  });
+});

--- a/packages/web/src/__tests__/user-evaluation-modal.test.tsx
+++ b/packages/web/src/__tests__/user-evaluation-modal.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import UserEvaluationModal from "../components/feature/builder/UserEvaluationModal";
+
+describe("UserEvaluationModal", () => {
+  const mockSubmit = vi.fn().mockResolvedValue(undefined);
+  const mockClose = vi.fn();
+
+  it("5차원 평가 폼을 렌더링해요", () => {
+    render(
+      <UserEvaluationModal jobId="job-1" onSubmit={mockSubmit} onClose={mockClose} />,
+    );
+
+    expect(screen.getByText("프로토타입 수동 평가")).toBeTruthy();
+    expect(screen.getByText("Build 품질")).toBeTruthy();
+    expect(screen.getByText("UI 품질")).toBeTruthy();
+    expect(screen.getByText("기능 품질")).toBeTruthy();
+    expect(screen.getByText("PRD 반영도")).toBeTruthy();
+    expect(screen.getByText("코드 품질")).toBeTruthy();
+    expect(screen.getByText("전체 평가")).toBeTruthy();
+  });
+
+  it("취소 버튼으로 모달을 닫아요", () => {
+    render(
+      <UserEvaluationModal jobId="job-1" onSubmit={mockSubmit} onClose={mockClose} />,
+    );
+
+    fireEvent.click(screen.getByText("취소"));
+    expect(mockClose).toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/components/feature/builder/CorrelationPanel.tsx
+++ b/packages/web/src/components/feature/builder/CorrelationPanel.tsx
@@ -1,0 +1,119 @@
+// F391: Builder Quality — 자동-수동 상관관계 패널 (Sprint 178)
+
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+
+interface CorrelationResult {
+  dimension: string;
+  pearson: number;
+  sampleSize: number;
+  autoMean: number;
+  manualMean: number;
+}
+
+interface CorrelationSummary {
+  correlations: CorrelationResult[];
+  overallPearson: number;
+  totalEvaluations: number;
+  calibrationStatus: "good" | "needs_attention" | "insufficient_data";
+}
+
+interface CorrelationPanelProps {
+  data: CorrelationSummary | null;
+  loading?: boolean;
+}
+
+const STATUS_CONFIG = {
+  good: { label: "양호", variant: "default" as const, color: "text-green-600" },
+  needs_attention: { label: "주의 필요", variant: "secondary" as const, color: "text-amber-600" },
+  insufficient_data: { label: "데이터 부족", variant: "outline" as const, color: "text-muted-foreground" },
+};
+
+const DIMENSION_LABELS: Record<string, string> = {
+  build: "Build",
+  ui: "UI",
+  functional: "Functional",
+  prd: "PRD",
+  code: "Code",
+};
+
+function pearsonColor(r: number): string {
+  const abs = Math.abs(r);
+  if (abs >= 0.7) return "text-green-600";
+  if (abs >= 0.4) return "text-amber-600";
+  return "text-red-600";
+}
+
+export default function CorrelationPanel({ data, loading }: CorrelationPanelProps) {
+  if (loading) {
+    return (
+      <Card className="p-4">
+        <div className="text-sm text-muted-foreground">상관관계 분석 로딩 중...</div>
+      </Card>
+    );
+  }
+
+  if (!data) {
+    return (
+      <Card className="p-4">
+        <div className="text-sm text-muted-foreground italic">
+          수동 평가 데이터가 없어요. 프로토타입 상세 페이지에서 평가를 등록하세요.
+        </div>
+      </Card>
+    );
+  }
+
+  const statusCfg = STATUS_CONFIG[data.calibrationStatus];
+
+  return (
+    <Card className="p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="text-sm font-medium">자동-수동 평가 상관관계</div>
+        <Badge variant={statusCfg.variant}>{statusCfg.label}</Badge>
+      </div>
+
+      <div className="flex items-center gap-4 text-xs text-muted-foreground">
+        <span>전체 평가: {data.totalEvaluations}건</span>
+        <span>
+          Overall r ={" "}
+          <span className={`font-medium ${pearsonColor(data.overallPearson)}`}>
+            {data.overallPearson.toFixed(3)}
+          </span>
+        </span>
+      </div>
+
+      {data.correlations.length > 0 && (
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="border-b">
+              <th className="text-left py-1 font-medium">차원</th>
+              <th className="text-right py-1 font-medium">Pearson r</th>
+              <th className="text-right py-1 font-medium">자동 평균</th>
+              <th className="text-right py-1 font-medium">수동 평균</th>
+              <th className="text-right py-1 font-medium">N</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.correlations.map((c) => (
+              <tr key={c.dimension} className="border-b border-border/50">
+                <td className="py-1">{DIMENSION_LABELS[c.dimension] ?? c.dimension}</td>
+                <td className={`text-right py-1 font-mono ${pearsonColor(c.pearson)}`}>
+                  {c.pearson.toFixed(3)}
+                </td>
+                <td className="text-right py-1 font-mono">{(c.autoMean * 100).toFixed(0)}%</td>
+                <td className="text-right py-1 font-mono">{(c.manualMean * 100).toFixed(0)}%</td>
+                <td className="text-right py-1 text-muted-foreground">{c.sampleSize}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {data.calibrationStatus === "needs_attention" && (
+        <div className="text-xs text-amber-600 bg-amber-50 rounded p-2">
+          일부 차원의 상관관계가 낮아요. 평가 기준을 조정하거나 추가 수동 평가를 수집하는 것을 권장해요.
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/packages/web/src/components/feature/builder/CostComparison.tsx
+++ b/packages/web/src/components/feature/builder/CostComparison.tsx
@@ -1,0 +1,65 @@
+// F390: Builder Quality — CLI vs API 비용 비교 (Sprint 178)
+
+import { Card } from "@/components/ui/card";
+
+interface CostComparisonProps {
+  generationModes: Record<string, number>;
+  totalCostSaved: number;
+}
+
+export default function CostComparison({
+  generationModes,
+  totalCostSaved,
+}: CostComparisonProps) {
+  const cliCount = generationModes["cli"] ?? 0;
+  const apiCount = generationModes["api"] ?? 0;
+  const total = cliCount + apiCount;
+
+  const cliPct = total > 0 ? (cliCount / total) * 100 : 0;
+  const apiPct = total > 0 ? (apiCount / total) * 100 : 0;
+
+  return (
+    <Card className="p-4">
+      <div className="text-sm font-medium mb-3">Generation Mode 비용 비교</div>
+      <div className="space-y-3">
+        {/* 모드 비율 바 */}
+        <div className="flex h-6 rounded overflow-hidden bg-muted">
+          {cliPct > 0 && (
+            <div
+              className="bg-green-500 flex items-center justify-center text-white text-xs font-medium"
+              style={{ width: `${cliPct}%` }}
+            >
+              {cliPct >= 15 ? `CLI ${cliPct.toFixed(0)}%` : ""}
+            </div>
+          )}
+          {apiPct > 0 && (
+            <div
+              className="bg-amber-500 flex items-center justify-center text-white text-xs font-medium"
+              style={{ width: `${apiPct}%` }}
+            >
+              {apiPct >= 15 ? `API ${apiPct.toFixed(0)}%` : ""}
+            </div>
+          )}
+        </div>
+
+        {/* 상세 */}
+        <div className="flex justify-between text-xs text-muted-foreground">
+          <div className="flex items-center gap-1">
+            <span className="w-2 h-2 rounded-full bg-green-500 inline-block" />
+            CLI (Max): {cliCount}회 ($0)
+          </div>
+          <div className="flex items-center gap-1">
+            <span className="w-2 h-2 rounded-full bg-amber-500 inline-block" />
+            API: {apiCount}회
+          </div>
+        </div>
+
+        {totalCostSaved > 0 && (
+          <div className="text-xs text-green-600 font-medium">
+            CLI 전환으로 약 ${totalCostSaved.toFixed(2)} 절감
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/packages/web/src/components/feature/builder/DimensionRadar.tsx
+++ b/packages/web/src/components/feature/builder/DimensionRadar.tsx
@@ -1,0 +1,104 @@
+// F390: Builder Quality — 5차원 레이더 차트 (Sprint 178)
+// 순수 SVG 구현 (라이브러리 없음)
+
+interface DimensionRadarProps {
+  dimensions: {
+    build: number;
+    ui: number;
+    functional: number;
+    prd: number;
+    code: number;
+  };
+}
+
+const LABELS = ["Build", "UI", "Functional", "PRD", "Code"];
+
+export default function DimensionRadar({ dimensions }: DimensionRadarProps) {
+  const values = [dimensions.build, dimensions.ui, dimensions.functional, dimensions.prd, dimensions.code];
+  const cx = 150;
+  const cy = 150;
+  const r = 100;
+  const levels = [0.2, 0.4, 0.6, 0.8, 1.0];
+
+  function polarToCart(angle: number, radius: number) {
+    const rad = ((angle - 90) * Math.PI) / 180;
+    return { x: cx + radius * Math.cos(rad), y: cy + radius * Math.sin(rad) };
+  }
+
+  const angleStep = 360 / 5;
+  const dataPoints = values.map((v, i) => {
+    const angle = i * angleStep;
+    return polarToCart(angle, v * r);
+  });
+  const polygon = dataPoints.map((p) => `${p.x},${p.y}`).join(" ");
+
+  return (
+    <div className="flex flex-col items-center">
+      <svg viewBox="0 0 300 300" width={280} height={280}>
+        {/* 격자 */}
+        {levels.map((lv) => (
+          <polygon
+            key={lv}
+            points={Array.from({ length: 5 }, (_, i) => {
+              const p = polarToCart(i * angleStep, lv * r);
+              return `${p.x},${p.y}`;
+            }).join(" ")}
+            fill="none"
+            stroke="currentColor"
+            strokeOpacity={0.15}
+            strokeWidth={1}
+          />
+        ))}
+
+        {/* 축 */}
+        {Array.from({ length: 5 }, (_, i) => {
+          const p = polarToCart(i * angleStep, r);
+          return (
+            <line
+              key={i}
+              x1={cx}
+              y1={cy}
+              x2={p.x}
+              y2={p.y}
+              stroke="currentColor"
+              strokeOpacity={0.2}
+              strokeWidth={1}
+            />
+          );
+        })}
+
+        {/* 데이터 영역 */}
+        <polygon
+          points={polygon}
+          fill="hsl(210, 80%, 55%)"
+          fillOpacity={0.25}
+          stroke="hsl(210, 80%, 55%)"
+          strokeWidth={2}
+        />
+
+        {/* 데이터 포인트 */}
+        {dataPoints.map((p, i) => (
+          <circle key={i} cx={p.x} cy={p.y} r={4} fill="hsl(210, 80%, 55%)" />
+        ))}
+
+        {/* 라벨 */}
+        {LABELS.map((label, i) => {
+          const p = polarToCart(i * angleStep, r + 24);
+          return (
+            <text
+              key={label}
+              x={p.x}
+              y={p.y}
+              textAnchor="middle"
+              dominantBaseline="middle"
+              className="fill-muted-foreground"
+              fontSize={11}
+            >
+              {label} ({(values[i] * 100).toFixed(0)}%)
+            </text>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}

--- a/packages/web/src/components/feature/builder/QualityTrendLine.tsx
+++ b/packages/web/src/components/feature/builder/QualityTrendLine.tsx
@@ -1,0 +1,117 @@
+// F390: Builder Quality — 일별 점수 추이 라인 차트 (Sprint 178)
+
+interface TrendPoint {
+  date: string;
+  avgScore: number;
+  count: number;
+}
+
+interface QualityTrendLineProps {
+  points: TrendPoint[];
+}
+
+export default function QualityTrendLine({ points }: QualityTrendLineProps) {
+  if (points.length === 0) {
+    return (
+      <div className="text-sm text-muted-foreground italic py-8 text-center">
+        아직 품질 데이터가 없어요.
+      </div>
+    );
+  }
+
+  const width = 500;
+  const height = 200;
+  const padX = 40;
+  const padY = 20;
+  const chartW = width - padX * 2;
+  const chartH = height - padY * 2;
+
+  const maxScore = 100;
+  const xScale = (i: number) => padX + (i / Math.max(points.length - 1, 1)) * chartW;
+  const yScale = (v: number) => padY + chartH - (v / maxScore) * chartH;
+
+  const linePath = points
+    .map((p, i) => `${i === 0 ? "M" : "L"}${xScale(i)},${yScale(p.avgScore)}`)
+    .join(" ");
+
+  // 80점 기준선
+  const thresholdY = yScale(80);
+
+  return (
+    <div>
+      <svg viewBox={`0 0 ${width} ${height}`} width="100%" preserveAspectRatio="xMidYMid meet">
+        {/* Y축 그리드 */}
+        {[0, 20, 40, 60, 80, 100].map((v) => (
+          <g key={v}>
+            <line
+              x1={padX}
+              x2={width - padX}
+              y1={yScale(v)}
+              y2={yScale(v)}
+              stroke="currentColor"
+              strokeOpacity={0.1}
+              strokeWidth={1}
+            />
+            <text
+              x={padX - 6}
+              y={yScale(v)}
+              textAnchor="end"
+              dominantBaseline="middle"
+              fontSize={9}
+              className="fill-muted-foreground"
+            >
+              {v}
+            </text>
+          </g>
+        ))}
+
+        {/* 80점 기준선 */}
+        <line
+          x1={padX}
+          x2={width - padX}
+          y1={thresholdY}
+          y2={thresholdY}
+          stroke="hsl(0, 70%, 55%)"
+          strokeWidth={1}
+          strokeDasharray="4 4"
+        />
+        <text
+          x={width - padX + 4}
+          y={thresholdY}
+          dominantBaseline="middle"
+          fontSize={8}
+          fill="hsl(0, 70%, 55%)"
+        >
+          80
+        </text>
+
+        {/* 데이터 라인 */}
+        <path d={linePath} fill="none" stroke="hsl(210, 80%, 55%)" strokeWidth={2} />
+
+        {/* 데이터 포인트 */}
+        {points.map((p, i) => (
+          <g key={p.date}>
+            <circle
+              cx={xScale(i)}
+              cy={yScale(p.avgScore)}
+              r={3}
+              fill={p.avgScore >= 80 ? "hsl(142, 70%, 45%)" : "hsl(38, 92%, 50%)"}
+            />
+            {/* X축 라벨 (최대 7개만) */}
+            {(points.length <= 7 || i % Math.ceil(points.length / 7) === 0) && (
+              <text
+                x={xScale(i)}
+                y={height - 4}
+                textAnchor="middle"
+                fontSize={8}
+                className="fill-muted-foreground"
+              >
+                {p.date.slice(5)}
+              </text>
+            )}
+          </g>
+        ))}
+      </svg>
+    </div>
+  );
+}

--- a/packages/web/src/components/feature/builder/ScoreCardGrid.tsx
+++ b/packages/web/src/components/feature/builder/ScoreCardGrid.tsx
@@ -1,0 +1,60 @@
+// F390: Builder Quality — 4개 KPI 스코어 카드 (Sprint 178)
+
+import { Card } from "@/components/ui/card";
+
+interface ScoreCardGridProps {
+  averageScore: number;
+  above80Pct: number;
+  totalCostSaved: number;
+  totalPrototypes: number;
+}
+
+export default function ScoreCardGrid({
+  averageScore,
+  above80Pct,
+  totalCostSaved,
+  totalPrototypes,
+}: ScoreCardGridProps) {
+  const cards = [
+    {
+      label: "평균 품질 점수",
+      value: averageScore.toFixed(1),
+      suffix: "/ 100",
+      color: averageScore >= 80 ? "text-green-600" : averageScore >= 60 ? "text-amber-600" : "text-red-600",
+    },
+    {
+      label: "80점+ 비율",
+      value: `${above80Pct.toFixed(1)}%`,
+      suffix: "",
+      color: above80Pct >= 70 ? "text-green-600" : above80Pct >= 40 ? "text-amber-600" : "text-red-600",
+    },
+    {
+      label: "비용 절감",
+      value: `$${totalCostSaved.toFixed(2)}`,
+      suffix: "saved",
+      color: "text-blue-600",
+    },
+    {
+      label: "총 프로토타입",
+      value: String(totalPrototypes),
+      suffix: "개",
+      color: "text-foreground",
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      {cards.map((card) => (
+        <Card key={card.label} className="p-4">
+          <div className="text-xs text-muted-foreground mb-1">{card.label}</div>
+          <div className="flex items-baseline gap-1">
+            <span className={`text-2xl font-bold ${card.color}`}>{card.value}</span>
+            {card.suffix && (
+              <span className="text-xs text-muted-foreground">{card.suffix}</span>
+            )}
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/packages/web/src/components/feature/builder/UserEvaluationModal.tsx
+++ b/packages/web/src/components/feature/builder/UserEvaluationModal.tsx
@@ -1,0 +1,173 @@
+// F391: 사용자 수동 평가 모달 (Sprint 178)
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+
+interface UserEvaluationModalProps {
+  jobId: string;
+  onSubmit: (data: {
+    jobId: string;
+    evaluatorRole: string;
+    buildScore: number;
+    uiScore: number;
+    functionalScore: number;
+    prdScore: number;
+    codeScore: number;
+    overallScore: number;
+    comment?: string;
+  }) => Promise<void>;
+  onClose: () => void;
+}
+
+const ROLES = [
+  { value: "bd_team", label: "BD팀" },
+  { value: "customer", label: "고객" },
+  { value: "executive", label: "경영진" },
+];
+
+const DIMENSIONS = [
+  { key: "buildScore", label: "Build 품질", desc: "빌드 성공, 에러 없음" },
+  { key: "uiScore", label: "UI 품질", desc: "디자인, 레이아웃, 반응형" },
+  { key: "functionalScore", label: "기능 품질", desc: "인터랙션, 네비게이션" },
+  { key: "prdScore", label: "PRD 반영도", desc: "요구사항 구현 충실도" },
+  { key: "codeScore", label: "코드 품질", desc: "구조, 가독성, 모범사례" },
+] as const;
+
+type ScoreKey = (typeof DIMENSIONS)[number]["key"];
+
+export default function UserEvaluationModal({
+  jobId,
+  onSubmit,
+  onClose,
+}: UserEvaluationModalProps) {
+  const [role, setRole] = useState("bd_team");
+  const [scores, setScores] = useState<Record<ScoreKey, number>>({
+    buildScore: 3,
+    uiScore: 3,
+    functionalScore: 3,
+    prdScore: 3,
+    codeScore: 3,
+  });
+  const [overallScore, setOverallScore] = useState(3);
+  const [comment, setComment] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    try {
+      await onSubmit({
+        jobId,
+        evaluatorRole: role,
+        ...scores,
+        overallScore,
+        comment: comment || undefined,
+      });
+      onClose();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <Card className="w-full max-w-lg p-6 space-y-4 max-h-[90vh] overflow-y-auto">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-bold">프로토타입 수동 평가</h3>
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            ✕
+          </Button>
+        </div>
+
+        {/* 역할 선택 */}
+        <div>
+          <label className="text-xs text-muted-foreground mb-1 block">평가자 역할</label>
+          <div className="flex gap-2">
+            {ROLES.map((r) => (
+              <button
+                key={r.value}
+                className={`px-3 py-1 rounded text-xs border transition-colors ${
+                  role === r.value
+                    ? "bg-primary text-primary-foreground border-primary"
+                    : "bg-background border-border hover:bg-muted"
+                }`}
+                onClick={() => setRole(r.value)}
+              >
+                {r.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* 5차원 점수 */}
+        {DIMENSIONS.map((dim) => (
+          <div key={dim.key}>
+            <div className="flex justify-between text-xs mb-1">
+              <span className="font-medium">{dim.label}</span>
+              <span className="text-muted-foreground">{dim.desc}</span>
+            </div>
+            <div className="flex gap-1">
+              {[1, 2, 3, 4, 5].map((v) => (
+                <button
+                  key={v}
+                  className={`flex-1 py-1 rounded text-xs font-medium border transition-colors ${
+                    scores[dim.key] === v
+                      ? "bg-primary text-primary-foreground border-primary"
+                      : "bg-background border-border hover:bg-muted"
+                  }`}
+                  onClick={() => setScores((s) => ({ ...s, [dim.key]: v }))}
+                >
+                  {v}
+                </button>
+              ))}
+            </div>
+          </div>
+        ))}
+
+        {/* 전체 점수 */}
+        <div>
+          <div className="flex justify-between text-xs mb-1">
+            <span className="font-medium">전체 평가</span>
+            <span className="text-muted-foreground">고객 데모 가능 수준?</span>
+          </div>
+          <div className="flex gap-1">
+            {[1, 2, 3, 4, 5].map((v) => (
+              <button
+                key={v}
+                className={`flex-1 py-1 rounded text-xs font-medium border transition-colors ${
+                  overallScore === v
+                    ? "bg-primary text-primary-foreground border-primary"
+                    : "bg-background border-border hover:bg-muted"
+                }`}
+                onClick={() => setOverallScore(v)}
+              >
+                {v}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* 코멘트 */}
+        <div>
+          <label className="text-xs text-muted-foreground mb-1 block">코멘트 (선택)</label>
+          <textarea
+            className="w-full border rounded p-2 text-sm min-h-[60px] bg-background"
+            placeholder="개선 의견이나 느낀 점을 적어주세요..."
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+          />
+        </div>
+
+        {/* 제출 */}
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" size="sm" onClick={onClose}>
+            취소
+          </Button>
+          <Button size="sm" onClick={handleSubmit} disabled={submitting}>
+            {submitting ? "저장 중..." : "평가 제출"}
+          </Button>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/packages/web/src/components/sidebar.tsx
+++ b/packages/web/src/components/sidebar.tsx
@@ -184,6 +184,7 @@ const DEFAULT_ADMIN_GROUP: NavGroup = {
     { href: "/workspace", label: "워크스페이스", icon: FolderKanban },
     { href: "/agents", label: "에이전트", icon: Bot },
     { href: "/prototype-dashboard", label: "Prototype", icon: FlaskConical },
+    { href: "/builder-quality", label: "Quality", icon: BarChart3 },
     { href: "/orchestration", label: "오케스트레이션", icon: Activity },
     { href: "/architecture", label: "아키텍처", icon: Blocks },
     { href: "/methodologies", label: "방법론", icon: Library },

--- a/packages/web/src/lib/api-client.ts
+++ b/packages/web/src/lib/api-client.ts
@@ -2309,3 +2309,105 @@ export async function fetchPrototypeFeedback(
 ): Promise<{ items: FeedbackItem[] }> {
   return fetchApi(`/prototype-jobs/${jobId}/feedback`);
 }
+
+// ─── F390: Quality Dashboard (Sprint 178) ───
+
+export interface QualityDashboardSummaryResponse {
+  totalPrototypes: number;
+  averageScore: number;
+  above80Count: number;
+  above80Pct: number;
+  totalCostSaved: number;
+  generationModes: Record<string, number>;
+}
+
+export interface DimensionAverageResponse {
+  build: number;
+  ui: number;
+  functional: number;
+  prd: number;
+  code: number;
+}
+
+export interface TrendPoint {
+  date: string;
+  avgScore: number;
+  count: number;
+}
+
+export interface QualityTrendResponse {
+  points: TrendPoint[];
+  period: string;
+}
+
+export async function fetchQualityDashboardSummary(): Promise<QualityDashboardSummaryResponse> {
+  const res = await fetchApi<{ summary: QualityDashboardSummaryResponse }>("/quality-dashboard/summary");
+  return res.summary;
+}
+
+export async function fetchQualityDimensions(): Promise<DimensionAverageResponse> {
+  const res = await fetchApi<{ dimensions: DimensionAverageResponse }>("/quality-dashboard/dimensions");
+  return res.dimensions;
+}
+
+export async function fetchQualityTrend(days?: number): Promise<QualityTrendResponse> {
+  const q = days ? `?days=${days}` : "";
+  const res = await fetchApi<{ trend: QualityTrendResponse }>(`/quality-dashboard/trend${q}`);
+  return res.trend;
+}
+
+// ─── F391: User Evaluations (Sprint 178) ───
+
+export interface UserEvaluationItem {
+  id: string;
+  jobId: string;
+  evaluatorRole: string;
+  buildScore: number;
+  uiScore: number;
+  functionalScore: number;
+  prdScore: number;
+  codeScore: number;
+  overallScore: number;
+  comment: string | null;
+  createdAt: string;
+}
+
+export interface CorrelationResult {
+  dimension: string;
+  pearson: number;
+  sampleSize: number;
+  autoMean: number;
+  manualMean: number;
+}
+
+export interface CorrelationSummaryResponse {
+  correlations: CorrelationResult[];
+  overallPearson: number;
+  totalEvaluations: number;
+  calibrationStatus: "good" | "needs_attention" | "insufficient_data";
+}
+
+export async function submitUserEvaluation(data: {
+  jobId: string;
+  evaluatorRole: string;
+  buildScore: number;
+  uiScore: number;
+  functionalScore: number;
+  prdScore: number;
+  codeScore: number;
+  overallScore: number;
+  comment?: string;
+}): Promise<{ evaluation: UserEvaluationItem }> {
+  return postApi("/user-evaluations", data);
+}
+
+export async function fetchUserEvaluations(
+  jobId: string,
+): Promise<{ items: UserEvaluationItem[] }> {
+  return fetchApi(`/user-evaluations/${jobId}`);
+}
+
+export async function fetchCorrelation(): Promise<CorrelationSummaryResponse> {
+  const res = await fetchApi<{ correlation: CorrelationSummaryResponse }>("/user-evaluations/correlation");
+  return res.correlation;
+}

--- a/packages/web/src/router.tsx
+++ b/packages/web/src/router.tsx
@@ -97,6 +97,8 @@ export const router = createBrowserRouter([
       // ── Sprint 160: Prototype Dashboard (F356) ──
       { path: "prototype-dashboard", lazy: () => import("@/routes/prototype-dashboard") },
       { path: "prototype-dashboard/:id", lazy: () => import("@/routes/prototype-detail") },
+      // ── Sprint 178: Builder Quality Dashboard (F390, F391) ──
+      { path: "builder-quality", lazy: () => import("@/routes/builder-quality") },
 
       // ── 지식/관리/설정 (변경 없음) ──
       { path: "wiki", lazy: () => import("@/routes/wiki") },

--- a/packages/web/src/routes/builder-quality.tsx
+++ b/packages/web/src/routes/builder-quality.tsx
@@ -1,0 +1,97 @@
+// F390+F391: Builder Quality Dashboard (Sprint 178)
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  fetchQualityDashboardSummary,
+  fetchQualityDimensions,
+  fetchQualityTrend,
+  fetchCorrelation,
+  type QualityDashboardSummaryResponse,
+  type DimensionAverageResponse,
+  type QualityTrendResponse,
+  type CorrelationSummaryResponse,
+} from "@/lib/api-client";
+import { Card } from "@/components/ui/card";
+import ScoreCardGrid from "@/components/feature/builder/ScoreCardGrid";
+import DimensionRadar from "@/components/feature/builder/DimensionRadar";
+import QualityTrendLine from "@/components/feature/builder/QualityTrendLine";
+import CostComparison from "@/components/feature/builder/CostComparison";
+import CorrelationPanel from "@/components/feature/builder/CorrelationPanel";
+
+export function Component() {
+  const [summary, setSummary] = useState<QualityDashboardSummaryResponse | null>(null);
+  const [dimensions, setDimensions] = useState<DimensionAverageResponse | null>(null);
+  const [trend, setTrend] = useState<QualityTrendResponse | null>(null);
+  const [correlation, setCorrelation] = useState<CorrelationSummaryResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    Promise.all([
+      fetchQualityDashboardSummary().catch(() => null),
+      fetchQualityDimensions().catch(() => null),
+      fetchQualityTrend(30).catch(() => null),
+      fetchCorrelation().catch(() => null),
+    ])
+      .then(([s, d, t, c]) => {
+        setSummary(s);
+        setDimensions(d);
+        setTrend(t);
+        setCorrelation(c);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <div className="text-muted-foreground">Loading quality data...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold font-display">Builder Quality Dashboard</h1>
+
+      {/* Score Cards */}
+      {summary && (
+        <ScoreCardGrid
+          averageScore={summary.averageScore}
+          above80Pct={summary.above80Pct}
+          totalCostSaved={summary.totalCostSaved}
+          totalPrototypes={summary.totalPrototypes}
+        />
+      )}
+
+      {/* Radar + Trend (2-col) */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <Card className="p-4">
+          <div className="text-sm font-medium mb-2">5차원 품질 분포</div>
+          {dimensions ? (
+            <DimensionRadar dimensions={dimensions} />
+          ) : (
+            <div className="text-sm text-muted-foreground italic py-8 text-center">
+              차원별 데이터가 없어요.
+            </div>
+          )}
+        </Card>
+        <Card className="p-4">
+          <div className="text-sm font-medium mb-2">품질 점수 추이 (30일)</div>
+          <QualityTrendLine points={trend?.points ?? []} />
+        </Card>
+      </div>
+
+      {/* Cost Comparison */}
+      {summary && (
+        <CostComparison
+          generationModes={summary.generationModes}
+          totalCostSaved={summary.totalCostSaved}
+        />
+      )}
+
+      {/* Correlation Panel (F391) */}
+      <CorrelationPanel data={correlation} />
+    </div>
+  );
+}

--- a/packages/web/src/routes/prototype-detail.tsx
+++ b/packages/web/src/routes/prototype-detail.tsx
@@ -8,9 +8,12 @@ import {
   fetchOgdSummary,
   fetchPrototypeFeedback,
   submitPrototypeFeedback,
+  submitUserEvaluation,
+  fetchUserEvaluations,
   type PrototypeJobDetail,
   type OgdSummaryResponse,
   type FeedbackItem,
+  type UserEvaluationItem,
 } from "@/lib/api-client";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -18,6 +21,7 @@ import { Card } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import BuildLogViewer from "@/components/feature/BuildLogViewer";
 import FeedbackForm from "@/components/feature/FeedbackForm";
+import UserEvaluationModal from "@/components/feature/builder/UserEvaluationModal";
 import QualityScoreChart from "@/components/feature/QualityScoreChart";
 
 function formatDate(ts: number | null): string {
@@ -47,20 +51,24 @@ export function Component() {
   const [job, setJob] = useState<PrototypeJobDetail | null>(null);
   const [ogdSummary, setOgdSummary] = useState<OgdSummaryResponse | null>(null);
   const [feedbacks, setFeedbacks] = useState<FeedbackItem[]>([]);
+  const [evaluations, setEvaluations] = useState<UserEvaluationItem[]>([]);
+  const [showEvalModal, setShowEvalModal] = useState(false);
   const [loading, setLoading] = useState(true);
 
   const load = useCallback(async () => {
     if (!id) return;
     setLoading(true);
     try {
-      const [jobData, ogd, fb] = await Promise.all([
+      const [jobData, ogd, fb, evals] = await Promise.all([
         fetchPrototypeJob(id),
         fetchOgdSummary(id).catch(() => null),
         fetchPrototypeFeedback(id).catch(() => ({ items: [] })),
+        fetchUserEvaluations(id).catch(() => ({ items: [] })),
       ]);
       setJob(jobData);
       setOgdSummary(ogd?.summary ?? null);
       setFeedbacks(fb.items);
+      setEvaluations(evals.items);
     } catch {
       setJob(null);
     } finally {
@@ -108,6 +116,9 @@ export function Component() {
         <Badge variant={job.status === "live" ? "default" : "outline"}>
           {STATUS_LABEL[job.status] ?? job.status}
         </Badge>
+        <Button size="sm" variant="outline" onClick={() => setShowEvalModal(true)}>
+          수동 평가
+        </Button>
       </div>
 
       {/* Meta Info */}
@@ -146,6 +157,9 @@ export function Component() {
           <TabsTrigger value="ogd">O-G-D</TabsTrigger>
           <TabsTrigger value="feedback">
             피드백 ({feedbacks.length})
+          </TabsTrigger>
+          <TabsTrigger value="evaluations">
+            수동 평가 ({evaluations.length})
           </TabsTrigger>
         </TabsList>
 
@@ -243,7 +257,47 @@ export function Component() {
             </div>
           )}
         </TabsContent>
+
+        <TabsContent value="evaluations" className="mt-4 space-y-3">
+          {evaluations.length > 0 ? (
+            evaluations.map((ev) => (
+              <Card key={ev.id} className="p-3">
+                <div className="flex items-center gap-2 mb-2">
+                  <Badge variant="outline" className="text-xs">{ev.evaluatorRole}</Badge>
+                  <span className="text-xs text-muted-foreground">{ev.createdAt}</span>
+                  <span className="text-xs font-medium ml-auto">전체: {ev.overallScore}/5</span>
+                </div>
+                <div className="grid grid-cols-5 gap-2 text-xs">
+                  <div>Build: {ev.buildScore}</div>
+                  <div>UI: {ev.uiScore}</div>
+                  <div>기능: {ev.functionalScore}</div>
+                  <div>PRD: {ev.prdScore}</div>
+                  <div>코드: {ev.codeScore}</div>
+                </div>
+                {ev.comment && (
+                  <p className="text-sm text-muted-foreground mt-2">{ev.comment}</p>
+                )}
+              </Card>
+            ))
+          ) : (
+            <div className="text-sm text-muted-foreground italic">
+              아직 수동 평가가 없어요. 상단의 &quot;수동 평가&quot; 버튼으로 등록하세요.
+            </div>
+          )}
+        </TabsContent>
       </Tabs>
+
+      {/* User Evaluation Modal */}
+      {showEvalModal && id && (
+        <UserEvaluationModal
+          jobId={id}
+          onSubmit={async (data) => {
+            await submitUserEvaluation(data);
+            await load();
+          }}
+          onClose={() => setShowEvalModal(false)}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- **F390**: Builder Quality 대시보드 — ScoreCard + 5차원 Radar + Trend 추이 + CLI/API 비용비교
- **F391**: 사용자 피드백 루프 — 수동 5차원 평가(1~5점) + Pearson 상관관계 캘리브레이션
- Phase 19 Builder Evolution M4 (마지막 마일스톤)

## Changes
- API: 2 routes (6 endpoints), 3 services, 2 schemas, 1 D1 migration
- Web: 1 page, 6 components (builder/ dir), prototype-detail 수동평가 연동
- Tests: 13 API pass + 5 Web tests
- Gap Analysis: 95%

## Test plan
- [ ] API `quality-dashboard` 3 endpoints 동작 확인
- [ ] API `user-evaluations` 3 endpoints 동작 확인
- [ ] Web `/builder-quality` 페이지 렌더링 확인
- [ ] prototype-detail 수동 평가 모달 동작 확인
- [ ] D1 migration 0112 적용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)