### PR TITLE
feat: Sprint 189 — Gate-X 독립 Workers scaffold + Gate 모듈 추출 (F402+F403)

### DIFF
--- a/docs/01-plan/features/sprint-189.plan.md
+++ b/docs/01-plan/features/sprint-189.plan.md
@@ -1,0 +1,122 @@
+---
+code: FX-PLAN-S189
+title: "Sprint 189 — Gate-X 독립 Workers scaffold + Gate 모듈 추출"
+version: 1.0
+status: Active
+category: PLAN
+phase: "Phase 21: Gate-X 독립 서비스"
+sprint: 189
+f-items: [F402, F403]
+req-codes: [FX-REQ-394, FX-REQ-395]
+created: 2026-04-07
+updated: 2026-04-07
+author: Sinclair + Claude
+---
+
+# Sprint 189 Plan — Gate-X 독립 Workers scaffold + Gate 모듈 추출
+
+## 1. Executive Summary
+
+| 항목 | 내용 |
+|------|------|
+| Feature | F402: Gate-X 독립 Workers scaffold + D1 전용 DB, F403: Gate 모듈 추출 (7R + 7S + 6Sch) |
+| Sprint | 189 |
+| Phase | Phase 21-A: 코어 API + 독립 배포 (M1, P0) |
+| 예상 산출물 | packages/gate-x/ 독립 Workers 서비스 + D1 마이그레이션 + 테스트 |
+
+### Value Delivered
+
+| 관점 | 내용 |
+|------|------|
+| Problem | Gate(검증) 기능이 FX 모놀리스에 묶여 독립 사용 불가 |
+| Solution | harness-kit 기반 독립 Workers 서비스로 분리 |
+| Function UX Effect | gate-x-api.workers.dev에서 검증 API를 독립 호출 가능 |
+| Core Value | 외부 제공 가능한 독립 검증 서비스 기반 확보 |
+
+## 2. 범위
+
+### 2.1 F402 — Gate-X 독립 Workers scaffold + D1 전용 DB
+
+- **목표**: harness-kit scaffold 기반으로 Gate-X 독립 Workers 프로젝트 구조 생성
+- **산출물**:
+  - `packages/gate-x/` 디렉토리 (package.json, tsconfig, vitest.config, wrangler.toml)
+  - `src/app.ts` — Hono 앱 + harness-kit 미들웨어 (CORS, JWT, ErrorHandler)
+  - `src/env.ts` — Gate-X 전용 환경 바인딩
+  - `src/index.ts` — Workers entry point
+  - D1 마이그레이션: Gate-X 전용 테이블 (~10개) 초기 스키마
+  - `src/middleware/tenant.ts` — 테넌트 가드 (harness-kit JWT 기반)
+- **의존**: harness-kit 패키지 (workspace:*)
+
+### 2.2 F403 — Gate 모듈 추출 (7 routes + 7 services + 6 schemas)
+
+- **목표**: `packages/api/src/modules/gate/`의 20개 파일을 Gate-X로 이전
+- **산출물**:
+  - `packages/gate-x/src/routes/` — 7 라우트 (import 경로 재작성)
+  - `packages/gate-x/src/services/` — 7 서비스 (크로스 모듈 의존 해소)
+  - `packages/gate-x/src/schemas/` — 6 Zod 스키마
+- **크로스 모듈 의존 해소**:
+  - `KpiService` (portal) → 평가 라우트에서 KPI 연동을 이벤트 기반 stub으로 대체
+  - `PipelineService` (launch) → decision-service에서 파이프라인 단계 조회를 D1 직접 쿼리로 대체 (Gate-X DB에 pipeline_stages 뷰 생성)
+  - `NotificationService` (portal) → 이벤트 발행으로 대체 (D1EventBus)
+  - `Env`, `TenantVariables` → Gate-X 자체 타입으로 전환
+- **테스트**: 이전된 서비스 단위 테스트 (vitest)
+
+## 3. 기술 결정
+
+| 결정 | 선택 | 근거 |
+|------|------|------|
+| D1 전략 | 새 DB (gate-x-db) | PRD 권장 — 외부 제공 시 깨끗한 분리 |
+| 인증 | 독립 JWT (harness-kit) | PRD 권장 — API Key 방식 병행은 Sprint 190 |
+| 크로스 의존 | Adapter 패턴 + EventBus | 직접 import 제거, 느슨한 연결 유지 |
+| package 위치 | `packages/gate-x/` | 모노리포 내 독립 패키지 (pnpm workspace) |
+| 라우트 prefix | `/api/gate/` | Gate-X 전용 네임스페이스 |
+
+## 4. D1 마이그레이션 계획
+
+Gate-X 전용 D1에 필요한 테이블 (FX modules/gate/ 사용 테이블 기반):
+
+| 테이블 | 원본 마이그레이션 | 용도 |
+|--------|-------------------|------|
+| ax_evaluations | 0052 | 평가 (핵심) |
+| ax_evaluation_history | 0054 | 평가 이력 |
+| decisions | 0069 | Go/Hold/Drop 의사결정 |
+| gate_packages | 0071 | 게이트 패키지 |
+| evaluation_reports | 0085 | 평가 리포트 |
+| expert_meetings | 0086 | 전문가 미팅 |
+| validation_history | 0086 | 검증 이력 |
+| ax_team_reviews | 0101 | 팀 리뷰 |
+| biz_items | (참조) | decision-service가 조회 — 최소 뷰 또는 stub |
+| pipeline_stages | (참조) | decision-service가 조회 — 최소 뷰 또는 stub |
+
+## 5. 실행 순서
+
+| # | 작업 | 예상 파일 수 |
+|---|------|-------------|
+| 1 | packages/gate-x/ scaffold 생성 (package.json, tsconfig, wrangler.toml, vitest) | 5 |
+| 2 | src/app.ts + src/env.ts + src/index.ts 기본 구조 | 3 |
+| 3 | src/middleware/tenant.ts 테넌트 가드 | 1 |
+| 4 | D1 마이그레이션 파일 (0001_initial.sql) | 1 |
+| 5 | schemas/ 6파일 복사 + import 경로 수정 | 6 |
+| 6 | services/ 7파일 이전 + 크로스 의존 해소 (adapter) | 9 (7 + 2 adapter) |
+| 7 | routes/ 7파일 이전 + import 경로 재작성 | 7 |
+| 8 | app.ts에 라우트 등록 | (수정) |
+| 9 | 단위 테스트 | 3+ |
+| **합계** | | **~35 파일** |
+
+## 6. 리스크
+
+| 리스크 | 확률 | 영향 | 대응 |
+|--------|------|------|------|
+| 크로스 모듈 의존이 예상보다 깊음 | 중 | 중 | Adapter에서 stub 반환, P1에서 이벤트 연동 완성 |
+| D1 테이블 스키마 복잡도 | 하 | 하 | FX 마이그레이션 SQL 재사용 |
+| pnpm workspace 설정 | 하 | 하 | 기존 패키지 구조 참고 |
+
+## 7. 성공 기준
+
+- [ ] `packages/gate-x/` 독립 패키지 존재
+- [ ] `pnpm typecheck` 성공 (gate-x 포함)
+- [ ] D1 마이그레이션 SQL 파일 생성
+- [ ] 7 routes + 7 services + 6 schemas 이전 완료
+- [ ] health check 엔드포인트 동작 (GET /api/health)
+- [ ] 크로스 모듈 import 0개 (gate → portal/launch 직접 참조 없음)
+- [ ] 단위 테스트 통과

