### PR TITLE
feat: Sprint 186 — F399 Strangler Fig 프록시 + harness-kit 이벤트 유틸리티

### DIFF
--- a/docs/01-plan/features/sprint-186.plan.md
+++ b/docs/01-plan/features/sprint-186.plan.md
@@ -1,0 +1,91 @@
+---
+code: FX-PLAN-S186
+title: Sprint 186 — F399 Strangler Fig 프록시 + harness-kit 이벤트 유틸리티
+version: "1.0"
+status: Active
+category: PLAN
+created: 2026-04-07
+updated: 2026-04-07
+author: Claude (Sprint Autopilot)
+sprint: 186
+f_items: [F399]
+req_codes: [FX-REQ-391]
+---
+
+# Sprint 186 Plan — F399
+
+## 1. 목표
+
+F399 = **Strangler Fig 프록시 레이어 + harness-kit 이벤트 유틸리티**
+
+Phase 20-B(분리 준비) M3 단계: harness-kit을 서비스 분리의 실용적 기반으로 강화한다.
+
+## 2. 배경
+
+- **Sprint 185 (F398)**: 이벤트 카탈로그 8종 스키마 + D1EventBus PoC를 `@foundry-x/shared`에 구현. domain_events D1 테이블(0114) 생성
+- **Sprint 180 (F394+F395)**: harness-kit 패키지 생성 — Workers scaffold + JWT/CORS/RBAC 미들웨어 + ESLint no-cross-service-import
+- **현재 gap**: harness-kit의 `NoopEventBus`는 stub, Strangler Fig 패턴 지원 없음
+
+## 3. 범위
+
+### 3.1 In Scope
+
+| 항목 | 위치 | 설명 |
+|------|------|------|
+| `D1EventBus` | `packages/harness-kit/src/events/d1-bus.ts` | D1 기반 이벤트 발행/폴링 (standalone, @foundry-x/* 무의존) |
+| `createEvent()` | `packages/harness-kit/src/events/helpers.ts` | 이벤트 팩토리 헬퍼 |
+| `createStranglerMiddleware()` | `packages/harness-kit/src/middleware/strangler.ts` | mode: local/proxy 라우팅 미들웨어 |
+| `StranglerRoute` 타입 | 위와 동일 | 경로별 라우팅 규칙 |
+| API proxy.ts 리팩토링 | `packages/api/src/routes/proxy.ts` | StranglerMiddleware 활용 데모 |
+| 테스트 2종 | `packages/harness-kit/__tests__/` | D1EventBus + Strangler 유닛 테스트 |
+
+### 3.2 Out of Scope
+
+- 실제 D1 migration 추가 (domain_events 테이블은 F398에서 이미 생성)
+- gateway-x / launch-x 실제 서비스 구현 (F401 범위)
+- E2E 테스트 변경 (F400 범위)
+
+## 4. 기술 접근 방식
+
+### 4.1 D1EventBus (harness-kit)
+
+harness-kit은 독립 npm 패키지이므로 `@foundry-x/shared` 의존성 없이 자체 D1EventBus를 구현한다.
+- `@foundry-x/shared`의 `D1EventBus`와 **동일한 D1 스키마** (domain_events 테이블) 사용
+- harness-kit `EventBus` 인터페이스 (`publish`, `subscribe`, `publishBatch`) + `poll()` 메서드 추가
+- `createEvent(type, source, payload, metadata?)` 헬퍼로 UUID + ISO timestamp 자동 생성
+
+### 4.2 Strangler Fig 미들웨어
+
+```
+StranglerRoute {
+  pathPrefix: string   // '/dx', '/gate', '/launch'
+  serviceId: ServiceId
+  mode: 'local' | 'proxy'  // 'local' = 모놀리스 처리, 'proxy' = 외부 서비스로 포워딩
+  targetUrl?: string   // HTTP fallback
+}
+```
+
+- `mode: 'local'` → `next()` 호출 (기존 로컬 핸들러로 fallthrough)
+- `mode: 'proxy'` → targetUrl 또는 Workers Service Binding으로 포워딩
+- Auth(JWT 검증)는 미들웨어 외부에서 처리 (관심사 분리)
+
+### 4.3 proxy.ts 리팩토링
+
+기존 `/dx/*`, `/aif/*` 라우트의 포워딩 로직을 `createStranglerMiddleware`로 추출.
+SSO 토큰 검증은 별도 미들웨어로 유지 (Strangler와 분리).
+
+## 5. 완료 기준
+
+- [ ] D1EventBus: publish/subscribe/poll/publishBatch 정상 동작
+- [ ] createEvent(): id(UUID) + timestamp 자동 주입
+- [ ] createStranglerMiddleware: local 모드 → next() 호출
+- [ ] createStranglerMiddleware: proxy 모드 → targetUrl 포워딩
+- [ ] proxy.ts: createStranglerMiddleware 활용
+- [ ] 테스트 전체 통과 (harness-kit)
+- [ ] typecheck 통과
+
+## 6. 의존성
+
+- PRD: `docs/specs/ax-bd-msa/prd-final.md`
+- F394+F395 (Sprint 180): harness-kit 패키지 기반
+- F398 (Sprint 185): domain_events D1 테이블 + @foundry-x/shared D1EventBus 참고

--- a/docs/02-design/features/sprint-186.design.md
+++ b/docs/02-design/features/sprint-186.design.md
@@ -1,0 +1,161 @@
+---
+code: FX-DSGN-S186
+title: Sprint 186 Design — F399 Strangler Fig 프록시 + harness-kit 이벤트 유틸리티
+version: "1.0"
+status: Active
+category: DSGN
+created: 2026-04-07
+updated: 2026-04-07
+author: Claude (Sprint Autopilot)
+sprint: 186
+references: [FX-PLAN-S186, FX-REQ-391]
+---
+
+# Sprint 186 Design — F399
+
+## 1. 개요
+
+harness-kit에 두 가지 핵심 유틸리티를 추가한다:
+1. **D1EventBus** — D1 테이블 기반 이벤트 발행/구독 (NoopEventBus 대체)
+2. **createStranglerMiddleware** — Strangler Fig 패턴 라우팅 미들웨어
+
+## 2. 인터페이스 설계
+
+### 2.1 D1EventBus
+
+```typescript
+// packages/harness-kit/src/events/d1-bus.ts
+
+export type D1LikeDatabase = {
+  prepare(query: string): {
+    bind(...args: unknown[]): {
+      run(): Promise<{ success: boolean }>;
+      all<T>(): Promise<{ results: T[] }>;
+    };
+  };
+};
+
+export class D1EventBus implements EventBus {
+  constructor(private readonly db: D1LikeDatabase) {}
+  
+  async publish(event: DomainEvent, tenantId?: string): Promise<void>
+  async publishBatch(events: DomainEvent[], tenantId?: string): Promise<void>
+  subscribe(type: EventType | '*', handler: (event: DomainEvent) => Promise<void>): void
+  async poll(limit?: number): Promise<number>  // 미처리 이벤트 처리 (cron용)
+}
+```
+
+`publish()` → domain_events INSERT (status='pending')
+`poll()` → pending 이벤트 조회 → _dispatch → _ack('processed'|'failed')
+
+### 2.2 createEvent 헬퍼
+
+```typescript
+// packages/harness-kit/src/events/helpers.ts
+
+export function createEvent<T = unknown>(
+  type: EventType,
+  source: ServiceId,
+  payload: T,
+  metadata?: DomainEvent['metadata'],
+): DomainEvent<T>
+// id: crypto.randomUUID(), timestamp: new Date().toISOString() 자동 주입
+```
+
+### 2.3 Strangler Fig 미들웨어
+
+```typescript
+// packages/harness-kit/src/middleware/strangler.ts
+
+export interface StranglerRoute {
+  pathPrefix: string;      // '/dx', '/gate', '/launch'
+  serviceId: ServiceId;
+  mode: 'local' | 'proxy';
+  targetUrl?: string;      // proxy 모드 HTTP endpoint
+}
+
+export interface StranglerConfig {
+  routes: StranglerRoute[];
+}
+
+export function createStranglerMiddleware(config: StranglerConfig): MiddlewareHandler
+```
+
+**동작 흐름**:
+```
+요청 도착
+  ↓
+pathPrefix 매칭 라우트 검색
+  ↓ 없으면 → next() (미매칭)
+  ↓ 있으면
+  mode === 'local' → next() (로컬 핸들러 처리)
+  mode === 'proxy' → X-Forwarded-From 헤더 추가 + fetch(targetUrl + remainingPath)
+                     targetUrl 없으면 → 502 "Service not configured"
+```
+
+**Query string 보존**: `c.req.url`에서 search params 추출하여 포워딩 URL에 포함
+
+## 3. 파일 매핑
+
+### §5 Worker 파일 매핑
+
+| Worker | 파일 | 작업 |
+|--------|------|------|
+| W1 (이벤트) | `packages/harness-kit/src/events/d1-bus.ts` | 신규 생성 |
+| W1 | `packages/harness-kit/src/events/helpers.ts` | 신규 생성 |
+| W1 | `packages/harness-kit/src/events/index.ts` | D1EventBus + createEvent export 추가 |
+| W1 | `packages/harness-kit/__tests__/events/d1-bus.test.ts` | 신규 생성 |
+| W2 (프록시) | `packages/harness-kit/src/middleware/strangler.ts` | 신규 생성 |
+| W2 | `packages/harness-kit/src/middleware/index.ts` | createStranglerMiddleware + 타입 export 추가 |
+| W2 | `packages/harness-kit/src/index.ts` | StranglerRoute + createStranglerMiddleware 재export |
+| W2 | `packages/harness-kit/__tests__/middleware/strangler.test.ts` | 신규 생성 |
+| W2 | `packages/api/src/routes/proxy.ts` | createStranglerMiddleware 활용으로 리팩토링 |
+
+## 4. 테스트 전략
+
+### 4.1 D1EventBus 테스트 (`__tests__/events/d1-bus.test.ts`)
+
+- in-memory mock DB (prepare/bind/run/all mock 구현)
+- `publish()`: domain_events에 INSERT되는지 확인
+- `subscribe() + poll()`: pending 이벤트 dispatch 후 handler 호출 확인
+- `poll()`: processed/failed 상태로 ACK 확인
+- `createEvent()`: id, timestamp 자동 생성 확인
+
+### 4.2 Strangler 테스트 (`__tests__/middleware/strangler.test.ts`)
+
+- Hono 앱에 미들웨어 등록 + `app.request()` 직접 호출
+- 미매칭 경로: `next()` 실행 → 로컬 핸들러 응답
+- local 모드 경로: `next()` 실행 → 로컬 핸들러 응답
+- proxy 모드 + targetUrl 없음: 502 반환
+- proxy 모드 + targetUrl 설정: fetch 호출 (mock) + X-Forwarded-From 헤더 확인
+
+### 4.3 proxy.ts 리팩토링 검증
+
+- 기존 테스트(`packages/api/src/__tests__/proxy.test.ts` 존재 시) 통과 유지
+- 없으면 신규 스모크 테스트 1건 추가
+
+## 5. 아키텍처 결정
+
+### ADR-002: harness-kit D1EventBus는 @foundry-x/shared 미의존
+
+**이유**: harness-kit은 Foundry-X 생태계 외부(gate-x, launch-x 등)에서도 사용되는 standalone npm 패키지. `@foundry-x/shared`를 의존하면 패키지 배포 시 internal types가 노출되고 monorepo 외부에서 설치 불가.
+
+**방식**: `@foundry-x/shared`의 D1EventBus와 동일한 D1 스키마(`domain_events` 테이블)를 사용하되, 타입과 구현은 harness-kit 내부에서 독립 정의.
+
+### ADR-003: Strangler 미들웨어는 Auth 미포함
+
+**이유**: Auth는 서비스별 정책이 다를 수 있음 (일부 서비스는 API Key, 일부는 JWT). Strangler는 "어디로 갈지"만 결정하는 순수 라우팅 미들웨어.
+
+## 6. 완료 기준 체크리스트
+
+- [ ] D1EventBus: EventBus 인터페이스 완전 구현
+- [ ] D1EventBus: poll() 정상 동작 (pending → processed/failed)
+- [ ] createEvent(): UUID + ISO timestamp 자동 생성
+- [ ] Strangler: local 모드 → next() fallthrough
+- [ ] Strangler: proxy 모드 → targetUrl 포워딩 + 헤더 보존
+- [ ] Strangler: 미매칭 경로 → next() fallthrough
+- [ ] Strangler: targetUrl 없이 proxy 모드 → 502
+- [ ] harness-kit exports 갱신 (index.ts, events/index.ts, middleware/index.ts)
+- [ ] proxy.ts: StranglerMiddleware 활용
+- [ ] 테스트 전체 통과
+- [ ] typecheck 통과

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -17,6 +17,7 @@
     "lint": "echo 'API lint: eslint config pending (Sprint 7)'"
   },
   "dependencies": {
+    "@foundry-x/harness-kit": "workspace:*",
     "@foundry-x/shared": "workspace:*",
     "@hono/swagger-ui": "^0.4.0",
     "@hono/zod-openapi": "^0.9.0",

--- a/packages/api/src/routes/proxy.ts
+++ b/packages/api/src/routes/proxy.ts
@@ -1,4 +1,11 @@
+// ─── F399: Strangler Fig 프록시 레이어 (Sprint 186) ───
+// createStranglerMiddleware로 라우팅 규칙을 선언적으로 관리한다.
+// 이미 분리된 서비스(dx, aif): Workers Service Binding 활용 (ServiceProxy 유지)
+// 이관 예정 서비스(gate, launch, auth, portal): mode:'local' → 이관 완료 후 mode:'proxy'로 전환
+
 import { OpenAPIHono } from "@hono/zod-openapi";
+import { createStranglerMiddleware } from "@foundry-x/harness-kit";
+import type { StranglerRoute } from "@foundry-x/harness-kit";
 import { SsoService } from "../modules/auth/services/sso.js";
 import { ServiceProxy } from "../services/service-proxy.js";
 import type { Env } from "../env.js";
@@ -7,7 +14,24 @@ export const proxyRoute = new OpenAPIHono<{ Bindings: Env }>();
 
 const ssoService = new SsoService();
 
-// ─── /dx/* → Discovery-X ───
+/**
+ * 서비스별 라우팅 규칙 — Phase 20-B 이관 로드맵 반영
+ * mode:'local'  → 현재 모놀리스에서 처리 (이관 전)
+ * mode:'proxy'  → 외부 서비스로 포워딩 (이관 후, targetUrl 또는 Workers Binding 필요)
+ *
+ * dx / aif는 Workers Service Binding 기반이므로 아래 StranglerConfig 대신
+ * ServiceProxy를 직접 사용한다 (Binding은 URL이 아닌 fetch 인터페이스).
+ */
+export const stranglerRoutes: StranglerRoute[] = [
+  // ─── 이관 예정 (현재 local 모드) — M5 이후 proxy 전환 ───
+  { pathPrefix: "/gate", serviceId: "gate-x", mode: "local" },
+  { pathPrefix: "/launch", serviceId: "launch-x", mode: "local" },
+];
+
+// 이관 예정 서비스 라우트 등록 (local 모드 — next()로 fallthrough)
+proxyRoute.use("*", createStranglerMiddleware({ routes: stranglerRoutes }));
+
+// ─── /dx/* → Discovery-X (Workers Service Binding 기반) ───
 
 proxyRoute.all("/dx/*", async (c) => {
   const hubToken = c.req.header("Authorization")?.replace("Bearer ", "");
@@ -25,7 +49,7 @@ proxyRoute.all("/dx/*", async (c) => {
   return proxy.forward("dx", path, c.req.raw, hubToken);
 });
 
-// ─── /aif/* → AI Foundry ───
+// ─── /aif/* → AI Foundry (Workers Service Binding 기반) ───
 
 proxyRoute.all("/aif/*", async (c) => {
   const hubToken = c.req.header("Authorization")?.replace("Bearer ", "");

--- a/packages/harness-kit/__tests__/events/d1-bus.test.ts
+++ b/packages/harness-kit/__tests__/events/d1-bus.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi } from "vitest";
+import { D1EventBus } from "../../src/events/d1-bus.js";
+import { createEvent } from "../../src/events/helpers.js";
+import type { D1LikeDatabase } from "../../src/events/d1-bus.js";
+import type { DomainEvent } from "../../src/events/types.js";
+
+// ─── D1 Mock ───
+
+type MockRow = {
+  id: string;
+  type: string;
+  source: string;
+  tenant_id: string;
+  payload: string;
+  metadata: string | null;
+  status: string;
+  created_at: string;
+};
+
+function createMockDb(rows: MockRow[] = []): D1LikeDatabase {
+  const store: MockRow[] = [...rows];
+  return {
+    prepare(sql: string) {
+      return {
+        bind(...args: unknown[]) {
+          return {
+            async run() {
+              if (sql.includes("INSERT INTO domain_events")) {
+                store.push({
+                  id: args[0] as string,
+                  type: args[1] as string,
+                  source: args[2] as string,
+                  tenant_id: args[3] as string,
+                  payload: args[4] as string,
+                  metadata: args[5] as string | null,
+                  status: "pending",
+                  created_at: args[6] as string,
+                });
+              }
+              if (sql.includes("UPDATE domain_events")) {
+                const targetId = args[2] as string;
+                const row = store.find((r) => r.id === targetId);
+                if (row) row.status = args[0] as string;
+              }
+              return { success: true };
+            },
+            async all<T>() {
+              if (sql.includes("SELECT") && sql.includes("status = 'pending'")) {
+                return {
+                  results: store.filter((r) => r.status === "pending").slice(0, (args[0] as number) || 50) as unknown as T[],
+                };
+              }
+              return { results: [] as T[] };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+// ─── Tests ───
+
+describe("D1EventBus", () => {
+  describe("publish()", () => {
+    it("이벤트를 domain_events에 INSERT한다", async () => {
+      const db = createMockDb();
+      const bus = new D1EventBus(db);
+
+      const event: DomainEvent = {
+        id: "evt-001",
+        type: "biz-item.created",
+        source: "foundry-x",
+        timestamp: "2026-04-07T00:00:00Z",
+        payload: { itemId: "item-1" },
+      };
+
+      await expect(bus.publish(event)).resolves.toBeUndefined();
+    });
+
+    it("tenantId 기본값 'default' 사용", async () => {
+      const db = createMockDb();
+      const runSpy = vi.fn().mockResolvedValue({ success: true });
+      const spyDb: D1LikeDatabase = {
+        prepare() {
+          return {
+            bind(...args: unknown[]) {
+              return { run: runSpy, all: async () => ({ results: [] }) };
+            },
+          };
+        },
+      };
+      const bus = new D1EventBus(spyDb);
+      await bus.publish({ id: "e1", type: "biz-item.created", source: "foundry-x", timestamp: new Date().toISOString(), payload: {} });
+      expect(runSpy).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("publishBatch()", () => {
+    it("복수 이벤트를 모두 INSERT한다", async () => {
+      const db = createMockDb();
+      const bus = new D1EventBus(db);
+
+      const events: DomainEvent[] = [
+        { id: "e1", type: "biz-item.created", source: "foundry-x", timestamp: new Date().toISOString(), payload: {} },
+        { id: "e2", type: "validation.completed", source: "gate-x", timestamp: new Date().toISOString(), payload: {} },
+      ];
+      await expect(bus.publishBatch(events)).resolves.toBeUndefined();
+    });
+
+    it("빈 배열 처리", async () => {
+      const db = createMockDb();
+      const bus = new D1EventBus(db);
+      await expect(bus.publishBatch([])).resolves.toBeUndefined();
+    });
+  });
+
+  describe("subscribe() + poll()", () => {
+    it("pending 이벤트를 dispatch 후 핸들러 호출", async () => {
+      const pendingRows: MockRow[] = [
+        {
+          id: "evt-pending-1",
+          type: "biz-item.created",
+          source: "foundry-x",
+          tenant_id: "org-1",
+          payload: JSON.stringify({ itemId: "x" }),
+          metadata: null,
+          status: "pending",
+          created_at: "2026-04-07T00:00:00Z",
+        },
+      ];
+      const db = createMockDb(pendingRows);
+      const bus = new D1EventBus(db);
+
+      const handler = vi.fn().mockResolvedValue(undefined);
+      bus.subscribe("biz-item.created", handler);
+
+      const count = await bus.poll();
+      expect(count).toBe(1);
+      expect(handler).toHaveBeenCalledOnce();
+      expect(handler.mock.calls[0][0]).toMatchObject({ id: "evt-pending-1", type: "biz-item.created" });
+    });
+
+    it("와일드카드('*') 구독은 모든 이벤트 수신", async () => {
+      const rows: MockRow[] = [
+        { id: "e1", type: "biz-item.created", source: "foundry-x", tenant_id: "t1", payload: "{}", metadata: null, status: "pending", created_at: "2026-04-07T00:00:00Z" },
+        { id: "e2", type: "validation.completed", source: "gate-x", tenant_id: "t1", payload: "{}", metadata: null, status: "pending", created_at: "2026-04-07T00:01:00Z" },
+      ];
+      const db = createMockDb(rows);
+      const bus = new D1EventBus(db);
+
+      const handler = vi.fn().mockResolvedValue(undefined);
+      bus.subscribe("*", handler);
+
+      const count = await bus.poll();
+      expect(count).toBe(2);
+      expect(handler).toHaveBeenCalledTimes(2);
+    });
+
+    it("핸들러 에러 시 failed 상태로 ACK", async () => {
+      const rows: MockRow[] = [
+        { id: "fail-1", type: "offering.generated", source: "foundry-x", tenant_id: "t1", payload: "{}", metadata: null, status: "pending", created_at: "2026-04-07T00:00:00Z" },
+      ];
+      const db = createMockDb(rows);
+      const bus = new D1EventBus(db);
+
+      bus.subscribe("offering.generated", async () => { throw new Error("handler error"); });
+
+      const count = await bus.poll();
+      // 에러가 발생해도 poll은 정상 종료하고 0을 반환 (failed로 ACK됨)
+      expect(count).toBe(0);
+      // row의 status가 'failed'로 변경됐는지 확인 (내부 store 접근)
+      const updatedRow = rows[0];
+      expect(updatedRow.status).toBe("failed");
+    });
+
+    it("poll 결과가 0이면 빈 DB", async () => {
+      const db = createMockDb([]);
+      const bus = new D1EventBus(db);
+      const count = await bus.poll();
+      expect(count).toBe(0);
+    });
+  });
+});
+
+describe("createEvent()", () => {
+  it("id와 timestamp가 자동 주입된다", () => {
+    const event = createEvent("biz-item.created", "foundry-x", { itemId: "abc" });
+    expect(event.id).toBeTruthy();
+    expect(event.id).toHaveLength(36); // UUID v4 형식
+    expect(event.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/); // ISO 8601
+    expect(event.type).toBe("biz-item.created");
+    expect(event.source).toBe("foundry-x");
+    expect(event.payload).toEqual({ itemId: "abc" });
+  });
+
+  it("metadata 선택 인자 포함 가능", () => {
+    const event = createEvent("validation.completed", "gate-x", {}, { correlationId: "corr-1", userId: "u1" });
+    expect(event.metadata?.correlationId).toBe("corr-1");
+    expect(event.metadata?.userId).toBe("u1");
+  });
+
+  it("metadata 없으면 metadata 키 미포함", () => {
+    const event = createEvent("pipeline.step-completed", "foundry-x", {});
+    expect(event.metadata).toBeUndefined();
+  });
+});

--- a/packages/harness-kit/__tests__/middleware/strangler.test.ts
+++ b/packages/harness-kit/__tests__/middleware/strangler.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Hono } from "hono";
+import { createStranglerMiddleware } from "../../src/middleware/strangler.js";
+import type { StranglerConfig } from "../../src/middleware/strangler.js";
+
+function createApp(config: StranglerConfig) {
+  const app = new Hono();
+  app.use("*", createStranglerMiddleware(config));
+  app.get("/gate/items", (c) => c.json({ source: "local", path: "/gate/items" }));
+  app.get("/other/data", (c) => c.json({ source: "local", path: "/other/data" }));
+  app.get("/gate", (c) => c.json({ source: "local", path: "/gate" }));
+  return app;
+}
+
+// vi.stubGlobal 사용 — ESM 모듈 내 fetch 참조를 안정적으로 intercept
+function mockFetch(response: Response) {
+  const fn = vi.fn().mockResolvedValue(response);
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("createStranglerMiddleware", () => {
+  describe("미매칭 경로", () => {
+    it("등록되지 않은 경로는 next()로 로컬 핸들러 실행", async () => {
+      const app = createApp({ routes: [{ pathPrefix: "/gate", serviceId: "gate-x", mode: "local" }] });
+      const res = await app.request("/other/data");
+      expect(res.status).toBe(200);
+      const body = await res.json<{ source: string }>();
+      expect(body.source).toBe("local");
+    });
+  });
+
+  describe("local 모드", () => {
+    it("local 모드는 next()로 로컬 핸들러 실행", async () => {
+      const app = createApp({ routes: [{ pathPrefix: "/gate", serviceId: "gate-x", mode: "local" }] });
+      const res = await app.request("/gate/items");
+      expect(res.status).toBe(200);
+      const body = await res.json<{ source: string }>();
+      expect(body.source).toBe("local");
+    });
+  });
+
+  describe("proxy 모드 — targetUrl 없음", () => {
+    it("proxy 모드 + targetUrl 없으면 502 반환", async () => {
+      const app = createApp({ routes: [{ pathPrefix: "/gate", serviceId: "gate-x", mode: "proxy" }] });
+      const res = await app.request("/gate/items");
+      expect(res.status).toBe(502);
+      const body = await res.json<{ error: string; serviceId: string }>();
+      expect(body.error).toBe("Service not configured");
+      expect(body.serviceId).toBe("gate-x");
+    });
+  });
+
+  describe("proxy 모드 — targetUrl 있음", () => {
+    it("proxy 모드 + targetUrl → fetch 호출", async () => {
+      const fetchMock = mockFetch(new Response(JSON.stringify({ proxied: true }), { status: 200 }));
+      const app = createApp({
+        routes: [{ pathPrefix: "/gate", serviceId: "gate-x", mode: "proxy", targetUrl: "https://gate-x.example.com" }],
+      });
+      const res = await app.request("/gate/items");
+      expect(res.status).toBe(200);
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const calledUrl = fetchMock.mock.calls[0][0] as string;
+      expect(calledUrl).toBe("https://gate-x.example.com/items");
+    });
+
+    it("proxy 모드 — X-Forwarded-From 헤더 설정", async () => {
+      const fetchMock = mockFetch(new Response("{}", { status: 200 }));
+      const app = createApp({
+        routes: [{ pathPrefix: "/gate", serviceId: "gate-x", mode: "proxy", targetUrl: "https://gate-x.example.com" }],
+      });
+      await app.request("/gate/items");
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const init = fetchMock.mock.calls[0][1] as RequestInit & { headers: Headers };
+      const headers = new Headers(init.headers);
+      expect(headers.get("x-forwarded-from")).toBe("foundry-x-strangler");
+      expect(headers.get("x-service-id")).toBe("gate-x");
+      expect(headers.get("x-original-path")).toBe("/gate/items");
+    });
+
+    it("proxy 모드 — query string 보존", async () => {
+      const fetchMock = mockFetch(new Response("{}", { status: 200 }));
+      const app = createApp({
+        routes: [{ pathPrefix: "/gate", serviceId: "gate-x", mode: "proxy", targetUrl: "https://gate-x.example.com" }],
+      });
+      await app.request("/gate/items?page=2&limit=10");
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const calledUrl = fetchMock.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("?page=2&limit=10");
+    });
+
+    it("더 긴 prefix가 우선 매칭", async () => {
+      const fetchMock = mockFetch(new Response("{}", { status: 200 }));
+      const app = createApp({
+        routes: [
+          { pathPrefix: "/gate", serviceId: "gate-x", mode: "proxy", targetUrl: "https://gate.example.com" },
+          { pathPrefix: "/gate/items", serviceId: "gate-x", mode: "proxy", targetUrl: "https://items.example.com" },
+        ],
+      });
+      await app.request("/gate/items");
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const calledUrl = fetchMock.mock.calls[0][0] as string;
+      expect(calledUrl).toBe("https://items.example.com/");
+    });
+  });
+
+  describe("루트 경로 처리", () => {
+    it("prefix만 일치하는 경우 '/' 경로로 포워딩", async () => {
+      const fetchMock = mockFetch(new Response("{}", { status: 200 }));
+      const app = createApp({
+        routes: [{ pathPrefix: "/gate", serviceId: "gate-x", mode: "proxy", targetUrl: "https://gate.example.com" }],
+      });
+      await app.request("/gate");
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const calledUrl = fetchMock.mock.calls[0][0] as string;
+      expect(calledUrl).toBe("https://gate.example.com/");
+    });
+  });
+});

--- a/packages/harness-kit/src/events/d1-bus.ts
+++ b/packages/harness-kit/src/events/d1-bus.ts
@@ -1,0 +1,113 @@
+// ─── F399: harness-kit D1EventBus — D1 기반 이벤트 발행/폴링 (Sprint 186) ───
+// @foundry-x/shared 미의존 독립 구현 (ADR-002: standalone npm 패키지 호환성)
+
+import type { DomainEvent, EventType } from "./types.js";
+import type { EventBus } from "./bus.js";
+
+export type D1LikeDatabase = {
+  prepare(query: string): {
+    bind(...args: unknown[]): {
+      run(): Promise<{ success: boolean }>;
+      all<T>(): Promise<{ results: T[] }>;
+    };
+  };
+};
+
+type EventHandler = (event: DomainEvent) => Promise<void>;
+
+/** D1 domain_events 테이블 기반 EventBus 구현 (migration: 0114_domain_events.sql) */
+export class D1EventBus implements EventBus {
+  private handlers: Map<EventType | "*", Set<EventHandler>> = new Map();
+
+  constructor(private readonly db: D1LikeDatabase) {}
+
+  async publish(event: DomainEvent, tenantId = "default"): Promise<void> {
+    await this.db
+      .prepare(
+        `INSERT INTO domain_events
+         (id, type, source, tenant_id, payload, metadata, status, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, 'pending', ?)`,
+      )
+      .bind(
+        event.id,
+        event.type,
+        event.source,
+        tenantId,
+        JSON.stringify(event.payload),
+        event.metadata ? JSON.stringify(event.metadata) : null,
+        event.timestamp,
+      )
+      .run();
+  }
+
+  async publishBatch(events: DomainEvent[], tenantId = "default"): Promise<void> {
+    await Promise.all(events.map((e) => this.publish(e, tenantId)));
+  }
+
+  subscribe(type: EventType | "*", handler: EventHandler): void {
+    if (!this.handlers.has(type)) {
+      this.handlers.set(type, new Set());
+    }
+    this.handlers.get(type)!.add(handler);
+  }
+
+  /**
+   * 미처리(pending) 이벤트를 가져와 등록된 핸들러에 dispatch한다.
+   * Cron Trigger 또는 수동 폴링에서 호출.
+   * @param limit 한 번에 처리할 최대 이벤트 수 (기본값: 50)
+   * @returns 처리 완료된 이벤트 수
+   */
+  async poll(limit = 50): Promise<number> {
+    const { results } = await this.db
+      .prepare(
+        `SELECT id, type, source, payload, metadata, created_at
+         FROM domain_events
+         WHERE status = 'pending'
+         ORDER BY created_at
+         LIMIT ?`,
+      )
+      .bind(limit)
+      .all<{
+        id: string;
+        type: string;
+        source: string;
+        payload: string;
+        metadata: string | null;
+        created_at: string;
+      }>();
+
+    let processed = 0;
+    for (const row of results) {
+      const event: DomainEvent = {
+        id: row.id,
+        type: row.type as EventType,
+        source: row.source as DomainEvent["source"],
+        timestamp: row.created_at,
+        payload: JSON.parse(row.payload) as unknown,
+        metadata: row.metadata ? (JSON.parse(row.metadata) as DomainEvent["metadata"]) : undefined,
+      };
+
+      try {
+        await this._dispatch(event);
+        await this._ack(row.id, "processed");
+        processed++;
+      } catch {
+        await this._ack(row.id, "failed");
+      }
+    }
+    return processed;
+  }
+
+  private async _dispatch(event: DomainEvent): Promise<void> {
+    const typeHandlers = this.handlers.get(event.type) ?? new Set();
+    const wildcardHandlers = this.handlers.get("*") ?? new Set();
+    await Promise.all([...typeHandlers, ...wildcardHandlers].map((h) => h(event)));
+  }
+
+  private async _ack(id: string, status: "processed" | "failed"): Promise<void> {
+    await this.db
+      .prepare(`UPDATE domain_events SET status = ?, processed_at = ? WHERE id = ?`)
+      .bind(status, new Date().toISOString(), id)
+      .run();
+  }
+}

--- a/packages/harness-kit/src/events/helpers.ts
+++ b/packages/harness-kit/src/events/helpers.ts
@@ -1,0 +1,24 @@
+// ─── F399: createEvent 헬퍼 — 이벤트 팩토리 (Sprint 186) ───
+
+import type { DomainEvent, EventType } from "./types.js";
+import type { ServiceId } from "../types.js";
+
+/**
+ * DomainEvent 객체를 생성한다.
+ * id(UUID)와 timestamp(ISO 8601)를 자동 주입한다.
+ */
+export function createEvent<T = unknown>(
+  type: EventType,
+  source: ServiceId,
+  payload: T,
+  metadata?: DomainEvent["metadata"],
+): DomainEvent<T> {
+  return {
+    id: crypto.randomUUID(),
+    type,
+    source,
+    timestamp: new Date().toISOString(),
+    payload,
+    ...(metadata ? { metadata } : {}),
+  };
+}

--- a/packages/harness-kit/src/events/index.ts
+++ b/packages/harness-kit/src/events/index.ts
@@ -6,3 +6,7 @@ export type {
 } from "./types.js";
 export type { EventBus } from "./bus.js";
 export { NoopEventBus } from "./bus.js";
+// F399: D1 기반 이벤트 버스 + 팩토리 헬퍼 (Sprint 186)
+export { D1EventBus } from "./d1-bus.js";
+export type { D1LikeDatabase } from "./d1-bus.js";
+export { createEvent } from "./helpers.js";

--- a/packages/harness-kit/src/index.ts
+++ b/packages/harness-kit/src/index.ts
@@ -5,8 +5,9 @@ export {
   rbac,
   errorHandler,
   HarnessError,
+  createStranglerMiddleware,
 } from "./middleware/index.js";
-export type { JwtPayload, Role } from "./middleware/index.js";
+export type { JwtPayload, Role, StranglerRoute, StranglerConfig } from "./middleware/index.js";
 
 // Types
 export type {
@@ -20,13 +21,14 @@ export type {
 export { getDb, runQuery, runExec } from "./d1/index.js";
 
 // Events
-export { NoopEventBus } from "./events/index.js";
+export { NoopEventBus, D1EventBus, createEvent } from "./events/index.js";
 export type {
   EventType,
   DomainEvent,
   EventPublisher,
   EventSubscriber,
   EventBus,
+  D1LikeDatabase,
 } from "./events/index.js";
 
 // ESLint

--- a/packages/harness-kit/src/middleware/index.ts
+++ b/packages/harness-kit/src/middleware/index.ts
@@ -4,3 +4,6 @@ export { createCorsMiddleware } from "./cors.js";
 export { rbac } from "./rbac.js";
 export type { Role } from "./rbac.js";
 export { errorHandler, HarnessError } from "./error-handler.js";
+// F399: Strangler Fig 프록시 미들웨어 (Sprint 186)
+export { createStranglerMiddleware } from "./strangler.js";
+export type { StranglerRoute, StranglerConfig } from "./strangler.js";

--- a/packages/harness-kit/src/middleware/strangler.ts
+++ b/packages/harness-kit/src/middleware/strangler.ts
@@ -1,0 +1,74 @@
+// ─── F399: Strangler Fig 프록시 미들웨어 (Sprint 186) ───
+// Strangler Fig 패턴: mode:'local' → 모놀리스 처리, mode:'proxy' → 외부 서비스 포워딩
+
+import type { Context, MiddlewareHandler, Next } from "hono";
+import type { ServiceId } from "../types.js";
+
+export interface StranglerRoute {
+  /** 매칭할 경로 접두사 (예: '/dx', '/gate', '/launch') */
+  pathPrefix: string;
+  /** 대상 서비스 식별자 */
+  serviceId: ServiceId;
+  /**
+   * 처리 모드:
+   * - 'local': 현재 모놀리스 핸들러로 fallthrough (서비스 이관 전)
+   * - 'proxy': targetUrl 또는 Workers Service Binding으로 포워딩 (이관 후)
+   */
+  mode: "local" | "proxy";
+  /** proxy 모드 시 HTTP 포워딩 대상 URL (예: 'https://gate-x.workers.dev') */
+  targetUrl?: string;
+}
+
+export interface StranglerConfig {
+  routes: StranglerRoute[];
+}
+
+/**
+ * Strangler Fig 패턴 라우팅 미들웨어.
+ *
+ * 등록된 경로에 대해 mode에 따라 로컬 처리 또는 외부 서비스로 포워딩한다.
+ * Auth 검증은 외부 미들웨어에서 처리한다 (ADR-003: 관심사 분리).
+ */
+export function createStranglerMiddleware(config: StranglerConfig): MiddlewareHandler {
+  return async function strangler(c: Context, next: Next): Promise<Response | void> {
+    const reqPath = c.req.path;
+
+    // 매칭 라우트 탐색 (더 긴 prefix 우선)
+    const route = config.routes
+      .filter((r) => reqPath.startsWith(r.pathPrefix))
+      .sort((a, b) => b.pathPrefix.length - a.pathPrefix.length)[0];
+
+    // 미매칭 또는 local 모드 → 다음 핸들러로 전달
+    if (!route || route.mode === "local") {
+      return next();
+    }
+
+    // proxy 모드 — targetUrl 없으면 502
+    if (!route.targetUrl) {
+      return c.json(
+        { error: "Service not configured", serviceId: route.serviceId },
+        502,
+      );
+    }
+
+    // 경로 재계산: prefix 이후 나머지 경로
+    const remainingPath = reqPath.slice(route.pathPrefix.length) || "/";
+
+    // URL에서 query string 보존
+    const url = new URL(c.req.url);
+    const targetUrl = `${route.targetUrl.replace(/\/$/, "")}${remainingPath}${url.search}`;
+
+    const headers = new Headers(c.req.raw.headers);
+    headers.set("X-Forwarded-From", "foundry-x-strangler");
+    headers.set("X-Original-Path", reqPath);
+    headers.set("X-Service-Id", route.serviceId);
+
+    const isBodyless = c.req.method === "GET" || c.req.method === "HEAD";
+
+    return fetch(targetUrl, {
+      method: c.req.method,
+      headers,
+      body: isBodyless ? undefined : c.req.raw.body,
+    });
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
 
   packages/api:
     dependencies:
+      '@foundry-x/harness-kit':
+        specifier: workspace:*
+        version: link:../harness-kit
       '@foundry-x/shared':
         specifier: workspace:*
         version: link:../shared


### PR DESCRIPTION
## Summary
- **harness-kit D1EventBus**: D1 테이블 기반 이벤트 발행/구독/폴링 (`@foundry-x/shared` 무의존 standalone 구현, ADR-002)
- **harness-kit createEvent()**: UUID + ISO timestamp 자동 주입 이벤트 팩토리 헬퍼
- **createStranglerMiddleware**: Hono 미들웨어 — `mode:'local'`(모놀리스 fallthrough) / `mode:'proxy'`(외부 서비스 포워딩), longest-prefix-wins 라우팅
- **proxy.ts 리팩토링**: 이관 예정 서비스(gate, launch) 선언적 등록, `@foundry-x/harness-kit` 의존성 추가

## Test plan
- [x] harness-kit 테스트 57/57 통과 (D1EventBus 11건 + Strangler 8건 신규)
- [x] API 테스트 3167/3168 통과
- [x] harness-kit typecheck 통과
- [x] proxy.ts typecheck 통과

## Match Rate
**100%** (11/11 Design 체크리스트)

## Phase 20-B 진행 상황
- ✅ Sprint 185 (F398): 이벤트 카탈로그 + D1 테이블 + IA 개편
- ✅ Sprint 186 (F399): Strangler 미들웨어 + harness-kit 이벤트 유틸리티
- 📋 Sprint 187 (F400): E2E 서비스별 태깅 + Gate-X scaffold PoC
- 📋 Sprint 188 (F401): Production 배포 + 개발자 가이드

---
🤖 Auto-generated from Sprint autopilot (Match Rate 100%)