--- a/docs/02-design/features/sprint-189.design.md
+++ b/docs/02-design/features/sprint-189.design.md
@@ -1,0 +1,208 @@
+---
+code: FX-DSGN-S189
+title: "Sprint 189 Design — Gate-X 독립 Workers scaffold + Gate 모듈 추출"
+version: 1.0
+status: Active
+category: DSGN
+sprint: 189
+f-items: [F402, F403]
+created: 2026-04-07
+updated: 2026-04-07
+author: Sinclair + Claude
+---
+
+# Sprint 189 Design — Gate-X 독립 Workers scaffold + Gate 모듈 추출
+
+## 1. 전체 구조
+
+```
+packages/gate-x/
+├── package.json                          # @foundry-x/gate-x
+├── tsconfig.json
+├── vitest.config.ts
+├── wrangler.toml                         # gate-x-api Workers
+└── src/
+    ├── index.ts                          # Workers entry (export default app)
+    ├── app.ts                            # Hono app + harness-kit 미들웨어
+    ├── env.ts                            # GateEnv (extends HarnessEnv)
+    ├── middleware/
+    │   └── tenant.ts                     # tenantGuard (harness-kit JWT 기반)
+    ├── routes/
+    │   ├── index.ts                      # 라우트 집약
+    │   ├── ax-bd-evaluations.ts          # 7 endpoints
+    │   ├── decisions.ts                  # 5 endpoints
+    │   ├── evaluation-report.ts          # 3 endpoints
+    │   ├── gate-package.ts               # 5 endpoints
+    │   ├── team-reviews.ts               # 4 endpoints
+    │   ├── validation-meetings.ts        # 5 endpoints
+    │   └── validation-tier.ts            # 3 endpoints
+    ├── services/
+    │   ├── evaluation-service.ts
+    │   ├── evaluation-criteria.ts
+    │   ├── evaluation-report-service.ts
+    │   ├── decision-service.ts           # 크로스 의존 해소 (어댑터 주입)
+    │   ├── gate-package-service.ts
+    │   ├── meeting-service.ts
+    │   ├── validation-service.ts
+    │   └── adapters/
+    │       ├── pipeline-adapter.ts       # PipelineService → D1 직접 쿼리
+    │       └── notification-adapter.ts   # NotificationService → D1EventBus
+    ├── schemas/
+    │   ├── decision.schema.ts
+    │   ├── evaluation-report.schema.ts
+    │   ├── evaluation.schema.ts
+    │   ├── gate-package.schema.ts
+    │   ├── team-review-schema.ts
+    │   └── validation.schema.ts
+    ├── types/
+    │   └── agent-execution.ts            # AgentExecution 타입 로컬 복사 (core 의존 제거)
+    └── db/
+        └── migrations/
+            └── 0001_initial.sql          # Gate-X 전용 D1 테이블 9개
+```
+
+## 2. package.json
+
+```json
+{
+  "name": "@foundry-x/gate-x",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "dev": "wrangler dev",
+    "build": "tsc",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src/"
+  },
+  "dependencies": {
+    "@foundry-x/harness-kit": "workspace:*",
+    "@hono/zod-openapi": "^0.18.0",
+    "hono": "^4.0.0",
+    "zod": "^3.22.0"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.0.0",
+    "typescript": "^5.9.3",
+    "vitest": "^3.0.0"
+  }
+}
+```
+
+## 3. wrangler.toml
+
+```toml
+name = "gate-x-api"
+account_id = "b6c06059b413892a92f150e5ca496236"
+main = "src/index.ts"
+compatibility_date = "2026-03-17"
+compatibility_flags = ["nodejs_compat"]
+
+[[d1_databases]]
+binding = "DB"
+database_name = "gate-x-db"
+database_id = "TBD"
+migrations_dir = "src/db/migrations"
+
+[vars]
+ENVIRONMENT = "production"
+```
+
+## 4. 크로스 모듈 의존 해소 전략
+
+| 원래 의존 | 해소 방법 |
+|----------|----------|
+| `KpiService` (portal) | `ax-bd-evaluations.ts` KPI CRUD를 gate-x `evaluation.schema` 내 kpi 타입 + `evaluation-service` 확장 |
+| `PipelineService` (launch) | `pipeline-adapter.ts` — D1 `pipeline_stages` 직접 쿼리 (Gate-X DB에 테이블 포함) |
+| `NotificationService` (portal) | `notification-adapter.ts` — `D1EventBus.publish("decision.made", ...)` 이벤트 발행 |
+| `AgentExecutionRequest/Result` (core) | `types/agent-execution.ts` 로컬 복사 (동일 타입, 단순 interface) |
+
+### PipelineAdapter (핵심)
+```typescript
+// gate-x/src/services/adapters/pipeline-adapter.ts
+export class PipelineAdapter {
+  constructor(private db: D1Database) {}
+
+  async getCurrentStage(bizItemId: string) {
+    return this.db.prepare(
+      `SELECT stage FROM pipeline_stages WHERE biz_item_id = ? AND exited_at IS NULL ORDER BY entered_at DESC LIMIT 1`
+    ).bind(bizItemId).first<{ stage: string }>();
+  }
+
+  async advanceStage(bizItemId: string, orgId: string, stage: string, userId: string, reason: string) {
+    const now = "datetime('now')";
+    await this.db.prepare(
+      `UPDATE pipeline_stages SET exited_at = ${now} WHERE biz_item_id = ? AND exited_at IS NULL`
+    ).bind(bizItemId).run();
+    await this.db.prepare(
+      `INSERT INTO pipeline_stages (id, biz_item_id, org_id, stage, entered_by, entered_at, reason) VALUES (?,?,?,?,?,${now},?)`
+    ).bind(crypto.randomUUID(), bizItemId, orgId, stage, userId, reason).run();
+  }
+}
+```
+
+### NotificationAdapter (핵심)
+```typescript
+// gate-x/src/services/adapters/notification-adapter.ts
+import { D1EventBus } from "@foundry-x/harness-kit/events";
+export class NotificationAdapter {
+  private bus: D1EventBus;
+  constructor(db: D1Database) { this.bus = new D1EventBus(db); }
+
+  async notify(params: { orgId: string; recipientId: string; type: string; bizItemId: string; title: string; body: string; actorId: string; }) {
+    await this.bus.publish({ type: "notification.requested", payload: params, source: "gate-x" });
+  }
+}
+```
+
+## 5. D1 마이그레이션 (0001_initial.sql)
+
+Gate-X 전용 테이블 9개:
+- `ax_evaluations` — 평가 (핵심)
+- `ax_evaluation_history` — 평가 이력
+- `decisions` — Go/Hold/Drop 의사결정
+- `gate_packages` — 게이트 패키지
+- `evaluation_reports` — 평가 리포트
+- `expert_meetings` — 전문가 미팅
+- `validation_history` — 검증 이력
+- `ax_team_reviews` — 팀 리뷰
+- `pipeline_stages` — 단계 추적 (biz_items stub 포함)
+- `biz_items` — Decision용 최소 참조 테이블
+
+## 6. Worker 매핑 (구현 병렬화)
+
+| Worker | 담당 | 파일 |
+|--------|------|------|
+| W1 | scaffold + app/env/index + D1 migration | package.json, tsconfig.json, wrangler.toml, vitest.config.ts, src/index.ts, src/app.ts, src/env.ts, src/middleware/tenant.ts, src/db/migrations/0001_initial.sql |
+| W2 | schemas + adapters | src/schemas/*(6파일), src/services/adapters/*(2파일), src/types/agent-execution.ts |
+| W3 | services | src/services/*(7파일) |
+| W4 | routes + tests | src/routes/*(8파일), src/routes/index.ts, src/test/*.test.ts |
+
+## 7. app.ts 설계
+
+```typescript
+// harness-kit 미들웨어 체인:
+// CORS → Auth(JWT) → tenantGuard → routes
+const config: HarnessConfig = {
+  serviceName: "gate-x",
+  serviceId: "gate-x",
+  corsOrigins: ["https://fx.minu.best", "http://localhost:3000"],
+  publicPaths: ["/api/health"],
+};
+app.use("*", createCorsMiddleware(config));
+app.use("/api/*", createAuthMiddleware(config));
+app.use("/api/*", tenantGuard);
+```
+
+## 8. 성공 기준 ↔ 구현 매핑
+
+| 성공 기준 | 구현 위치 |
+|----------|----------|
+| packages/gate-x/ 독립 패키지 존재 | §1 전체 구조 |
+| pnpm typecheck 성공 | tsconfig.json + strict |
+| D1 마이그레이션 SQL 파일 생성 | src/db/migrations/0001_initial.sql |
+| 7 routes + 7 services + 6 schemas | §1 구조 |
+| health check (GET /api/health) | app.ts health endpoint |
+| 크로스 모듈 import 0개 | §4 해소 전략 |
+| 단위 테스트 통과 | src/test/*.test.ts |

--- a/packages/gate-x/package.json
+++ b/packages/gate-x/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@foundry-x/gate-x",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "dev": "wrangler dev",
+    "build": "tsc",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src/"
+  },
+  "dependencies": {
+    "@foundry-x/harness-kit": "workspace:*",
+    "@hono/zod-openapi": "^0.18.4",
+    "hono": "^4.0.0",
+    "zod": "^3.22.0"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20241218.0",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.9.3",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/gate-x/src/app.ts
+++ b/packages/gate-x/src/app.ts
@@ -1,0 +1,50 @@
+import { Hono } from "hono";
+import {
+  createAuthMiddleware,
+  createCorsMiddleware,
+  errorHandler,
+} from "@foundry-x/harness-kit";
+import type { HarnessConfig } from "@foundry-x/harness-kit";
+import type { GateEnv } from "./env.js";
+import type { TenantVariables } from "./middleware/tenant.js";
+import { tenantGuard } from "./middleware/tenant.js";
+import {
+  axBdEvaluationsRoute,
+  decisionsRoute,
+  evaluationReportRoute,
+  gatePackageRoute,
+  teamReviewsRoute,
+  validationMeetingsRoute,
+  validationTierRoute,
+} from "./routes/index.js";
+
+const config: HarnessConfig = {
+  serviceName: "gate-x",
+  serviceId: "gate-x",
+  corsOrigins: ["https://fx.minu.best", "http://localhost:3000"],
+  publicPaths: ["/api/health"],
+};
+
+export const app = new Hono<{ Bindings: GateEnv; Variables: TenantVariables }>();
+
+// Middleware chain: CORS → Auth → TenantGuard → Routes
+app.use("*", createCorsMiddleware(config));
+app.onError(errorHandler);
+app.use("/api/*", createAuthMiddleware(config));
+app.use("/api/*", tenantGuard as Parameters<typeof app.use>[1]);
+
+// Health check (public)
+app.get("/api/health", (c) => {
+  return c.json({ service: "gate-x", status: "ok", ts: new Date().toISOString() });
+});
+
+// Routes
+app.route("/api/gate", axBdEvaluationsRoute);
+app.route("/api/gate", decisionsRoute);
+app.route("/api/gate", evaluationReportRoute);
+app.route("/api/gate", gatePackageRoute);
+app.route("/api/gate", teamReviewsRoute);
+app.route("/api/gate", validationMeetingsRoute);
+app.route("/api/gate", validationTierRoute);
+
+export default app;

--- a/packages/gate-x/src/db/migrations/0001_initial.sql
+++ b/packages/gate-x/src/db/migrations/0001_initial.sql
@@ -1,0 +1,166 @@
+-- Gate-X 독립 서비스 초기 스키마 (Sprint 189, F402)
+-- gate-x-db 전용 테이블 10개
+
+-- 1. biz_items (최소 참조용 — Decision/Validation이 참조)
+CREATE TABLE IF NOT EXISTS biz_items (
+  id TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active',
+  created_by TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- 2. pipeline_stages (단계 추적 + validation_tier 포함)
+CREATE TABLE IF NOT EXISTS pipeline_stages (
+  id TEXT PRIMARY KEY,
+  biz_item_id TEXT NOT NULL REFERENCES biz_items(id),
+  org_id TEXT NOT NULL,
+  stage TEXT NOT NULL,
+  entered_by TEXT NOT NULL,
+  entered_at TEXT NOT NULL DEFAULT (datetime('now')),
+  exited_at TEXT,
+  reason TEXT,
+  validation_tier TEXT DEFAULT 'none'
+);
+CREATE INDEX IF NOT EXISTS idx_pipeline_active ON pipeline_stages(biz_item_id, exited_at);
+
+-- 3. ax_evaluations (평가 핵심)
+CREATE TABLE IF NOT EXISTS ax_evaluations (
+  id TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL,
+  idea_id TEXT,
+  bmc_id TEXT,
+  title TEXT NOT NULL,
+  description TEXT,
+  owner_id TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'draft',
+  decision_reason TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_ax_evaluations_org ON ax_evaluations(org_id, status);
+
+-- 4. ax_evaluation_kpis (KPI — portal KpiService 대체)
+CREATE TABLE IF NOT EXISTS ax_evaluation_kpis (
+  id TEXT PRIMARY KEY,
+  evaluation_id TEXT NOT NULL REFERENCES ax_evaluations(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  category TEXT NOT NULL,
+  target REAL NOT NULL DEFAULT 0,
+  actual REAL,
+  unit TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- 5. ax_evaluation_history (평가 이력)
+CREATE TABLE IF NOT EXISTS ax_evaluation_history (
+  id TEXT PRIMARY KEY,
+  evaluation_id TEXT NOT NULL REFERENCES ax_evaluations(id) ON DELETE CASCADE,
+  org_id TEXT NOT NULL,
+  from_status TEXT NOT NULL,
+  to_status TEXT NOT NULL,
+  reason TEXT,
+  changed_by TEXT NOT NULL,
+  changed_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- 6. decisions (Go/Hold/Drop 의사결정)
+CREATE TABLE IF NOT EXISTS decisions (
+  id TEXT PRIMARY KEY,
+  biz_item_id TEXT NOT NULL,
+  org_id TEXT NOT NULL,
+  decision TEXT NOT NULL CHECK(decision IN ('GO','HOLD','DROP')),
+  stage TEXT NOT NULL,
+  comment TEXT NOT NULL,
+  decided_by TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_decisions_org ON decisions(org_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_decisions_item ON decisions(biz_item_id);
+
+-- 7. gate_packages (ORB/PRB 패키지)
+CREATE TABLE IF NOT EXISTS gate_packages (
+  id TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL,
+  biz_item_id TEXT NOT NULL,
+  gate_type TEXT NOT NULL CHECK(gate_type IN ('orb','prb')),
+  items TEXT NOT NULL DEFAULT '[]',
+  status TEXT NOT NULL DEFAULT 'draft',
+  download_url TEXT,
+  created_by TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- 8. evaluation_reports (평가 결과서)
+CREATE TABLE IF NOT EXISTS evaluation_reports (
+  id TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL,
+  biz_item_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  summary TEXT,
+  skill_scores TEXT NOT NULL DEFAULT '{}',
+  traffic_light TEXT NOT NULL DEFAULT 'red',
+  traffic_light_history TEXT NOT NULL DEFAULT '[]',
+  recommendation TEXT,
+  generated_by TEXT NOT NULL DEFAULT 'system',
+  version INTEGER NOT NULL DEFAULT 1,
+  created_by TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_eval_reports_org ON evaluation_reports(org_id, biz_item_id);
+
+-- 9. expert_meetings (전문가 미팅)
+CREATE TABLE IF NOT EXISTS expert_meetings (
+  id TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL,
+  biz_item_id TEXT NOT NULL,
+  type TEXT NOT NULL DEFAULT 'interview',
+  title TEXT NOT NULL,
+  scheduled_at TEXT NOT NULL,
+  attendees TEXT NOT NULL DEFAULT '[]',
+  location TEXT,
+  notes TEXT,
+  status TEXT NOT NULL DEFAULT 'scheduled',
+  created_by TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- 10. validation_history (검증 이력)
+CREATE TABLE IF NOT EXISTS validation_history (
+  id TEXT PRIMARY KEY,
+  biz_item_id TEXT NOT NULL,
+  org_id TEXT NOT NULL,
+  tier TEXT NOT NULL,
+  decision TEXT NOT NULL,
+  comment TEXT NOT NULL DEFAULT '',
+  decided_by TEXT NOT NULL,
+  decided_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- 11. ax_team_reviews (팀 리뷰)
+CREATE TABLE IF NOT EXISTS ax_team_reviews (
+  id TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL,
+  biz_item_id TEXT NOT NULL,
+  reviewer_id TEXT NOT NULL,
+  decision TEXT NOT NULL CHECK(decision IN ('Go','Hold','Drop')),
+  comment TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(org_id, biz_item_id, reviewer_id)
+);
+
+-- 12. domain_events (D1EventBus 이벤트 저장소)
+CREATE TABLE IF NOT EXISTS domain_events (
+  id TEXT PRIMARY KEY,
+  type TEXT NOT NULL,
+  payload TEXT NOT NULL DEFAULT '{}',
+  source TEXT NOT NULL DEFAULT 'gate-x',
+  processed INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_domain_events_unprocessed ON domain_events(processed, created_at);

--- a/packages/gate-x/src/env.ts
+++ b/packages/gate-x/src/env.ts
@@ -1,0 +1,10 @@
+import type { HarnessEnv } from "@foundry-x/harness-kit";
+
+/** Gate-X Workers 환경 바인딩 */
+export interface GateEnv extends HarnessEnv {
+  DB: D1Database;
+  JWT_SECRET: string;
+  CACHE?: KVNamespace;
+  ANTHROPIC_API_KEY?: string;
+  ENVIRONMENT?: string;
+}

--- a/packages/gate-x/src/index.ts
+++ b/packages/gate-x/src/index.ts
@@ -1,0 +1,3 @@
+import app from "./app.js";
+
+export default app;

--- a/packages/gate-x/src/middleware/tenant.ts
+++ b/packages/gate-x/src/middleware/tenant.ts
@@ -1,0 +1,35 @@
+import type { Context, Next } from "hono";
+import type { GateEnv } from "../env.js";
+
+export interface TenantVariables {
+  orgId: string;
+  orgRole: string;
+  userId: string;
+  jwtPayload: Record<string, unknown>;
+}
+
+const PUBLIC_PATHS = ["/api/health"];
+
+/** tenantGuard — JWT payload에서 orgId 추출, gate-x 전용 */
+export async function tenantGuard(
+  c: Context<{ Bindings: GateEnv; Variables: TenantVariables }>,
+  next: Next,
+) {
+  if (PUBLIC_PATHS.some((p) => c.req.path === p)) {
+    return next();
+  }
+
+  const payload = (c.get("jwtPayload") as unknown) as
+    | { sub?: string; orgId?: string; orgRole?: string }
+    | undefined;
+
+  if (!payload?.orgId) {
+    return c.json({ error: "Organization context required" }, 403);
+  }
+
+  c.set("orgId", payload.orgId);
+  c.set("orgRole", payload.orgRole ?? "member");
+  c.set("userId", payload.sub ?? "");
+
+  return next();
+}

--- a/packages/gate-x/src/routes/ax-bd-evaluations.ts
+++ b/packages/gate-x/src/routes/ax-bd-evaluations.ts
@@ -1,0 +1,97 @@
+import { Hono } from "hono";
+import type { GateEnv } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import { EvaluationService } from "../services/evaluation-service.js";
+import {
+  CreateEvaluationSchema,
+  UpdateEvalStatusSchema,
+  CreateKpiSchema,
+  UpdateKpiSchema,
+} from "../schemas/evaluation.schema.js";
+
+export const axBdEvaluationsRoute = new Hono<{
+  Bindings: GateEnv;
+  Variables: TenantVariables;
+}>();
+
+axBdEvaluationsRoute.post("/ax-bd/evaluations", async (c) => {
+  const body = await c.req.json();
+  const parsed = CreateEvaluationSchema.safeParse(body);
+  if (!parsed.success) return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  const svc = new EvaluationService(c.env.DB);
+  const evaluation = await svc.create(c.get("orgId"), c.get("userId"), parsed.data);
+  return c.json(evaluation, 201);
+});
+
+axBdEvaluationsRoute.get("/ax-bd/evaluations", async (c) => {
+  const { status, limit, offset } = c.req.query();
+  const svc = new EvaluationService(c.env.DB);
+  const result = await svc.list(c.get("orgId"), { status: status || undefined, limit: Number(limit) || 20, offset: Number(offset) || 0 });
+  return c.json(result);
+});
+
+axBdEvaluationsRoute.get("/ax-bd/evaluations/portfolio", async (c) => {
+  const svc = new EvaluationService(c.env.DB);
+  return c.json(await svc.getPortfolio(c.get("orgId")));
+});
+
+axBdEvaluationsRoute.get("/ax-bd/evaluations/:evalId", async (c) => {
+  const svc = new EvaluationService(c.env.DB);
+  const evaluation = await svc.getById(c.req.param("evalId"), c.get("orgId"));
+  if (!evaluation) return c.json({ error: "Evaluation not found" }, 404);
+  return c.json(evaluation);
+});
+
+axBdEvaluationsRoute.patch("/ax-bd/evaluations/:evalId", async (c) => {
+  const body = await c.req.json();
+  const parsed = UpdateEvalStatusSchema.safeParse(body);
+  if (!parsed.success) return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  const svc = new EvaluationService(c.env.DB);
+  try {
+    const evaluation = await svc.updateStatus(c.req.param("evalId"), c.get("orgId"), c.get("userId"), parsed.data.status, parsed.data.reason);
+    return c.json(evaluation);
+  } catch (e) {
+    const msg = (e as Error).message;
+    if (msg === "Evaluation not found") return c.json({ error: msg }, 404);
+    if (msg.startsWith("Invalid status transition")) return c.json({ error: msg }, 400);
+    throw e;
+  }
+});
+
+axBdEvaluationsRoute.post("/ax-bd/evaluations/:evalId/kpis", async (c) => {
+  const body = await c.req.json();
+  const parsed = CreateKpiSchema.safeParse(body);
+  if (!parsed.success) return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  const svc = new EvaluationService(c.env.DB);
+  const evaluation = await svc.getById(c.req.param("evalId"), c.get("orgId"));
+  if (!evaluation) return c.json({ error: "Evaluation not found" }, 404);
+  const kpi = await svc.createKpi(c.req.param("evalId"), parsed.data);
+  return c.json(kpi, 201);
+});
+
+axBdEvaluationsRoute.get("/ax-bd/evaluations/:evalId/kpis", async (c) => {
+  const svc = new EvaluationService(c.env.DB);
+  const evaluation = await svc.getById(c.req.param("evalId"), c.get("orgId"));
+  if (!evaluation) return c.json({ error: "Evaluation not found" }, 404);
+  return c.json(await svc.listKpis(c.req.param("evalId")));
+});
+
+axBdEvaluationsRoute.patch("/ax-bd/evaluations/:evalId/kpis/:kpiId", async (c) => {
+  const body = await c.req.json();
+  const parsed = UpdateKpiSchema.safeParse(body);
+  if (!parsed.success) return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  const svc = new EvaluationService(c.env.DB);
+  const evaluation = await svc.getById(c.req.param("evalId"), c.get("orgId"));
+  if (!evaluation) return c.json({ error: "Evaluation not found" }, 404);
+  try {
+    return c.json(await svc.updateKpi(c.req.param("kpiId"), c.req.param("evalId"), parsed.data));
+  } catch (e) {
+    if ((e as Error).message === "KPI not found") return c.json({ error: "KPI not found" }, 404);
+    throw e;
+  }
+});
+
+axBdEvaluationsRoute.get("/ax-bd/evaluations/:evalId/history", async (c) => {
+  const svc = new EvaluationService(c.env.DB);
+  return c.json(await svc.getHistory(c.req.param("evalId"), c.get("orgId")));
+});

--- a/packages/gate-x/src/routes/decisions.ts
+++ b/packages/gate-x/src/routes/decisions.ts
@@ -1,0 +1,33 @@
+import { Hono } from "hono";
+import type { GateEnv } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import { DecisionService } from "../services/decision-service.js";
+import { CreateDecisionSchema, DecisionFilterSchema } from "../schemas/decision.schema.js";
+
+export const decisionsRoute = new Hono<{ Bindings: GateEnv; Variables: TenantVariables }>();
+
+decisionsRoute.post("/decisions", async (c) => {
+  const body = await c.req.json();
+  const parsed = CreateDecisionSchema.safeParse(body);
+  if (!parsed.success) return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  const svc = new DecisionService(c.env.DB);
+  const decision = await svc.create({ bizItemId: parsed.data.bizItemId, orgId: c.get("orgId"), decision: parsed.data.decision, comment: parsed.data.comment, decidedBy: c.get("userId") });
+  return c.json(decision, 201);
+});
+
+decisionsRoute.get("/decisions/stats", async (c) => {
+  return c.json(await new DecisionService(c.env.DB).getStats(c.get("orgId")));
+});
+
+decisionsRoute.get("/decisions/pending", async (c) => {
+  return c.json(await new DecisionService(c.env.DB).getPending(c.get("orgId")));
+});
+
+decisionsRoute.get("/decisions", async (c) => {
+  const parsed = DecisionFilterSchema.safeParse(c.req.query());
+  if (!parsed.success) return c.json({ error: "Invalid filters", details: parsed.error.flatten() }, 400);
+  const svc = new DecisionService(c.env.DB);
+  const bizItemId = c.req.query("bizItemId");
+  if (bizItemId) return c.json(await svc.listByItem(bizItemId, c.get("orgId")));
+  return c.json(await svc.listByOrg(c.get("orgId"), { limit: parsed.data.limit, offset: parsed.data.offset }));
+});

--- a/packages/gate-x/src/routes/evaluation-report.ts
+++ b/packages/gate-x/src/routes/evaluation-report.ts
@@ -1,0 +1,27 @@
+import { Hono } from "hono";
+import type { GateEnv } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import { EvaluationReportService } from "../services/evaluation-report-service.js";
+import { GenerateReportSchema, ReportListQuerySchema } from "../schemas/evaluation-report.schema.js";
+
+export const evaluationReportRoute = new Hono<{ Bindings: GateEnv; Variables: TenantVariables }>();
+
+evaluationReportRoute.post("/ax-bd/evaluation-reports/generate", async (c) => {
+  const body = await c.req.json();
+  const parsed = GenerateReportSchema.safeParse(body);
+  if (!parsed.success) return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  const report = await new EvaluationReportService(c.env.DB).generate(c.get("orgId"), c.get("userId"), parsed.data);
+  return c.json(report, 201);
+});
+
+evaluationReportRoute.get("/ax-bd/evaluation-reports", async (c) => {
+  const parsed = ReportListQuerySchema.safeParse(c.req.query());
+  if (!parsed.success) return c.json({ error: "Invalid query", details: parsed.error.flatten() }, 400);
+  return c.json(await new EvaluationReportService(c.env.DB).list(c.get("orgId"), parsed.data));
+});
+
+evaluationReportRoute.get("/ax-bd/evaluation-reports/:id", async (c) => {
+  const report = await new EvaluationReportService(c.env.DB).getById(c.get("orgId"), c.req.param("id"));
+  if (!report) return c.json({ error: "Evaluation report not found" }, 404);
+  return c.json(report);
+});

--- a/packages/gate-x/src/routes/gate-package.ts
+++ b/packages/gate-x/src/routes/gate-package.ts
@@ -1,0 +1,41 @@
+import { Hono } from "hono";
+import type { GateEnv } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import { GatePackageService, MissingArtifactsError } from "../services/gate-package-service.js";
+import { CreateGatePackageSchema, UpdateGateStatusSchema } from "../schemas/gate-package.schema.js";
+
+export const gatePackageRoute = new Hono<{ Bindings: GateEnv; Variables: TenantVariables }>();
+
+gatePackageRoute.post("/gate-package/:bizItemId", async (c) => {
+  const body = await c.req.json();
+  const parsed = CreateGatePackageSchema.safeParse(body);
+  if (!parsed.success) return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  try {
+    const pkg = await new GatePackageService(c.env.DB).create({ bizItemId: c.req.param("bizItemId"), orgId: c.get("orgId"), gateType: parsed.data.gateType, createdBy: c.get("userId") });
+    return c.json(pkg, 201);
+  } catch (e) {
+    if (e instanceof MissingArtifactsError) return c.json({ error: `${e.missing.join("와 ")}가 필요해요`, missing: e.missing }, 422);
+    throw e;
+  }
+});
+
+gatePackageRoute.get("/gate-package/:bizItemId/download", async (c) => {
+  const download = await new GatePackageService(c.env.DB).getDownload(c.req.param("bizItemId"), c.get("orgId"));
+  if (!download) return c.json({ error: "게이트 패키지를 찾을 수 없어요" }, 404);
+  return c.json(download);
+});
+
+gatePackageRoute.get("/gate-package/:bizItemId", async (c) => {
+  const pkg = await new GatePackageService(c.env.DB).get(c.req.param("bizItemId"), c.get("orgId"));
+  if (!pkg) return c.json({ error: "게이트 패키지를 찾을 수 없어요" }, 404);
+  return c.json(pkg);
+});
+
+gatePackageRoute.patch("/gate-package/:bizItemId/status", async (c) => {
+  const body = await c.req.json();
+  const parsed = UpdateGateStatusSchema.safeParse(body);
+  if (!parsed.success) return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  const pkg = await new GatePackageService(c.env.DB).updateStatus(c.req.param("bizItemId"), c.get("orgId"), parsed.data.status);
+  if (!pkg) return c.json({ error: "게이트 패키지를 찾을 수 없어요" }, 404);
+  return c.json(pkg);
+});

--- a/packages/gate-x/src/routes/index.ts
+++ b/packages/gate-x/src/routes/index.ts
@@ -1,0 +1,7 @@
+export { axBdEvaluationsRoute } from "./ax-bd-evaluations.js";
+export { decisionsRoute } from "./decisions.js";
+export { evaluationReportRoute } from "./evaluation-report.js";
+export { gatePackageRoute } from "./gate-package.js";
+export { teamReviewsRoute } from "./team-reviews.js";
+export { validationMeetingsRoute } from "./validation-meetings.js";
+export { validationTierRoute } from "./validation-tier.js";

--- a/packages/gate-x/src/routes/team-reviews.ts
+++ b/packages/gate-x/src/routes/team-reviews.ts
@@ -1,0 +1,38 @@
+import { Hono } from "hono";
+import type { GateEnv } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import { SubmitTeamReviewSchema, TeamDecideSchema } from "../schemas/team-review-schema.js";
+
+export const teamReviewsRoute = new Hono<{ Bindings: GateEnv; Variables: TenantVariables }>();
+
+teamReviewsRoute.get("/ax-bd/team-reviews/:itemId", async (c) => {
+  const result = await c.env.DB.prepare("SELECT * FROM ax_team_reviews WHERE biz_item_id = ? ORDER BY created_at DESC").bind(c.req.param("itemId")).all();
+  return c.json({ data: result.results });
+});
+
+teamReviewsRoute.get("/ax-bd/team-reviews/:itemId/summary", async (c) => {
+  const result = await c.env.DB.prepare("SELECT decision, COUNT(*) as count FROM ax_team_reviews WHERE biz_item_id = ? GROUP BY decision").bind(c.req.param("itemId")).all<{ decision: string; count: number }>();
+  const summary: Record<string, number> = { Go: 0, Hold: 0, Drop: 0 };
+  for (const row of result.results) { summary[row.decision] = row.count; }
+  const total = (summary["Go"] ?? 0) + (summary["Hold"] ?? 0) + (summary["Drop"] ?? 0);
+  return c.json({ data: { ...summary, total } });
+});
+
+teamReviewsRoute.post("/ax-bd/team-reviews/:itemId", async (c) => {
+  const body = await c.req.json();
+  const parsed = SubmitTeamReviewSchema.safeParse(body);
+  if (!parsed.success) return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  const id = crypto.randomUUID().replace(/-/g, "");
+  await c.env.DB.prepare(`INSERT INTO ax_team_reviews (id, org_id, biz_item_id, reviewer_id, decision, comment) VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT(org_id, biz_item_id, reviewer_id) DO UPDATE SET decision = excluded.decision, comment = excluded.comment, created_at = datetime('now')`)
+    .bind(id, c.get("orgId"), c.req.param("itemId"), c.get("userId"), parsed.data.decision, parsed.data.comment)
+    .run();
+  return c.json({ message: "Vote submitted" }, 201);
+});
+
+teamReviewsRoute.post("/ax-bd/team-reviews/:itemId/decide", async (c) => {
+  const body = await c.req.json();
+  const parsed = TeamDecideSchema.safeParse(body);
+  if (!parsed.success) return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  const { finalDecision, reason } = parsed.data;
+  return c.json({ data: { itemId: c.req.param("itemId"), finalDecision, reason, decidedBy: c.get("userId"), decidedAt: new Date().toISOString() } });
+});

--- a/packages/gate-x/src/routes/validation-meetings.ts
+++ b/packages/gate-x/src/routes/validation-meetings.ts
@@ -1,0 +1,41 @@
+import { Hono } from "hono";
+import type { GateEnv } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import { MeetingService } from "../services/meeting-service.js";
+import { CreateMeetingSchema, UpdateMeetingSchema, MeetingFilterSchema } from "../schemas/validation.schema.js";
+
+export const validationMeetingsRoute = new Hono<{ Bindings: GateEnv; Variables: TenantVariables }>();
+
+validationMeetingsRoute.post("/validation/meetings", async (c) => {
+  const body = await c.req.json();
+  const parsed = CreateMeetingSchema.safeParse(body);
+  if (!parsed.success) return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  return c.json(await new MeetingService(c.env.DB).create(parsed.data, c.get("orgId"), c.get("userId")), 201);
+});
+
+validationMeetingsRoute.get("/validation/meetings", async (c) => {
+  const parsed = MeetingFilterSchema.safeParse(c.req.query());
+  if (!parsed.success) return c.json({ error: "Invalid filters", details: parsed.error.flatten() }, 400);
+  return c.json(await new MeetingService(c.env.DB).list(c.get("orgId"), parsed.data));
+});
+
+validationMeetingsRoute.get("/validation/meetings/:id", async (c) => {
+  const meeting = await new MeetingService(c.env.DB).getById(c.req.param("id"), c.get("orgId"));
+  if (!meeting) return c.json({ error: "Meeting not found" }, 404);
+  return c.json(meeting);
+});
+
+validationMeetingsRoute.patch("/validation/meetings/:id", async (c) => {
+  const body = await c.req.json();
+  const parsed = UpdateMeetingSchema.safeParse(body);
+  if (!parsed.success) return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  const updated = await new MeetingService(c.env.DB).update(c.req.param("id"), c.get("orgId"), parsed.data);
+  if (!updated) return c.json({ error: "Meeting not found" }, 404);
+  return c.json(updated);
+});
+
+validationMeetingsRoute.delete("/validation/meetings/:id", async (c) => {
+  const deleted = await new MeetingService(c.env.DB).delete(c.req.param("id"), c.get("orgId"));
+  if (!deleted) return c.json({ error: "Meeting not found" }, 404);
+  return c.json({ success: true });
+});

--- a/packages/gate-x/src/routes/validation-tier.ts
+++ b/packages/gate-x/src/routes/validation-tier.ts
@@ -1,0 +1,49 @@
+import { Hono } from "hono";
+import type { GateEnv } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import { ValidationService, ValidationTierError } from "../services/validation-service.js";
+import { SubmitValidationSchema, ValidationFilterSchema } from "../schemas/validation.schema.js";
+
+export const validationTierRoute = new Hono<{ Bindings: GateEnv; Variables: TenantVariables }>();
+
+validationTierRoute.post("/validation/division/submit", async (c) => {
+  const body = await c.req.json();
+  const parsed = SubmitValidationSchema.safeParse(body);
+  if (!parsed.success) return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  try {
+    return c.json(await new ValidationService(c.env.DB).submitDivisionReview(parsed.data.bizItemId, c.get("orgId"), parsed.data.decision, parsed.data.comment ?? "", c.get("userId")));
+  } catch (e) {
+    if (e instanceof ValidationTierError) return c.json({ error: e.message }, 400);
+    throw e;
+  }
+});
+
+validationTierRoute.post("/validation/company/submit", async (c) => {
+  const body = await c.req.json();
+  const parsed = SubmitValidationSchema.safeParse(body);
+  if (!parsed.success) return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  try {
+    return c.json(await new ValidationService(c.env.DB).submitCompanyReview(parsed.data.bizItemId, c.get("orgId"), parsed.data.decision, parsed.data.comment ?? "", c.get("userId")));
+  } catch (e) {
+    if (e instanceof ValidationTierError) return c.json({ error: e.message }, 400);
+    throw e;
+  }
+});
+
+validationTierRoute.get("/validation/division/items", async (c) => {
+  const parsed = ValidationFilterSchema.safeParse(c.req.query());
+  if (!parsed.success) return c.json({ error: "Invalid filters", details: parsed.error.flatten() }, 400);
+  return c.json(await new ValidationService(c.env.DB).getDivisionItems(c.get("orgId"), parsed.data));
+});
+
+validationTierRoute.get("/validation/company/items", async (c) => {
+  const parsed = ValidationFilterSchema.safeParse(c.req.query());
+  if (!parsed.success) return c.json({ error: "Invalid filters", details: parsed.error.flatten() }, 400);
+  return c.json(await new ValidationService(c.env.DB).getCompanyItems(c.get("orgId"), parsed.data));
+});
+
+validationTierRoute.get("/validation/status/:bizItemId", async (c) => {
+  const status = await new ValidationService(c.env.DB).getValidationStatus(c.req.param("bizItemId"), c.get("orgId"));
+  if (!status) return c.json({ error: "Item not found" }, 404);
+  return c.json(status);
+});

--- a/packages/gate-x/src/schemas/decision.schema.ts
+++ b/packages/gate-x/src/schemas/decision.schema.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const DecisionEnum = z.enum(["GO", "HOLD", "DROP"]);
+
+export type DecisionType = z.infer<typeof DecisionEnum>;
+
+export const CreateDecisionSchema = z.object({
+  bizItemId: z.string().min(1),
+  decision: DecisionEnum,
+  comment: z.string().min(1).max(2000),
+});
+
+export const DecisionFilterSchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+});

--- a/packages/gate-x/src/schemas/evaluation-report.schema.ts
+++ b/packages/gate-x/src/schemas/evaluation-report.schema.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+export const GenerateReportSchema = z.object({
+  bizItemId: z.string().min(1),
+  title: z.string().min(1).optional(),
+});
+
+export const ReportListQuerySchema = z.object({
+  bizItemId: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+export type GenerateReportInput = z.infer<typeof GenerateReportSchema>;
+export type ReportListQuery = z.infer<typeof ReportListQuerySchema>;
+
+export interface EvaluationReport {
+  id: string;
+  orgId: string;
+  bizItemId: string;
+  title: string;
+  summary: string | null;
+  skillScores: Record<string, { score: number; label: string; summary: string }>;
+  trafficLight: "green" | "yellow" | "red";
+  trafficLightHistory: Array<{ date: string; value: string }>;
+  recommendation: string | null;
+  generatedBy: string;
+  version: number;
+  createdBy: string;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/packages/gate-x/src/schemas/evaluation.schema.ts
+++ b/packages/gate-x/src/schemas/evaluation.schema.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+export const CreateEvaluationSchema = z.object({
+  title: z.string().min(1).max(200),
+  description: z.string().max(2000).optional(),
+  ideaId: z.string().optional(),
+  bmcId: z.string().optional(),
+});
+
+export const UpdateEvalStatusSchema = z.object({
+  status: z.enum(["draft", "active", "go", "kill", "hold"]),
+  reason: z.string().max(500).optional(),
+});
+
+export const CreateKpiSchema = z.object({
+  name: z.string().min(1).max(200),
+  category: z.enum(["market", "tech", "revenue", "risk", "custom"]),
+  target: z.number().min(0),
+  unit: z.string().max(20).optional(),
+});
+
+export const UpdateKpiSchema = z.object({
+  actual: z.number().nullable().optional(),
+  target: z.number().min(0).optional(),
+});

--- a/packages/gate-x/src/schemas/gate-package.schema.ts
+++ b/packages/gate-x/src/schemas/gate-package.schema.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const GateTypeEnum = z.enum(["orb", "prb"]);
+export type GateType = z.infer<typeof GateTypeEnum>;
+
+export const CreateGatePackageSchema = z.object({
+  gateType: GateTypeEnum,
+});
+
+export const GateStatusEnum = z.enum(["draft", "ready", "submitted"]);
+export type GateStatus = z.infer<typeof GateStatusEnum>;
+
+export const UpdateGateStatusSchema = z.object({
+  status: GateStatusEnum,
+});

--- a/packages/gate-x/src/schemas/team-review-schema.ts
+++ b/packages/gate-x/src/schemas/team-review-schema.ts
@@ -1,0 +1,19 @@
+/**
+ * Sprint 154: F342 팀 검토 투표 스키마
+ * Sprint 154+: F349 팀장 최종결정 스키마 추가
+ */
+import { z } from "zod";
+
+export const SubmitTeamReviewSchema = z.object({
+  decision: z.enum(["Go", "Hold", "Drop"]),
+  comment: z.string().nullable().default(null),
+});
+
+export type SubmitTeamReviewInput = z.infer<typeof SubmitTeamReviewSchema>;
+
+export const TeamDecideSchema = z.object({
+  finalDecision: z.enum(["Go", "Hold", "Drop"]),
+  reason: z.string().min(1, "결정 사유를 입력해주세요"),
+});
+
+export type TeamDecideInput = z.infer<typeof TeamDecideSchema>;

--- a/packages/gate-x/src/schemas/validation.schema.ts
+++ b/packages/gate-x/src/schemas/validation.schema.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+// F294: Validation tier
+export const VALIDATION_TIERS = [
+  "none", "division_pending", "division_approved", "company_pending", "company_approved",
+] as const;
+export type ValidationTier = (typeof VALIDATION_TIERS)[number];
+export const ValidationTierEnum = z.enum(VALIDATION_TIERS);
+
+export const SubmitValidationSchema = z.object({
+  bizItemId: z.string().min(1),
+  decision: z.enum(["approve", "reject"]),
+  comment: z.string().max(2000).optional(),
+});
+
+export const ValidationFilterSchema = z.object({
+  tier: ValidationTierEnum.optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+// F295: Meeting
+export const MEETING_TYPES = ["interview", "meeting", "workshop", "review"] as const;
+export type MeetingType = (typeof MEETING_TYPES)[number];
+
+export const MEETING_STATUSES = ["scheduled", "completed", "cancelled"] as const;
+export type MeetingStatus = (typeof MEETING_STATUSES)[number];
+
+export const CreateMeetingSchema = z.object({
+  bizItemId: z.string().min(1),
+  type: z.enum(MEETING_TYPES).default("interview"),
+  title: z.string().min(1).max(200),
+  scheduledAt: z.string(),
+  attendees: z.array(z.string()).default([]),
+  location: z.string().max(200).optional(),
+  notes: z.string().max(5000).optional(),
+});
+
+export const UpdateMeetingSchema = z.object({
+  title: z.string().min(1).max(200).optional(),
+  scheduledAt: z.string().optional(),
+  attendees: z.array(z.string()).optional(),
+  location: z.string().max(200).optional(),
+  notes: z.string().max(5000).optional(),
+  status: z.enum(MEETING_STATUSES).optional(),
+});
+
+export const MeetingFilterSchema = z.object({
+  bizItemId: z.string().optional(),
+  status: z.enum(MEETING_STATUSES).optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+});

--- a/packages/gate-x/src/services/adapters/notification-adapter.ts
+++ b/packages/gate-x/src/services/adapters/notification-adapter.ts
@@ -1,0 +1,29 @@
+/**
+ * NotificationAdapter — NotificationService (portal 모듈) 대체
+ * D1에 직접 domain_events 레코드 삽입 (biz-item.updated 이벤트 타입 사용)
+ */
+
+export interface NotifyParams {
+  orgId: string;
+  recipientId: string;
+  type: string;
+  bizItemId: string;
+  title: string;
+  body: string;
+  actorId: string;
+}
+
+export class NotificationAdapter {
+  constructor(private db: D1Database) {}
+
+  async notify(params: NotifyParams): Promise<void> {
+    const id = crypto.randomUUID();
+    const now = new Date().toISOString();
+    await this.db
+      .prepare(
+        `INSERT INTO domain_events (id, type, payload, source, processed, created_at) VALUES (?, ?, ?, ?, 0, ?)`,
+      )
+      .bind(id, "biz-item.updated", JSON.stringify(params), "gate-x", now)
+      .run();
+  }
+}

--- a/packages/gate-x/src/services/adapters/pipeline-adapter.ts
+++ b/packages/gate-x/src/services/adapters/pipeline-adapter.ts
@@ -1,0 +1,54 @@
+/**
+ * PipelineAdapter — PipelineService (launch 모듈) 대체
+ * Gate-X D1에서 직접 pipeline_stages 쿼리
+ */
+
+export type PipelineStage =
+  | "REGISTERED"
+  | "DISCOVERY"
+  | "FORMALIZATION"
+  | "REVIEW"
+  | "DECISION"
+  | "OFFERING"
+  | "MVP";
+
+export class PipelineAdapter {
+  constructor(private db: D1Database) {}
+
+  async getCurrentStage(bizItemId: string): Promise<{ stage: PipelineStage } | null> {
+    return this.db
+      .prepare(
+        `SELECT stage FROM pipeline_stages
+         WHERE biz_item_id = ? AND exited_at IS NULL
+         ORDER BY entered_at DESC LIMIT 1`,
+      )
+      .bind(bizItemId)
+      .first<{ stage: PipelineStage }>();
+  }
+
+  async advanceStage(
+    bizItemId: string,
+    orgId: string,
+    stage: PipelineStage,
+    userId: string,
+    reason: string,
+  ): Promise<void> {
+    // Close current stage
+    await this.db
+      .prepare(
+        `UPDATE pipeline_stages SET exited_at = datetime('now')
+         WHERE biz_item_id = ? AND exited_at IS NULL`,
+      )
+      .bind(bizItemId)
+      .run();
+
+    // Open next stage
+    await this.db
+      .prepare(
+        `INSERT INTO pipeline_stages (id, biz_item_id, org_id, stage, entered_by, reason)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(crypto.randomUUID(), bizItemId, orgId, stage, userId, reason)
+      .run();
+  }
+}

--- a/packages/gate-x/src/services/decision-service.ts
+++ b/packages/gate-x/src/services/decision-service.ts
@@ -1,0 +1,166 @@
+/**
+ * DecisionService — Go/Hold/Drop 의사결정 + 자동 단계 전환
+ * 크로스 의존 해소: PipelineAdapter + NotificationAdapter 사용
+ */
+import type { DecisionType } from "../schemas/decision.schema.js";
+import { PipelineAdapter } from "./adapters/pipeline-adapter.js";
+import type { PipelineStage } from "./adapters/pipeline-adapter.js";
+import { NotificationAdapter } from "./adapters/notification-adapter.js";
+
+export interface Decision {
+  id: string;
+  bizItemId: string;
+  orgId: string;
+  decision: DecisionType;
+  stage: string;
+  comment: string;
+  decidedBy: string;
+  createdAt: string;
+}
+
+export interface CreateDecisionInput {
+  bizItemId: string;
+  orgId: string;
+  decision: DecisionType;
+  comment: string;
+  decidedBy: string;
+}
+
+export interface DecisionStats {
+  total: number;
+  go: number;
+  hold: number;
+  drop: number;
+}
+
+export interface PendingDecisionItem {
+  bizItemId: string;
+  title: string;
+  currentStage: string;
+  stageEnteredAt: string;
+  createdBy: string;
+}
+
+const NEXT_STAGE: Record<string, PipelineStage> = {
+  REGISTERED: "DISCOVERY",
+  DISCOVERY: "FORMALIZATION",
+  FORMALIZATION: "REVIEW",
+  REVIEW: "DECISION",
+  DECISION: "OFFERING",
+  OFFERING: "MVP",
+};
+
+export class DecisionService {
+  private pipelineAdapter: PipelineAdapter;
+  private notificationAdapter: NotificationAdapter;
+
+  constructor(private db: D1Database) {
+    this.pipelineAdapter = new PipelineAdapter(db);
+    this.notificationAdapter = new NotificationAdapter(db);
+  }
+
+  async create(input: CreateDecisionInput): Promise<Decision> {
+    const id = crypto.randomUUID();
+    const currentStage = await this.pipelineAdapter.getCurrentStage(input.bizItemId);
+    const stage = currentStage?.stage ?? "REGISTERED";
+
+    await this.db
+      .prepare(`INSERT INTO decisions (id, biz_item_id, org_id, decision, stage, comment, decided_by) VALUES (?, ?, ?, ?, ?, ?, ?)`)
+      .bind(id, input.bizItemId, input.orgId, input.decision, stage, input.comment, input.decidedBy)
+      .run();
+
+    // Auto stage transition on GO
+    if (input.decision === "GO") {
+      const nextStage = NEXT_STAGE[stage];
+      if (nextStage) {
+        await this.pipelineAdapter.advanceStage(input.bizItemId, input.orgId, nextStage, input.decidedBy, `GO decision: ${input.comment}`);
+      } else if (stage === "MVP") {
+        await this.db.prepare(`UPDATE biz_items SET status = 'completed', updated_at = datetime('now') WHERE id = ?`).bind(input.bizItemId).run();
+      }
+    }
+
+    // DROP → mark item as dropped
+    if (input.decision === "DROP") {
+      await this.db.prepare(`UPDATE biz_items SET status = 'dropped', updated_at = datetime('now') WHERE id = ?`).bind(input.bizItemId).run();
+    }
+
+    // Create notification for item creator
+    const item = await this.db.prepare(`SELECT created_by FROM biz_items WHERE id = ?`).bind(input.bizItemId).first<Record<string, unknown>>();
+    if (item?.["created_by"] && item["created_by"] !== input.decidedBy) {
+      await this.notificationAdapter.notify({
+        orgId: input.orgId,
+        recipientId: item["created_by"] as string,
+        type: "decision_made",
+        bizItemId: input.bizItemId,
+        title: `의사결정: ${input.decision}`,
+        body: input.comment,
+        actorId: input.decidedBy,
+      });
+    }
+
+    return { id, bizItemId: input.bizItemId, orgId: input.orgId, decision: input.decision, stage, comment: input.comment, decidedBy: input.decidedBy, createdAt: new Date().toISOString() };
+  }
+
+  async listByItem(bizItemId: string, orgId: string): Promise<Decision[]> {
+    const { results } = await this.db
+      .prepare(`SELECT id, biz_item_id, org_id, decision, stage, comment, decided_by, created_at FROM decisions WHERE biz_item_id = ? AND org_id = ? ORDER BY created_at DESC`)
+      .bind(bizItemId, orgId)
+      .all<Record<string, unknown>>();
+    return results.map((r) => this.mapRow(r));
+  }
+
+  async listByOrg(orgId: string, opts?: { limit?: number; offset?: number }): Promise<Decision[]> {
+    const limit = opts?.limit ?? 20;
+    const offset = opts?.offset ?? 0;
+    const { results } = await this.db
+      .prepare(`SELECT id, biz_item_id, org_id, decision, stage, comment, decided_by, created_at FROM decisions WHERE org_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?`)
+      .bind(orgId, limit, offset)
+      .all<Record<string, unknown>>();
+    return results.map((r) => this.mapRow(r));
+  }
+
+  async getStats(orgId: string): Promise<DecisionStats> {
+    const { results } = await this.db
+      .prepare(`SELECT decision, COUNT(*) as cnt FROM decisions WHERE org_id = ? GROUP BY decision`)
+      .bind(orgId)
+      .all<Record<string, unknown>>();
+
+    let total = 0, go = 0, hold = 0, drop = 0;
+    for (const r of results) {
+      const cnt = Number(r["cnt"]);
+      total += cnt;
+      if (r["decision"] === "GO") go = cnt;
+      else if (r["decision"] === "HOLD") hold = cnt;
+      else if (r["decision"] === "DROP") drop = cnt;
+    }
+    return { total, go, hold, drop };
+  }
+
+  async getPending(orgId: string): Promise<PendingDecisionItem[]> {
+    const { results } = await this.db
+      .prepare(`SELECT ps.biz_item_id, bi.title, ps.stage, ps.entered_at, bi.created_by FROM pipeline_stages ps JOIN biz_items bi ON bi.id = ps.biz_item_id WHERE ps.org_id = ? AND ps.exited_at IS NULL AND ps.stage IN ('REVIEW', 'DECISION') ORDER BY ps.entered_at ASC`)
+      .bind(orgId)
+      .all<Record<string, unknown>>();
+
+    return results.map((r) => ({
+      bizItemId: r["biz_item_id"] as string,
+      title: r["title"] as string,
+      currentStage: r["stage"] as string,
+      stageEnteredAt: r["entered_at"] as string,
+      createdBy: r["created_by"] as string,
+    }));
+  }
+
+  private mapRow(r: Record<string, unknown>): Decision {
+    return {
+      id: r["id"] as string,
+      bizItemId: r["biz_item_id"] as string,
+      orgId: r["org_id"] as string,
+      decision: r["decision"] as DecisionType,
+      stage: r["stage"] as string,
+      comment: r["comment"] as string,
+      decidedBy: r["decided_by"] as string,
+      createdAt: r["created_at"] as string,
+    };
+  }
+}

--- a/packages/gate-x/src/services/evaluation-criteria.ts
+++ b/packages/gate-x/src/services/evaluation-criteria.ts
@@ -1,0 +1,58 @@
+import type { AgentExecutionRequest, AgentExecutionResult } from "../types/agent-execution.js";
+
+export interface EvaluationScore {
+  criteriaName: string;
+  score: number;
+  passed: boolean;
+  feedback: string[];
+  details: Record<string, unknown>;
+}
+
+export interface EvaluationCriteria {
+  readonly name: string;
+  readonly weight: number;
+  evaluate(result: AgentExecutionResult, request: AgentExecutionRequest): EvaluationScore;
+}
+
+export class CodeReviewCriteria implements EvaluationCriteria {
+  readonly name = "code-review";
+  readonly weight = 0.4;
+
+  evaluate(result: AgentExecutionResult, _request: AgentExecutionRequest): EvaluationScore {
+    const comments = (result.output["reviewComments"] as Array<Record<string, unknown>>) ?? [];
+    const errors = comments.filter((c) => c["severity"] === "error");
+    const warnings = comments.filter((c) => c["severity"] === "warning");
+    const deduction = errors.length * 20 + warnings.length * 5;
+    const score = Math.max(0, 100 - deduction);
+    return { criteriaName: this.name, score, passed: score >= 60, feedback: errors.map((c) => `[error] ${String(c["file"])}:${String(c["line"])} — ${String(c["comment"])}`), details: { errorCount: errors.length, warningCount: warnings.length, totalComments: comments.length } };
+  }
+}
+
+export class TestCoverageCriteria implements EvaluationCriteria {
+  readonly name = "test-coverage";
+  readonly weight = 0.3;
+
+  evaluate(result: AgentExecutionResult, _request: AgentExecutionRequest): EvaluationScore {
+    const files = (result.output["generatedCode"] as Array<Record<string, string>>) ?? [];
+    const testFiles = files.filter((f) => f["path"]?.includes(".test.") || f["path"]?.includes("__tests__"));
+    const sourceFiles = files.filter((f) => !f["path"]?.includes(".test.") && !f["path"]?.includes("__tests__"));
+    const score = sourceFiles.length === 0 ? 100 : Math.min(100, (testFiles.length / sourceFiles.length) * 100);
+    const feedback: string[] = testFiles.length === 0 && sourceFiles.length > 0 ? ["No test files generated"] : [];
+    return { criteriaName: this.name, score, passed: score >= 60, feedback, details: { testFiles: testFiles.length, sourceFiles: sourceFiles.length } };
+  }
+}
+
+export class SpecComplianceCriteria implements EvaluationCriteria {
+  readonly name = "spec-compliance";
+  readonly weight = 0.3;
+
+  evaluate(result: AgentExecutionResult, request: AgentExecutionRequest): EvaluationScore {
+    const criteria = ((request.context?.["spec"] as Record<string, unknown>)?.["acceptanceCriteria"] as string[]) ?? [];
+    if (criteria.length === 0) return { criteriaName: this.name, score: 100, passed: true, feedback: [], details: { totalCriteria: 0, metCriteria: 0 } };
+    const outputJson = JSON.stringify(result.output).toLowerCase();
+    const met = criteria.filter((c) => outputJson.includes(c.toLowerCase()));
+    const unmet = criteria.filter((c) => !outputJson.includes(c.toLowerCase()));
+    const score = Math.round((met.length / criteria.length) * 100);
+    return { criteriaName: this.name, score, passed: score >= 60, feedback: unmet.map((c) => `Acceptance criteria not addressed: ${c}`), details: { totalCriteria: criteria.length, metCriteria: met.length, unmetCriteria: unmet } };
+  }
+}

--- a/packages/gate-x/src/services/evaluation-report-service.ts
+++ b/packages/gate-x/src/services/evaluation-report-service.ts
@@ -1,0 +1,116 @@
+import type {
+  EvaluationReport,
+  GenerateReportInput,
+  ReportListQuery,
+} from "../schemas/evaluation-report.schema.js";
+
+interface ReportRow {
+  id: string;
+  org_id: string;
+  biz_item_id: string;
+  title: string;
+  summary: string | null;
+  skill_scores: string;
+  traffic_light: string;
+  traffic_light_history: string;
+  recommendation: string | null;
+  generated_by: string;
+  version: number;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface ArtifactRow {
+  skill_id: string;
+  status: string;
+  output_text: string | null;
+  duration_ms: number;
+}
+
+const SKILL_LABELS: Record<string, string> = {
+  "2-1": "시장 규모 분석",
+  "2-2": "경쟁 분석",
+  "2-3": "고객 분석",
+  "2-4": "기술 분석",
+  "2-5": "사업성 평가",
+  "2-6": "리스크 분석",
+  "2-7": "재무 분석",
+  "2-8": "종합 판단",
+};
+
+function rowToReport(row: ReportRow): EvaluationReport {
+  return {
+    id: row.id,
+    orgId: row.org_id,
+    bizItemId: row.biz_item_id,
+    title: row.title,
+    summary: row.summary,
+    skillScores: JSON.parse(row.skill_scores) as Record<string, { score: number; label: string; summary: string }>,
+    trafficLight: row.traffic_light as EvaluationReport["trafficLight"],
+    trafficLightHistory: JSON.parse(row.traffic_light_history) as Array<{ date: string; value: string }>,
+    recommendation: row.recommendation,
+    generatedBy: row.generated_by,
+    version: row.version,
+    createdBy: row.created_by,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function computeTrafficLight(scores: Record<string, { score: number }>): "green" | "yellow" | "red" {
+  const values = Object.values(scores).map((s) => s.score);
+  if (values.length === 0) return "red";
+  const avg = values.reduce((a, b) => a + b, 0) / values.length;
+  if (avg >= 70) return "green";
+  if (avg >= 40) return "yellow";
+  return "red";
+}
+
+export class EvaluationReportService {
+  constructor(private db: D1Database) {}
+
+  async generate(orgId: string, userId: string, input: GenerateReportInput): Promise<EvaluationReport> {
+    const { results: artifacts } = await this.db
+      .prepare(`SELECT skill_id, status, output_text, duration_ms FROM bd_artifacts WHERE org_id = ? AND biz_item_id = ? AND status = 'completed' ORDER BY skill_id, version DESC`)
+      .bind(orgId, input.bizItemId)
+      .all<ArtifactRow>();
+
+    const seen = new Set<string>();
+    const skillScores: Record<string, { score: number; label: string; summary: string }> = {};
+
+    for (const art of artifacts) {
+      if (seen.has(art.skill_id)) continue;
+      seen.add(art.skill_id);
+      const outputLen = art.output_text?.length ?? 0;
+      const score = Math.min(100, Math.round((outputLen / 500) * 100));
+      skillScores[art.skill_id] = { score, label: SKILL_LABELS[art.skill_id] ?? art.skill_id, summary: art.output_text ? art.output_text.slice(0, 200) : "(산출물 없음)" };
+    }
+
+    const trafficLight = computeTrafficLight(skillScores);
+    const now = new Date().toISOString();
+    const title = input.title ?? `${input.bizItemId} 통합 평가 결과서`;
+    const id = crypto.randomUUID().replace(/-/g, "").slice(0, 32);
+
+    await this.db.prepare(`INSERT INTO evaluation_reports (id, org_id, biz_item_id, title, summary, skill_scores, traffic_light, traffic_light_history, recommendation, generated_by, created_by, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'ai', ?, ?, ?)`)
+      .bind(id, orgId, input.bizItemId, title, null, JSON.stringify(skillScores), trafficLight, JSON.stringify([{ date: now, value: trafficLight }]), null, userId, now, now)
+      .run();
+
+    return { id, orgId, bizItemId: input.bizItemId, title, summary: null, skillScores, trafficLight, trafficLightHistory: [{ date: now, value: trafficLight }], recommendation: null, generatedBy: "ai", version: 1, createdBy: userId, createdAt: now, updatedAt: now };
+  }
+
+  async getById(orgId: string, id: string): Promise<EvaluationReport | null> {
+    const row = await this.db.prepare("SELECT * FROM evaluation_reports WHERE id = ? AND org_id = ?").bind(id, orgId).first<ReportRow>();
+    return row ? rowToReport(row) : null;
+  }
+
+  async list(orgId: string, query: ReportListQuery): Promise<{ items: EvaluationReport[]; total: number }> {
+    const conditions = ["org_id = ?"];
+    const params: unknown[] = [orgId];
+    if (query.bizItemId) { conditions.push("biz_item_id = ?"); params.push(query.bizItemId); }
+    const where = conditions.join(" AND ");
+    const countRow = await this.db.prepare(`SELECT COUNT(*) as cnt FROM evaluation_reports WHERE ${where}`).bind(...params).first<{ cnt: number }>();
+    const { results } = await this.db.prepare(`SELECT * FROM evaluation_reports WHERE ${where} ORDER BY created_at DESC LIMIT ? OFFSET ?`).bind(...params, query.limit, query.offset).all<ReportRow>();
+    return { items: results.map(rowToReport), total: countRow?.cnt ?? 0 };
+  }
+}

--- a/packages/gate-x/src/services/evaluation-service.ts
+++ b/packages/gate-x/src/services/evaluation-service.ts
@@ -1,0 +1,199 @@
+export type EvalStatus = "draft" | "active" | "go" | "kill" | "hold";
+
+const VALID_TRANSITIONS: Record<EvalStatus, EvalStatus[]> = {
+  draft: ["active"],
+  active: ["go", "kill", "hold"],
+  go: ["active", "kill"],
+  kill: ["active"],
+  hold: ["active", "kill"],
+};
+
+export interface Evaluation {
+  id: string;
+  orgId: string;
+  ideaId: string | null;
+  bmcId: string | null;
+  title: string;
+  description: string | null;
+  ownerId: string;
+  status: EvalStatus;
+  decisionReason: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface EvalHistoryEntry {
+  id: string;
+  evalId: string;
+  actorId: string;
+  action: string;
+  fromStatus: string | null;
+  toStatus: string | null;
+  reason: string | null;
+  createdAt: number;
+}
+
+export interface PortfolioSummary {
+  total: number;
+  byStatus: Record<string, number>;
+  recentChanges: EvalHistoryEntry[];
+}
+
+export interface KpiItem {
+  id: string;
+  evaluationId: string;
+  name: string;
+  category: string;
+  target: number;
+  actual: number | null;
+  unit: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+function rowToEvaluation(row: Record<string, unknown>): Evaluation {
+  return {
+    id: row["id"] as string,
+    orgId: row["org_id"] as string,
+    ideaId: (row["idea_id"] as string) || null,
+    bmcId: (row["bmc_id"] as string) || null,
+    title: row["title"] as string,
+    description: (row["description"] as string) || null,
+    ownerId: row["owner_id"] as string,
+    status: row["status"] as EvalStatus,
+    decisionReason: (row["decision_reason"] as string) || null,
+    createdAt: row["created_at"] as number,
+    updatedAt: row["updated_at"] as number,
+  };
+}
+
+function rowToHistory(row: Record<string, unknown>): EvalHistoryEntry {
+  return {
+    id: row["id"] as string,
+    evalId: row["eval_id"] as string,
+    actorId: row["actor_id"] as string,
+    action: row["action"] as string,
+    fromStatus: (row["from_status"] as string) || null,
+    toStatus: (row["to_status"] as string) || null,
+    reason: (row["reason"] as string) || null,
+    createdAt: row["created_at"] as number,
+  };
+}
+
+export class EvaluationService {
+  constructor(private db: D1Database) {}
+
+  async create(
+    orgId: string,
+    ownerId: string,
+    data: { title: string; description?: string; ideaId?: string; bmcId?: string },
+  ): Promise<Evaluation> {
+    const id = crypto.randomUUID();
+    const now = Date.now();
+
+    await this.db
+      .prepare(
+        `INSERT INTO ax_evaluations (id, org_id, idea_id, bmc_id, title, description, owner_id, status, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, 'draft', ?, ?)`,
+      )
+      .bind(id, orgId, data.ideaId || null, data.bmcId || null, data.title, data.description || null, ownerId, now, now)
+      .run();
+
+    return { id, orgId, ideaId: data.ideaId || null, bmcId: data.bmcId || null, title: data.title, description: data.description || null, ownerId, status: "draft", decisionReason: null, createdAt: now, updatedAt: now };
+  }
+
+  async list(orgId: string, filters?: { status?: string; limit?: number; offset?: number }): Promise<{ items: Evaluation[]; total: number }> {
+    const limit = filters?.limit ?? 20;
+    const offset = filters?.offset ?? 0;
+    const bindings: unknown[] = [orgId];
+    let where = "org_id = ?";
+
+    if (filters?.status) {
+      where += " AND status = ?";
+      bindings.push(filters.status);
+    }
+
+    const countRow = await this.db.prepare(`SELECT COUNT(*) as cnt FROM ax_evaluations WHERE ${where}`).bind(...bindings).first<{ cnt: number }>();
+    const { results } = await this.db.prepare(`SELECT * FROM ax_evaluations WHERE ${where} ORDER BY updated_at DESC LIMIT ? OFFSET ?`).bind(...bindings, limit, offset).all();
+
+    return { items: (results as Record<string, unknown>[]).map(rowToEvaluation), total: countRow?.cnt ?? 0 };
+  }
+
+  async getById(evalId: string, orgId: string): Promise<Evaluation | null> {
+    const row = await this.db.prepare("SELECT * FROM ax_evaluations WHERE id = ? AND org_id = ?").bind(evalId, orgId).first();
+    return row ? rowToEvaluation(row as Record<string, unknown>) : null;
+  }
+
+  async updateStatus(evalId: string, orgId: string, actorId: string, newStatus: EvalStatus, reason?: string): Promise<Evaluation> {
+    const current = await this.getById(evalId, orgId);
+    if (!current) throw new Error("Evaluation not found");
+
+    const allowed = VALID_TRANSITIONS[current.status];
+    if (!allowed.includes(newStatus)) throw new Error(`Invalid status transition: ${current.status} → ${newStatus}`);
+
+    const now = Date.now();
+    await this.db.prepare("UPDATE ax_evaluations SET status = ?, decision_reason = ?, updated_at = ? WHERE id = ? AND org_id = ?").bind(newStatus, reason || null, now, evalId, orgId).run();
+
+    const historyId = crypto.randomUUID();
+    await this.db.prepare(`INSERT INTO ax_evaluation_history (id, eval_id, actor_id, action, from_status, to_status, reason, created_at) VALUES (?, ?, ?, 'status_change', ?, ?, ?, ?)`).bind(historyId, evalId, actorId, current.status, newStatus, reason || null, now).run();
+
+    return { ...current, status: newStatus, decisionReason: reason || null, updatedAt: now };
+  }
+
+  async getHistory(evalId: string, orgId: string): Promise<EvalHistoryEntry[]> {
+    const evalRow = await this.getById(evalId, orgId);
+    if (!evalRow) return [];
+    const { results } = await this.db.prepare("SELECT * FROM ax_evaluation_history WHERE eval_id = ? ORDER BY created_at DESC").bind(evalId).all();
+    return (results as Record<string, unknown>[]).map(rowToHistory);
+  }
+
+  async getPortfolio(orgId: string): Promise<PortfolioSummary> {
+    const { results: statusRows } = await this.db.prepare("SELECT status, COUNT(*) as cnt FROM ax_evaluations WHERE org_id = ? GROUP BY status").bind(orgId).all();
+    const byStatus: Record<string, number> = {};
+    let total = 0;
+    for (const row of statusRows as Array<Record<string, unknown>>) {
+      const status = row["status"] as string;
+      const cnt = row["cnt"] as number;
+      byStatus[status] = cnt;
+      total += cnt;
+    }
+    const { results: historyRows } = await this.db.prepare(`SELECT h.* FROM ax_evaluation_history h JOIN ax_evaluations e ON h.eval_id = e.id WHERE e.org_id = ? ORDER BY h.created_at DESC LIMIT 10`).bind(orgId).all();
+    return { total, byStatus, recentChanges: (historyRows as Record<string, unknown>[]).map(rowToHistory) };
+  }
+
+  // KPI methods (gate-x 자체 구현 — KpiService portal 대체)
+  async createKpi(evalId: string, data: { name: string; category: string; target: number; unit?: string }): Promise<KpiItem> {
+    const id = crypto.randomUUID();
+    const now = new Date().toISOString();
+    await this.db.prepare(`INSERT INTO ax_evaluation_kpis (id, evaluation_id, name, category, target, unit) VALUES (?, ?, ?, ?, ?, ?)`).bind(id, evalId, data.name, data.category, data.target, data.unit ?? null).run();
+    return { id, evaluationId: evalId, name: data.name, category: data.category, target: data.target, actual: null, unit: data.unit ?? null, createdAt: now, updatedAt: now };
+  }
+
+  async listKpis(evalId: string): Promise<KpiItem[]> {
+    const { results } = await this.db.prepare("SELECT * FROM ax_evaluation_kpis WHERE evaluation_id = ? ORDER BY created_at ASC").bind(evalId).all();
+    return (results as Record<string, unknown>[]).map((r) => ({
+      id: r["id"] as string,
+      evaluationId: r["evaluation_id"] as string,
+      name: r["name"] as string,
+      category: r["category"] as string,
+      target: r["target"] as number,
+      actual: r["actual"] as number | null,
+      unit: (r["unit"] as string) || null,
+      createdAt: r["created_at"] as string,
+      updatedAt: r["updated_at"] as string,
+    }));
+  }
+
+  async updateKpi(kpiId: string, evalId: string, data: { actual?: number | null; target?: number }): Promise<KpiItem> {
+    const sets: string[] = ["updated_at = datetime('now')"];
+    const params: unknown[] = [];
+    if (data.actual !== undefined) { sets.push("actual = ?"); params.push(data.actual); }
+    if (data.target !== undefined) { sets.push("target = ?"); params.push(data.target); }
+    params.push(kpiId, evalId);
+    const res = await this.db.prepare(`UPDATE ax_evaluation_kpis SET ${sets.join(", ")} WHERE id = ? AND evaluation_id = ?`).bind(...params).run();
+    if (!res.meta.changes) throw new Error("KPI not found");
+    const row = await this.db.prepare("SELECT * FROM ax_evaluation_kpis WHERE id = ?").bind(kpiId).first<Record<string, unknown>>();
+    if (!row) throw new Error("KPI not found");
+    return { id: row["id"] as string, evaluationId: row["evaluation_id"] as string, name: row["name"] as string, category: row["category"] as string, target: row["target"] as number, actual: row["actual"] as number | null, unit: (row["unit"] as string) || null, createdAt: row["created_at"] as string, updatedAt: row["updated_at"] as string };
+  }
+}

--- a/packages/gate-x/src/services/gate-package-service.ts
+++ b/packages/gate-x/src/services/gate-package-service.ts
@@ -1,0 +1,69 @@
+import type { GateType, GateStatus } from "../schemas/gate-package.schema.js";
+
+export interface GatePackageItem { type: string; id: string; title: string; content?: string; }
+export interface GatePackage { id: string; orgId: string; bizItemId: string; gateType: GateType; items: GatePackageItem[]; status: GateStatus; downloadUrl: string | null; createdBy: string; createdAt: string; }
+export interface CreateGatePackageInput { bizItemId: string; orgId: string; gateType: GateType; createdBy: string; }
+
+export class GatePackageService {
+  constructor(private db: D1Database) {}
+
+  async create(input: CreateGatePackageInput): Promise<GatePackage> {
+    const items = await this.collectArtifacts(input.bizItemId, input.orgId);
+    const types = items.map((i) => i.type);
+    const missing: string[] = [];
+    if (!types.includes("bmc")) missing.push("BMC");
+    if (!types.includes("prd")) missing.push("PRD");
+    if (missing.length > 0) throw new MissingArtifactsError(missing);
+
+    const id = crypto.randomUUID();
+    await this.db.prepare(`INSERT INTO gate_packages (id, org_id, biz_item_id, gate_type, items, created_by) VALUES (?, ?, ?, ?, ?, ?)`)
+      .bind(id, input.orgId, input.bizItemId, input.gateType, JSON.stringify(items), input.createdBy)
+      .run();
+
+    return { id, orgId: input.orgId, bizItemId: input.bizItemId, gateType: input.gateType, items, status: "draft", downloadUrl: null, createdBy: input.createdBy, createdAt: new Date().toISOString() };
+  }
+
+  async get(bizItemId: string, orgId: string): Promise<GatePackage | null> {
+    const row = await this.db.prepare(`SELECT id, org_id, biz_item_id, gate_type, items, status, download_url, created_by, created_at FROM gate_packages WHERE biz_item_id = ? AND org_id = ? ORDER BY created_at DESC LIMIT 1`).bind(bizItemId, orgId).first<Record<string, unknown>>();
+    return row ? this.mapRow(row) : null;
+  }
+
+  async getDownload(bizItemId: string, orgId: string): Promise<{ filename: string; items: GatePackageItem[] } | null> {
+    const pkg = await this.get(bizItemId, orgId);
+    if (!pkg) return null;
+    return { filename: `gate-${pkg.gateType}-${bizItemId}.zip`, items: pkg.items };
+  }
+
+  async updateStatus(bizItemId: string, orgId: string, status: GateStatus): Promise<GatePackage | null> {
+    const pkg = await this.get(bizItemId, orgId);
+    if (!pkg) return null;
+    await this.db.prepare(`UPDATE gate_packages SET status = ? WHERE id = ?`).bind(status, pkg.id).run();
+    return { ...pkg, status };
+  }
+
+  private async collectArtifacts(bizItemId: string, orgId: string): Promise<GatePackageItem[]> {
+    const items: GatePackageItem[] = [];
+    const bmc = await this.db.prepare(`SELECT id, title FROM bmc_canvases WHERE biz_item_id = ? AND org_id = ? ORDER BY created_at DESC LIMIT 1`).bind(bizItemId, orgId).first<Record<string, unknown>>();
+    if (bmc) items.push({ type: "bmc", id: bmc["id"] as string, title: (bmc["title"] as string) || "BMC" });
+    const prd = await this.db.prepare(`SELECT id, title FROM prd_documents WHERE biz_item_id = ? AND org_id = ? ORDER BY created_at DESC LIMIT 1`).bind(bizItemId, orgId).first<Record<string, unknown>>();
+    if (prd) items.push({ type: "prd", id: prd["id"] as string, title: (prd["title"] as string) || "PRD" });
+    const bdp = await this.db.prepare(`SELECT id, version_num FROM bdp_versions WHERE biz_item_id = ? AND org_id = ? ORDER BY version_num DESC LIMIT 1`).bind(bizItemId, orgId).first<Record<string, unknown>>();
+    if (bdp) items.push({ type: "bdp", id: bdp["id"] as string, title: `BDP v${String(bdp["version_num"])}` });
+    return items;
+  }
+
+  private mapRow(r: Record<string, unknown>): GatePackage {
+    let items: GatePackageItem[] = [];
+    try { items = JSON.parse(r["items"] as string) as GatePackageItem[]; } catch { items = []; }
+    return { id: r["id"] as string, orgId: r["org_id"] as string, bizItemId: r["biz_item_id"] as string, gateType: r["gate_type"] as GateType, items, status: r["status"] as GateStatus, downloadUrl: (r["download_url"] as string) || null, createdBy: r["created_by"] as string, createdAt: r["created_at"] as string };
+  }
+}
+
+export class MissingArtifactsError extends Error {
+  public missing: string[];
+  constructor(missing: string[]) {
+    super(`Missing required artifacts: ${missing.join(", ")}`);
+    this.name = "MissingArtifactsError";
+    this.missing = missing;
+  }
+}

--- a/packages/gate-x/src/services/meeting-service.ts
+++ b/packages/gate-x/src/services/meeting-service.ts
@@ -1,0 +1,64 @@
+import type { MeetingType, MeetingStatus } from "../schemas/validation.schema.js";
+
+export interface Meeting { id: string; orgId: string; bizItemId: string; type: MeetingType; title: string; scheduledAt: string; attendees: string[]; location: string | null; notes: string | null; status: MeetingStatus; createdBy: string; createdAt: string; updatedAt: string; }
+export interface CreateMeetingInput { bizItemId: string; type?: MeetingType; title: string; scheduledAt: string; attendees?: string[]; location?: string; notes?: string; }
+export interface UpdateMeetingInput { title?: string; scheduledAt?: string; attendees?: string[]; location?: string; notes?: string; status?: MeetingStatus; }
+export interface MeetingFilters { bizItemId?: string; status?: MeetingStatus; limit?: number; offset?: number; }
+
+export class MeetingService {
+  constructor(private db: D1Database) {}
+
+  async create(input: CreateMeetingInput, orgId: string, userId: string): Promise<Meeting> {
+    const id = crypto.randomUUID();
+    const type = input.type ?? "interview";
+    await this.db.prepare(`INSERT INTO expert_meetings (id, org_id, biz_item_id, type, title, scheduled_at, attendees, location, notes, created_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+      .bind(id, orgId, input.bizItemId, type, input.title, input.scheduledAt, JSON.stringify(input.attendees ?? []), input.location ?? null, input.notes ?? null, userId)
+      .run();
+    return { id, orgId, bizItemId: input.bizItemId, type, title: input.title, scheduledAt: input.scheduledAt, attendees: input.attendees ?? [], location: input.location ?? null, notes: input.notes ?? null, status: "scheduled", createdBy: userId, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() };
+  }
+
+  async list(orgId: string, filters?: MeetingFilters): Promise<{ items: Meeting[]; total: number }> {
+    const limit = filters?.limit ?? 20;
+    const offset = filters?.offset ?? 0;
+    const conditions: string[] = ["org_id = ?"];
+    const params: unknown[] = [orgId];
+    if (filters?.bizItemId) { conditions.push("biz_item_id = ?"); params.push(filters.bizItemId); }
+    if (filters?.status) { conditions.push("status = ?"); params.push(filters.status); }
+    const where = conditions.join(" AND ");
+    const countResult = await this.db.prepare(`SELECT COUNT(*) as cnt FROM expert_meetings WHERE ${where}`).bind(...params).first<{ cnt: number }>();
+    const { results } = await this.db.prepare(`SELECT id, org_id, biz_item_id, type, title, scheduled_at, attendees, location, notes, status, created_by, created_at, updated_at FROM expert_meetings WHERE ${where} ORDER BY scheduled_at DESC LIMIT ? OFFSET ?`).bind(...params, limit, offset).all<Record<string, unknown>>();
+    return { items: results.map((r) => this.mapRow(r)), total: countResult?.cnt ?? 0 };
+  }
+
+  async getById(id: string, orgId: string): Promise<Meeting | null> {
+    const row = await this.db.prepare(`SELECT id, org_id, biz_item_id, type, title, scheduled_at, attendees, location, notes, status, created_by, created_at, updated_at FROM expert_meetings WHERE id = ? AND org_id = ?`).bind(id, orgId).first<Record<string, unknown>>();
+    return row ? this.mapRow(row) : null;
+  }
+
+  async update(id: string, orgId: string, input: UpdateMeetingInput): Promise<Meeting | null> {
+    const sets: string[] = ["updated_at = datetime('now')"];
+    const params: unknown[] = [];
+    if (input.title !== undefined) { sets.push("title = ?"); params.push(input.title); }
+    if (input.scheduledAt !== undefined) { sets.push("scheduled_at = ?"); params.push(input.scheduledAt); }
+    if (input.attendees !== undefined) { sets.push("attendees = ?"); params.push(JSON.stringify(input.attendees)); }
+    if (input.location !== undefined) { sets.push("location = ?"); params.push(input.location); }
+    if (input.notes !== undefined) { sets.push("notes = ?"); params.push(input.notes); }
+    if (input.status !== undefined) { sets.push("status = ?"); params.push(input.status); }
+    params.push(id, orgId);
+    await this.db.prepare(`UPDATE expert_meetings SET ${sets.join(", ")} WHERE id = ? AND org_id = ?`).bind(...params).run();
+    return this.getById(id, orgId);
+  }
+
+  async delete(id: string, orgId: string): Promise<boolean> {
+    const existing = await this.getById(id, orgId);
+    if (!existing) return false;
+    await this.db.prepare(`DELETE FROM expert_meetings WHERE id = ? AND org_id = ?`).bind(id, orgId).run();
+    return true;
+  }
+
+  private mapRow(r: Record<string, unknown>): Meeting {
+    let attendees: string[] = [];
+    try { attendees = JSON.parse(r["attendees"] as string) as string[]; } catch { attendees = []; }
+    return { id: r["id"] as string, orgId: r["org_id"] as string, bizItemId: r["biz_item_id"] as string, type: r["type"] as MeetingType, title: r["title"] as string, scheduledAt: r["scheduled_at"] as string, attendees, location: (r["location"] as string) || null, notes: (r["notes"] as string) || null, status: r["status"] as MeetingStatus, createdBy: r["created_by"] as string, createdAt: r["created_at"] as string, updatedAt: r["updated_at"] as string };
+  }
+}

--- a/packages/gate-x/src/services/validation-service.ts
+++ b/packages/gate-x/src/services/validation-service.ts
@@ -1,0 +1,67 @@
+import type { ValidationTier } from "../schemas/validation.schema.js";
+
+export interface ValidationResult { bizItemId: string; previousTier: ValidationTier; currentTier: ValidationTier; decision: "approve" | "reject"; comment: string; decidedBy: string; decidedAt: string; }
+export interface ValidationItem { bizItemId: string; title: string; currentStage: string; validationTier: ValidationTier; stageEnteredAt: string; createdBy: string; }
+export interface ValidationStatus { bizItemId: string; tier: ValidationTier; history: Array<{ tier: ValidationTier; decision: string; decidedBy: string; decidedAt: string; comment: string; }>; }
+
+export class ValidationService {
+  constructor(private db: D1Database) {}
+
+  async submitDivisionReview(bizItemId: string, orgId: string, decision: "approve" | "reject", comment: string, userId: string): Promise<ValidationResult> {
+    const current = await this.getCurrentTier(bizItemId, orgId);
+    if (current !== "none" && current !== "division_pending") throw new ValidationTierError(`Cannot submit division review: current tier is '${current}'`);
+    const newTier: ValidationTier = decision === "approve" ? "division_approved" : "none";
+    await this.db.prepare(`UPDATE pipeline_stages SET validation_tier = ? WHERE biz_item_id = ? AND org_id = ? AND exited_at IS NULL`).bind(newTier, bizItemId, orgId).run();
+    await this.recordHistory(bizItemId, orgId, newTier, decision, comment, userId);
+    return { bizItemId, previousTier: current, currentTier: newTier, decision, comment, decidedBy: userId, decidedAt: new Date().toISOString() };
+  }
+
+  async submitCompanyReview(bizItemId: string, orgId: string, decision: "approve" | "reject", comment: string, userId: string): Promise<ValidationResult> {
+    const current = await this.getCurrentTier(bizItemId, orgId);
+    if (current !== "division_approved" && current !== "company_pending") throw new ValidationTierError(`Cannot submit company review: current tier is '${current}', need 'division_approved'`);
+    const newTier: ValidationTier = decision === "approve" ? "company_approved" : "division_approved";
+    await this.db.prepare(`UPDATE pipeline_stages SET validation_tier = ? WHERE biz_item_id = ? AND org_id = ? AND exited_at IS NULL`).bind(newTier, bizItemId, orgId).run();
+    await this.recordHistory(bizItemId, orgId, newTier, decision, comment, userId);
+    return { bizItemId, previousTier: current, currentTier: newTier, decision, comment, decidedBy: userId, decidedAt: new Date().toISOString() };
+  }
+
+  async getDivisionItems(orgId: string, filters?: { limit?: number; offset?: number }): Promise<{ items: ValidationItem[]; total: number }> {
+    const limit = filters?.limit ?? 20;
+    const offset = filters?.offset ?? 0;
+    const countResult = await this.db.prepare(`SELECT COUNT(*) as cnt FROM pipeline_stages ps JOIN biz_items bi ON bi.id = ps.biz_item_id WHERE ps.org_id = ? AND ps.exited_at IS NULL AND ps.stage IN ('REVIEW', 'DECISION') AND (ps.validation_tier IS NULL OR ps.validation_tier IN ('none', 'division_pending'))`).bind(orgId).first<{ cnt: number }>();
+    const { results } = await this.db.prepare(`SELECT ps.biz_item_id, bi.title, ps.stage, ps.validation_tier, ps.entered_at, bi.created_by FROM pipeline_stages ps JOIN biz_items bi ON bi.id = ps.biz_item_id WHERE ps.org_id = ? AND ps.exited_at IS NULL AND ps.stage IN ('REVIEW', 'DECISION') AND (ps.validation_tier IS NULL OR ps.validation_tier IN ('none', 'division_pending')) ORDER BY ps.entered_at ASC LIMIT ? OFFSET ?`).bind(orgId, limit, offset).all<Record<string, unknown>>();
+    return { items: results.map((r) => this.mapValidationItem(r)), total: countResult?.cnt ?? 0 };
+  }
+
+  async getCompanyItems(orgId: string, filters?: { limit?: number; offset?: number }): Promise<{ items: ValidationItem[]; total: number }> {
+    const limit = filters?.limit ?? 20;
+    const offset = filters?.offset ?? 0;
+    const countResult = await this.db.prepare(`SELECT COUNT(*) as cnt FROM pipeline_stages ps JOIN biz_items bi ON bi.id = ps.biz_item_id WHERE ps.org_id = ? AND ps.exited_at IS NULL AND ps.validation_tier = 'division_approved'`).bind(orgId).first<{ cnt: number }>();
+    const { results } = await this.db.prepare(`SELECT ps.biz_item_id, bi.title, ps.stage, ps.validation_tier, ps.entered_at, bi.created_by FROM pipeline_stages ps JOIN biz_items bi ON bi.id = ps.biz_item_id WHERE ps.org_id = ? AND ps.exited_at IS NULL AND ps.validation_tier = 'division_approved' ORDER BY ps.entered_at ASC LIMIT ? OFFSET ?`).bind(orgId, limit, offset).all<Record<string, unknown>>();
+    return { items: results.map((r) => this.mapValidationItem(r)), total: countResult?.cnt ?? 0 };
+  }
+
+  async getValidationStatus(bizItemId: string, orgId: string): Promise<ValidationStatus | null> {
+    const current = await this.db.prepare(`SELECT validation_tier FROM pipeline_stages WHERE biz_item_id = ? AND org_id = ? AND exited_at IS NULL ORDER BY entered_at DESC LIMIT 1`).bind(bizItemId, orgId).first<{ validation_tier: string }>();
+    if (!current) return null;
+    const { results } = await this.db.prepare(`SELECT tier, decision, decided_by, decided_at, comment FROM validation_history WHERE biz_item_id = ? AND org_id = ? ORDER BY decided_at DESC`).bind(bizItemId, orgId).all<Record<string, unknown>>();
+    return { bizItemId, tier: (current.validation_tier || "none") as ValidationTier, history: results.map((r) => ({ tier: r["tier"] as ValidationTier, decision: r["decision"] as string, decidedBy: r["decided_by"] as string, decidedAt: r["decided_at"] as string, comment: r["comment"] as string })) };
+  }
+
+  private async getCurrentTier(bizItemId: string, orgId: string): Promise<ValidationTier> {
+    const row = await this.db.prepare(`SELECT validation_tier FROM pipeline_stages WHERE biz_item_id = ? AND org_id = ? AND exited_at IS NULL ORDER BY entered_at DESC LIMIT 1`).bind(bizItemId, orgId).first<{ validation_tier: string }>();
+    return (row?.validation_tier || "none") as ValidationTier;
+  }
+
+  private async recordHistory(bizItemId: string, orgId: string, tier: ValidationTier, decision: string, comment: string, userId: string): Promise<void> {
+    await this.db.prepare(`INSERT INTO validation_history (id, biz_item_id, org_id, tier, decision, comment, decided_by) VALUES (?, ?, ?, ?, ?, ?, ?)`).bind(crypto.randomUUID(), bizItemId, orgId, tier, decision, comment, userId).run();
+  }
+
+  private mapValidationItem(r: Record<string, unknown>): ValidationItem {
+    return { bizItemId: r["biz_item_id"] as string, title: r["title"] as string, currentStage: r["stage"] as string, validationTier: (r["validation_tier"] || "none") as ValidationTier, stageEnteredAt: r["entered_at"] as string, createdBy: r["created_by"] as string };
+  }
+}
+
+export class ValidationTierError extends Error {
+  constructor(message: string) { super(message); this.name = "ValidationTierError"; }
+}

--- a/packages/gate-x/src/test/decision-service.test.ts
+++ b/packages/gate-x/src/test/decision-service.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from "vitest";
+import { DecisionService } from "../services/decision-service.js";
+
+function makeDb(overrides: Record<string, unknown> = {}) {
+  const runResult = { meta: { changes: 1 } };
+  const prepare = vi.fn().mockReturnValue({
+    bind: vi.fn().mockReturnThis(),
+    run: vi.fn().mockResolvedValue(runResult),
+    first: vi.fn().mockResolvedValue(null),
+    all: vi.fn().mockResolvedValue({ results: [] }),
+  });
+  return { prepare, ...overrides } as unknown as D1Database;
+}
+
+describe("DecisionService", () => {
+  it("should list pending decisions (empty)", async () => {
+    const db = makeDb();
+    const svc = new DecisionService(db);
+    const result = await svc.getPending("org-1");
+    expect(result).toEqual([]);
+  });
+
+  it("should return empty stats when no decisions", async () => {
+    const db = makeDb();
+    const svc = new DecisionService(db);
+    const stats = await svc.getStats("org-1");
+    expect(stats.total).toBe(0);
+    expect(stats.go).toBe(0);
+  });
+
+  it("should list empty decisions by org", async () => {
+    const db = makeDb();
+    const svc = new DecisionService(db);
+    const decisions = await svc.listByOrg("org-1");
+    expect(decisions).toEqual([]);
+  });
+});

--- a/packages/gate-x/src/test/evaluation-service.test.ts
+++ b/packages/gate-x/src/test/evaluation-service.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from "vitest";
+import { EvaluationService } from "../services/evaluation-service.js";
+
+function makeDb() {
+  const mockResult = { meta: { changes: 1 } };
+  const prepare = vi.fn().mockReturnValue({
+    bind: vi.fn().mockReturnThis(),
+    run: vi.fn().mockResolvedValue(mockResult),
+    first: vi.fn().mockResolvedValue(null),
+    all: vi.fn().mockResolvedValue({ results: [] }),
+  });
+  return { prepare } as unknown as D1Database;
+}
+
+describe("EvaluationService", () => {
+  it("should list evaluations (empty org)", async () => {
+    const svc = new EvaluationService(makeDb());
+    const result = await svc.list("org-1");
+    expect(result.items).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+
+  it("should return null for missing evaluation", async () => {
+    const svc = new EvaluationService(makeDb());
+    const result = await svc.getById("nonexistent", "org-1");
+    expect(result).toBeNull();
+  });
+
+  it("should return empty portfolio for new org", async () => {
+    const db = makeDb();
+    // Stub STATUS group query
+    (db.prepare as ReturnType<typeof vi.fn>).mockReturnValue({
+      bind: vi.fn().mockReturnThis(),
+      run: vi.fn().mockResolvedValue({ meta: { changes: 0 } }),
+      first: vi.fn().mockResolvedValue(null),
+      all: vi.fn().mockResolvedValue({ results: [] }),
+    });
+    const svc = new EvaluationService(db);
+    const portfolio = await svc.getPortfolio("org-1");
+    expect(portfolio.total).toBe(0);
+    expect(portfolio.byStatus).toEqual({});
+  });
+});

--- a/packages/gate-x/src/test/health.test.ts
+++ b/packages/gate-x/src/test/health.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from "vitest";
+import app from "../app.js";
+
+describe("GET /api/health", () => {
+  it("should return 200 with service name", async () => {
+    const res = await app.request("/api/health");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { service: string; status: string };
+    expect(body.service).toBe("gate-x");
+    expect(body.status).toBe("ok");
+  });
+});

--- a/packages/gate-x/src/types/agent-execution.ts
+++ b/packages/gate-x/src/types/agent-execution.ts
@@ -1,0 +1,33 @@
+/**
+ * Gate-X 로컬 agent execution 타입 (core 의존 제거용 복사본)
+ * 원본: packages/api/src/core/agent/services/execution-types.ts
+ */
+
+export type AgentTaskType =
+  | "code-review"
+  | "code-generation"
+  | "spec-analysis"
+  | "test-generation"
+  | "security-review"
+  | "qa-testing"
+  | "infra-analysis"
+  | "policy-evaluation"
+  | "skill-query"
+  | "ontology-lookup"
+  | "bmc-generation"
+  | "bmc-insight"
+  | "market-summary";
+
+export interface AgentExecutionRequest {
+  taskType: AgentTaskType;
+  input: Record<string, unknown>;
+  context?: Record<string, unknown>;
+}
+
+export interface AgentExecutionResult {
+  taskType: AgentTaskType;
+  success: boolean;
+  output: Record<string, unknown>;
+  error?: string;
+  durationMs: number;
+}

--- a/packages/gate-x/tsconfig.json
+++ b/packages/gate-x/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src"]
+}

--- a/packages/gate-x/vitest.config.ts
+++ b/packages/gate-x/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+  },
+});

--- a/packages/gate-x/wrangler.toml
+++ b/packages/gate-x/wrangler.toml
@@ -1,0 +1,23 @@
+name = "gate-x-api"
+account_id = "b6c06059b413892a92f150e5ca496236"
+main = "src/index.ts"
+compatibility_date = "2026-03-17"
+compatibility_flags = ["nodejs_compat"]
+
+[[d1_databases]]
+binding = "DB"
+database_name = "gate-x-db"
+database_id = "TBD"
+migrations_dir = "src/db/migrations"
+
+[vars]
+ENVIRONMENT = "production"
+
+[env.dev]
+name = "gate-x-api-dev"
+
+[[env.dev.d1_databases]]
+binding = "DB"
+database_name = "gate-x-db-dev"
+database_id = "TBD"
+migrations_dir = "src/db/migrations"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,34 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@29.0.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.12.12(@types/node@22.19.15)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/gate-x:
+    dependencies:
+      '@foundry-x/harness-kit':
+        specifier: workspace:*
+        version: link:../harness-kit
+      '@hono/zod-openapi':
+        specifier: ^0.18.4
+        version: 0.18.4(hono@4.12.8)(zod@3.25.76)
+      hono:
+        specifier: ^4.0.0
+        version: 4.12.8
+      zod:
+        specifier: ^3.22.0
+        version: 3.25.76
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20241218.0
+        version: 4.20260316.1
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.37
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@20.19.37)(jiti@2.6.1)(jsdom@29.0.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.12.12(@types/node@20.19.37)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
+
   packages/harness-kit:
     dependencies:
       commander:
@@ -348,6 +376,11 @@ packages:
 
   '@asteasolutions/zod-to-openapi@5.5.0':
     resolution: {integrity: sha512-d5HwrvM6dOKr3XdeF+DmashGvfEc+1oiEfbscugsiwSTrFtuMa7ETpW9sTNnVgn+hJaz+PRxPQUYD7q9/5dUig==}
+    peerDependencies:
+      zod: ^3.20.2
+
+  '@asteasolutions/zod-to-openapi@7.3.4':
+    resolution: {integrity: sha512-/2rThQ5zPi9OzVwes6U7lK1+Yvug0iXu25olp7S0XsYmOqnyMfxH7gdSQjn/+DSOHRg7wnotwGJSyL+fBKdnEA==}
     peerDependencies:
       zod: ^3.20.2
 
@@ -1665,6 +1698,13 @@ packages:
     peerDependencies:
       hono: '*'
 
+  '@hono/zod-openapi@0.18.4':
+    resolution: {integrity: sha512-6NHMHU96Hh32B1yDhb94Z4Z5/POsmEu2AXpWLWcBq9arskRnOMt2752yEoXoADV8WUAc7H1IkNaQHGj1ytXbYw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      hono: '>=4.3.6'
+      zod: 3.*
+
   '@hono/zod-openapi@0.9.10':
     resolution: {integrity: sha512-v/b/z0qPxDo952gjRyhJ0n9ifbPoIluR2KmXDL20np0hj99+XvakoIHK5/T/3+hUmXlTj1Kn3TiGsSV6hwZesg==}
     engines: {node: '>=16.0.0'}
@@ -1674,6 +1714,12 @@ packages:
 
   '@hono/zod-validator@0.2.1':
     resolution: {integrity: sha512-HFoxln7Q6JsE64qz2WBS28SD33UB2alp3aRKmcWnNLDzEL1BLsWfbdX6e1HIiUprHYTIXf5y7ax8eYidKUwyaA==}
+    peerDependencies:
+      hono: '>=3.9.0'
+      zod: ^3.19.1
+
+  '@hono/zod-validator@0.4.3':
+    resolution: {integrity: sha512-xIgMYXDyJ4Hj6ekm9T9Y27s080Nl9NXHcJkOvkXPhubOLj8hZkOL8pDnnXfvCf5xEE8Q4oMFenQUZZREUY2gqQ==}
     peerDependencies:
       hono: '>=3.9.0'
       zod: ^3.19.1
@@ -8712,6 +8758,11 @@ snapshots:
       openapi3-ts: 4.5.0
       zod: 3.25.76
 
+  '@asteasolutions/zod-to-openapi@7.3.4(zod@3.25.76)':
+    dependencies:
+      openapi3-ts: 4.5.0
+      zod: 3.25.76
+
   '@axis-ds/theme@1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@4.2.1)':
     dependencies:
       '@axis-ds/tokens': 1.1.1(tailwindcss@4.2.1)
@@ -9798,6 +9849,13 @@ snapshots:
     dependencies:
       hono: 4.12.8
 
+  '@hono/zod-openapi@0.18.4(hono@4.12.8)(zod@3.25.76)':
+    dependencies:
+      '@asteasolutions/zod-to-openapi': 7.3.4(zod@3.25.76)
+      '@hono/zod-validator': 0.4.3(hono@4.12.8)(zod@3.25.76)
+      hono: 4.12.8
+      zod: 3.25.76
+
   '@hono/zod-openapi@0.9.10(hono@4.12.8)(zod@3.25.76)':
     dependencies:
       '@asteasolutions/zod-to-openapi': 5.5.0(zod@3.25.76)
@@ -9806,6 +9864,11 @@ snapshots:
       zod: 3.25.76
 
   '@hono/zod-validator@0.2.1(hono@4.12.8)(zod@3.25.76)':
+    dependencies:
+      hono: 4.12.8
+      zod: 3.25.76
+
+  '@hono/zod-validator@0.4.3(hono@4.12.8)(zod@3.25.76)':
     dependencies:
       hono: 4.12.8
       zod: 3.25.76


### PR DESCRIPTION
## Summary
- `packages/gate-x/` 독립 Cloudflare Workers 패키지 생성 (harness-kit 기반)
- `packages/api/src/modules/gate/`의 20개 파일을 gate-x로 이전 (7R+7S+6Sch)
- 크로스 모듈 의존 완전 해소 (PipelineAdapter, NotificationAdapter)

## F-items
- F402: Gate-X 독립 Workers scaffold + D1 전용 DB
- F403: Gate 모듈 추출 (7 routes + 7 services + 6 schemas)

## Changes
- `packages/gate-x/` 신규 (39 files, 2171 LOC)
- D1 초기 마이그레이션: 12개 테이블 (`0001_initial.sql`)
- `GET /api/health` 공개 엔드포인트
- 7/7 단위 테스트 통과, typecheck 0 errors
- Match Rate: **97%**

## Test plan
- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm test` — 7/7 passed
- [x] Cross-module imports 0 (portal/launch/core 참조 없음)
- [x] D1 migration SQL 12 tables
- [x] Health endpoint returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)