### PR TITLE
feat: Sprint 204 — F425+F426 Builder v2 LLM 판별 고도화

### DIFF
--- a/docs/01-plan/features/sprint-204.plan.md
+++ b/docs/01-plan/features/sprint-204.plan.md
@@ -1,0 +1,70 @@
+---
+code: FX-PLAN-S204
+title: Sprint 204 — F425+F426 Builder v2 LLM 판별 고도화
+version: 1.0
+status: Active
+category: PLAN
+created: 2026-04-07
+updated: 2026-04-07
+author: Claude (Autopilot)
+sprint: 204
+f_items: F425, F426
+---
+
+# Sprint 204 Plan — F425+F426 Builder v2 LLM 판별 고도화
+
+## 1. 목표
+
+Phase 22-D (Prototype Builder v2)의 핵심 판별 정확도 개선.
+
+- **F425**: `prdScore` 함수의 키워드 매칭 → LLM 의미 비교 교체 (기본 경로 변경)
+- **F426**: 5차원 전체를 LLM이 통합 평가하는 `evaluateQualityWithLlm` 신규 구현
+
+## 2. 배경
+
+현재 `scorer.ts`는:
+- `prdScore(job, workDir, { useLlm: false })` — 기본값이 키워드 모드
+- 5차원 평가 모두 정적 분석으로만 동작
+- LLM 경로(`prdScoreWithLlm`)는 구현되어 있지만 옵트인
+
+PRD 2.1 As-Is에서 명시: "PRD 정합성(25%)은 키워드 매칭 수준 — 의미적 반영도 미평가"
+
+## 3. 범위
+
+### F425: PRD 정합성 LLM 판별
+- `prdScoreWithLlm` 프롬프트 개선: Must Have 요구사항 목록 추출 → 각 항목 의미 비교
+- LLM 기본 경로 활성화 (`useLlm` 기본값 `true`)
+- 결과에 `missingRequirements` 배열 포함 (피드백 품질 향상)
+- 키워드 모드는 fallback으로 유지 (API 키 없음 / 호출 실패)
+
+### F426: 5차원 LLM 통합 판별
+- 신규 함수 `evaluateQualityWithLlm(job, workDir)` 추가
+  1. 정적 분석 5차원 먼저 실행 (보조 데이터)
+  2. 정적 결과 + 소스코드 요약을 컨텍스트로 단일 LLM 호출
+  3. LLM이 5차원 각각 점수 + 근거 + 개선 지시 반환
+  4. 최종 점수 = LLM 판정 (정적 분석은 참고용)
+- `evaluateQuality`에 `{ useLlmIntegrated: true }` 옵션 추가
+- 기존 테스트 호환성 유지
+
+## 4. 파일 변경
+
+| 파일 | 변경 유형 | 내용 |
+|------|-----------|------|
+| `prototype-builder/src/scorer.ts` | 수정 | F425 prdScore 개선 + F426 통합 판별 함수 추가 |
+| `prototype-builder/src/types.ts` | 수정 | `LlmDimensionResult`, `IntegratedEvalOptions` 타입 추가 |
+| `prototype-builder/src/orchestrator.ts` | 수정 | `useLlmIntegrated` 옵션 전달 |
+| `prototype-builder/src/__tests__/scorer.test.ts` | 수정 | F425/F426 신규 테스트 추가 |
+
+## 5. 성공 기준
+
+- [ ] F425: `prdScore(..., { useLlm: true })` 가 의미론적 비교로 동작
+- [ ] F425: LLM 기본값 활성화 (orchestrator `useLlm: true`)
+- [ ] F426: `evaluateQualityWithLlm` 함수 존재 + 5차원 LLM 점수 반환
+- [ ] F426: 정적 분석 결과를 `staticAnalysis` 필드로 포함
+- [ ] 테스트: LLM mock으로 F425/F426 시나리오 커버
+- [ ] `pnpm typecheck` 통과
+
+## 6. 비고
+
+- `useLlm` 기본값 변경은 orchestrator 레벨에서만 (scorer 함수 시그니처는 하위 호환 유지)
+- `ANTHROPIC_API_KEY` 없을 때 fallback 동작 유지 필수

--- a/docs/02-design/features/sprint-204.design.md
+++ b/docs/02-design/features/sprint-204.design.md
@@ -1,0 +1,197 @@
+---
+code: FX-DSGN-S204
+title: Sprint 204 Design — F425+F426 LLM 판별 고도화
+version: 1.0
+status: Active
+category: DSGN
+created: 2026-04-07
+updated: 2026-04-07
+author: Claude (Autopilot)
+sprint: 204
+f_items: F425, F426
+---
+
+# Sprint 204 Design — F425+F426 LLM 판별 고도화
+
+## §1. F425: PRD 정합성 LLM 판별 개선
+
+### 1.1 현재 구현 (As-Is)
+
+```ts
+// prdScoreWithLlm — 단순 카운트
+prompt: "PRD와 코드를 비교해 implemented/total/missing을 JSON으로 반환"
+// → {"implemented": 5, "total": 8, "missing": ["기능A", ...]}
+```
+
+문제: PRD에서 요구사항을 자동 추출하지 않음. LLM이 직접 요구사항을 판단.
+
+### 1.2 개선 설계 (To-Be)
+
+**2단계 프롬프트 구조**:
+
+1단계 (요구사항 추출): PRD 텍스트에서 Must Have 항목을 structured list로 추출  
+2단계 (의미적 비교): 추출된 요구사항 목록 vs 생성 코드 — 각 항목별 구현 여부 판단
+
+**단일 LLM 호출로 통합** (비용 절감):
+
+```
+프롬프트 구조:
+[PRD 전문] + [생성 코드 요약] →
+LLM이 동시에:
+  1. Must Have 요구사항 목록 추출
+  2. 각 요구사항의 구현 여부 평가
+  3. 미구현 항목에 구체적 수정 지시 생성
+```
+
+**응답 스키마 (JSON)**:
+```json
+{
+  "requirements": [
+    { "id": 1, "text": "사용자 인증 로그인", "implemented": true, "evidence": "LoginForm 컴포넌트 존재" },
+    { "id": 2, "text": "대시보드 차트", "implemented": false, "evidence": null, "fix": "Chart 컴포넌트 추가 필요" }
+  ],
+  "summary": { "implemented": 5, "total": 8, "score": 0.625 }
+}
+```
+
+### 1.3 fallback 체계
+
+```
+API 키 없음 → prdScoreKeyword() 즉시
+API 호출 실패 → prdScoreKeyword() with warning log
+응답 파싱 실패 → prdScoreKeyword() with warning log
+```
+
+---
+
+## §2. F426: 5차원 LLM 통합 판별
+
+### 2.1 설계 원칙
+
+- 정적 분석은 **컨텍스트 제공** 역할 (보조 데이터)
+- LLM은 정적 결과를 참고하되, 독자적으로 5차원 재평가
+- LLM이 정적 분석과 다른 점수를 내면 LLM 우선
+
+### 2.2 함수 시그니처
+
+```ts
+export async function evaluateQualityWithLlm(
+  job: PrototypeJob,
+  workDir: string,
+): Promise<QualityScore>
+```
+
+내부 흐름:
+1. 정적 분석 5차원 실행 (기존 함수들)
+2. 소스 코드 요약 수집
+3. 단일 LLM 호출 (정적 결과 + 코드 요약 컨텍스트)
+4. LLM JSON 응답 파싱 → `QualityScore` 반환
+
+### 2.3 LLM 프롬프트
+
+```
+당신은 React/TypeScript 프로토타입의 품질을 평가하는 전문가입니다.
+
+## 정적 분석 결과 (참고용)
+build: 95, ui: 72, functional: 68, prd: 60, code: 85
+
+## 소스 코드 요약
+[최대 8000자]
+
+## PRD 요구사항
+[최대 4000자]
+
+## 평가 기준
+각 차원을 0~100점으로 평가하고, 구체적 근거와 개선 지시를 제공하세요.
+
+JSON 형식:
+{
+  "build": { "score": 95, "rationale": "...", "fix": null },
+  "ui": { "score": 70, "rationale": "...", "fix": "폰트 페어링 개선..." },
+  "functional": { "score": 65, "rationale": "...", "fix": "..." },
+  "prd": { "score": 75, "rationale": "...", "fix": "..." },
+  "code": { "score": 80, "rationale": "...", "fix": null }
+}
+```
+
+### 2.4 타입 추가
+
+```ts
+// types.ts에 추가
+export interface LlmDimensionResult {
+  score: number;      // 0 ~ 100
+  rationale: string;
+  fix: string | null;
+}
+
+export interface LlmIntegratedEvaluation {
+  build: LlmDimensionResult;
+  ui: LlmDimensionResult;
+  functional: LlmDimensionResult;
+  prd: LlmDimensionResult;
+  code: LlmDimensionResult;
+}
+```
+
+### 2.5 QualityScore 확장
+
+`QualityScore`에 선택적 필드 추가 (하위 호환):
+
+```ts
+export interface QualityScore {
+  total: number;
+  dimensions: DimensionScore[];
+  evaluatedAt: string;
+  round: number;
+  jobId: string;
+  // 추가 (F426)
+  llmEvaluation?: LlmIntegratedEvaluation;  // LLM 통합 판별 결과
+  staticAnalysis?: DimensionScore[];         // 원본 정적 분석 (보조)
+}
+```
+
+### 2.6 orchestrator 통합
+
+```ts
+// OgdOptions에 useLlmIntegrated 추가
+export interface OgdOptions {
+  maxRounds?: number;
+  qualityThreshold?: number;
+  costTracker?: CostTracker;
+  useLlm?: boolean;           // F425: prd 차원 LLM 기본
+  useLlmIntegrated?: boolean; // F426: 5차원 LLM 통합
+}
+```
+
+---
+
+## §3. 테스트 설계
+
+### 3.1 F425 테스트
+
+| 케이스 | 설명 | 기대값 |
+|--------|------|--------|
+| LLM 요구사항 추출 | requirements 배열 파싱 | 각 항목 `implemented` 필드 |
+| 의미적 매칭 점수 | 7/10 구현 | score ≈ 0.70 |
+| API 키 없음 fallback | keyword 모드 | `details`에 'keyword' 포함 없음 |
+| 응답 파싱 실패 | JSON 오류 | keyword fallback, 에러 throw 없음 |
+
+### 3.2 F426 테스트
+
+| 케이스 | 설명 | 기대값 |
+|--------|------|--------|
+| 5차원 LLM 평가 | 정상 응답 | `dimensions` 5개, `llmEvaluation` 존재 |
+| staticAnalysis 보존 | 정적 결과 포함 | `staticAnalysis` 필드에 원본 있음 |
+| LLM 실패 fallback | API 오류 | 정적 분석 결과로 fallback, 에러 throw 없음 |
+| 가중치 합 | 5차원 가중치 | 합 = 1.0 |
+
+---
+
+## §4. 구현 파일 매핑
+
+| Worker | 파일 | 변경 내용 |
+|--------|------|-----------|
+| W1 | `prototype-builder/src/types.ts` | `LlmDimensionResult`, `LlmIntegratedEvaluation` 타입 + `QualityScore` 확장 |
+| W1 | `prototype-builder/src/scorer.ts` | `prdScoreWithLlm` 개선 (F425) + `evaluateQualityWithLlm` 신규 (F426) |
+| W1 | `prototype-builder/src/orchestrator.ts` | `useLlmIntegrated` 옵션 + 기본값 `useLlm: true` |
+| W1 | `prototype-builder/src/__tests__/scorer.test.ts` | F425/F426 테스트 케이스 추가 |

--- a/prototype-builder/src/__tests__/scorer.test.ts
+++ b/prototype-builder/src/__tests__/scorer.test.ts
@@ -27,6 +27,7 @@ import fs from 'node:fs/promises';
 import Anthropic from '@anthropic-ai/sdk';
 import {
   evaluateQuality,
+  evaluateQualityWithLlm,
   generateTargetFeedback,
   functionalScore,
   prdScore,
@@ -136,16 +137,23 @@ describe('scorer', () => {
   });
 
   describe('prdScore (LLM mode)', () => {
-    it('LLM 응답에서 implemented/total을 파싱해 점수를 산출해요', async () => {
+    it('LLM 응답에서 requirements/summary를 파싱해 점수를 산출해요 (F425 신규 포맷)', async () => {
       const job = makeJob({
         prdContent: '## Must Have\n- 대시보드\n- 차트\n- 로그인',
       });
 
-      // Mock Anthropic API
+      // Mock Anthropic API — F425 신규 포맷 (requirements + summary)
       const mockCreate = vi.fn().mockResolvedValue({
         content: [{
           type: 'text',
-          text: '{"implemented": 2, "total": 3, "missing": ["로그인"]}',
+          text: JSON.stringify({
+            requirements: [
+              { id: 1, text: '대시보드', implemented: true, evidence: 'Dashboard.tsx', fix: null },
+              { id: 2, text: '차트', implemented: true, evidence: 'Chart 존재', fix: null },
+              { id: 3, text: '로그인', implemented: false, evidence: null, fix: 'LoginForm 추가' },
+            ],
+            summary: { implemented: 2, total: 3, score: 0.667 },
+          }),
         }],
       });
       vi.mocked(Anthropic).mockImplementation(() => ({
@@ -332,6 +340,171 @@ describe('scorer', () => {
       const feedback = generateTargetFeedback(score);
       expect(feedback.weakestDimension).toBe('prd');
       expect(feedback.prompt).toContain('Must Have');
+    });
+  });
+
+  // ─────────────────────────────────────────────
+  // F425: PRD 정합성 LLM 판별 개선
+  // ─────────────────────────────────────────────
+  describe('F425: prdScore LLM 의미론적 비교', () => {
+    it('requirements 배열이 포함된 LLM 응답을 파싱해 점수를 산출해요', async () => {
+      const job = makeJob({
+        prdContent: '## Must Have\n- 사용자 인증 로그인\n- 대시보드 차트\n- 데이터 필터',
+      });
+
+      const mockCreate = vi.fn().mockResolvedValue({
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            requirements: [
+              { id: 1, text: '사용자 인증 로그인', implemented: true, evidence: 'LoginForm 존재', fix: null },
+              { id: 2, text: '대시보드 차트', implemented: true, evidence: 'ChartComponent 존재', fix: null },
+              { id: 3, text: '데이터 필터', implemented: false, evidence: null, fix: 'FilterPanel 추가 필요' },
+            ],
+            summary: { implemented: 2, total: 3, score: 0.667 },
+          }),
+        }],
+      });
+      vi.mocked(Anthropic).mockImplementation(() => ({
+        messages: { create: mockCreate },
+      }) as unknown as Anthropic);
+
+      process.env['ANTHROPIC_API_KEY'] = 'test-key';
+      mockFs.readdir.mockResolvedValue([] as never);
+
+      const result = await prdScore(job, '/tmp/test', { useLlm: true });
+
+      expect(result.dimension).toBe('prd');
+      expect(result.score).toBeCloseTo(0.67, 1);
+      expect(result.details).toContain('LLM');
+      expect(result.details).toContain('2/3');
+      expect(result.details).toContain('데이터 필터');
+
+      delete process.env['ANTHROPIC_API_KEY'];
+    });
+
+    it('LLM 응답 파싱 실패 시 keyword fallback으로 에러 없이 동작해요', async () => {
+      const job = makeJob({ prdContent: '대시보드 구현' });
+
+      const mockCreate = vi.fn().mockResolvedValue({
+        content: [{ type: 'text', text: 'invalid json {{{{' }],
+      });
+      vi.mocked(Anthropic).mockImplementation(() => ({
+        messages: { create: mockCreate },
+      }) as unknown as Anthropic);
+
+      process.env['ANTHROPIC_API_KEY'] = 'test-key';
+      mockFs.readdir.mockResolvedValue([] as never);
+
+      const result = await prdScore(job, '/tmp/test', { useLlm: true });
+      expect(result.dimension).toBe('prd');
+      // fallback: 에러 throw 없이 반환
+
+      delete process.env['ANTHROPIC_API_KEY'];
+    });
+  });
+
+  // ─────────────────────────────────────────────
+  // F426: 5차원 LLM 통합 판별
+  // ─────────────────────────────────────────────
+  describe('F426: evaluateQualityWithLlm 5차원 통합 판별', () => {
+    it('LLM이 5차원을 평가하고 llmEvaluation + staticAnalysis를 포함해요', async () => {
+      const job = makeJob();
+
+      const llmResponse = {
+        build: { score: 90, rationale: '빌드 성공', fix: null },
+        ui: { score: 72, rationale: '시맨틱 미흡', fix: 'header 추가' },
+        functional: { score: 68, rationale: '핸들러 부족', fix: 'onClick 추가' },
+        prd: { score: 80, rationale: '8/10 구현', fix: '차트 미구현' },
+        code: { score: 85, rationale: 'TS 에러 1건', fix: null },
+      };
+
+      const mockCreate = vi.fn().mockResolvedValue({
+        content: [{ type: 'text', text: JSON.stringify(llmResponse) }],
+      });
+      vi.mocked(Anthropic).mockImplementation(() => ({
+        messages: { create: mockCreate },
+      }) as unknown as Anthropic);
+
+      process.env['ANTHROPIC_API_KEY'] = 'test-key';
+      mockFs.readdir.mockResolvedValue([] as never);
+      mockExecSuccess();
+
+      const result = await evaluateQualityWithLlm(job, '/tmp/test');
+
+      expect(result.dimensions).toHaveLength(5);
+      expect(result.llmEvaluation).toBeDefined();
+      expect(result.staticAnalysis).toBeDefined();
+      expect(result.llmEvaluation?.ui.score).toBe(72);
+      expect(result.llmEvaluation?.ui.fix).toBe('header 추가');
+      expect(result.total).toBeGreaterThan(0);
+      expect(result.total).toBeLessThanOrEqual(100);
+
+      // LLM 점수가 dimensions에 반영되는지 확인
+      const uiDim = result.dimensions.find(d => d.dimension === 'ui');
+      expect(uiDim?.details).toContain('LLM');
+      expect(uiDim?.details).toContain('72');
+
+      delete process.env['ANTHROPIC_API_KEY'];
+    });
+
+    it('API 키 없으면 정적 분석으로 fallback하고 staticAnalysis 필드를 포함해요', async () => {
+      delete process.env['ANTHROPIC_API_KEY'];
+      mockFs.readdir.mockResolvedValue([] as never);
+      mockExecSuccess();
+
+      const result = await evaluateQualityWithLlm(makeJob(), '/tmp/test');
+
+      expect(result.dimensions).toHaveLength(5);
+      expect(result.staticAnalysis).toBeDefined();
+      expect(result.llmEvaluation).toBeUndefined();
+    });
+
+    it('LLM 호출 실패 시 정적 분석 fallback, 에러 throw 없어요', async () => {
+      const mockCreate = vi.fn().mockRejectedValue(new Error('API timeout'));
+      vi.mocked(Anthropic).mockImplementation(() => ({
+        messages: { create: mockCreate },
+      }) as unknown as Anthropic);
+
+      process.env['ANTHROPIC_API_KEY'] = 'test-key';
+      mockFs.readdir.mockResolvedValue([] as never);
+      mockExecSuccess();
+
+      const result = await evaluateQualityWithLlm(makeJob(), '/tmp/test');
+
+      expect(result.dimensions).toHaveLength(5);
+      expect(result.staticAnalysis).toBeDefined();
+
+      delete process.env['ANTHROPIC_API_KEY'];
+    });
+
+    it('evaluateQuality(useLlmIntegrated: true)이 evaluateQualityWithLlm을 호출해요', async () => {
+      const mockCreate = vi.fn().mockResolvedValue({
+        content: [{ type: 'text', text: JSON.stringify({
+          build: { score: 85, rationale: 'OK', fix: null },
+          ui: { score: 75, rationale: 'OK', fix: null },
+          functional: { score: 70, rationale: 'OK', fix: null },
+          prd: { score: 80, rationale: 'OK', fix: null },
+          code: { score: 90, rationale: 'OK', fix: null },
+        }) }],
+      });
+      vi.mocked(Anthropic).mockImplementation(() => ({
+        messages: { create: mockCreate },
+      }) as unknown as Anthropic);
+
+      process.env['ANTHROPIC_API_KEY'] = 'test-key';
+      mockFs.readdir.mockResolvedValue([] as never);
+      mockExecSuccess();
+
+      const result = await evaluateQuality(makeJob(), '/tmp/test', {
+        useLlmIntegrated: true,
+        skipBuild: false,
+      });
+
+      expect(result.llmEvaluation).toBeDefined();
+      expect(mockCreate).toHaveBeenCalled();
+
+      delete process.env['ANTHROPIC_API_KEY'];
     });
   });
 });

--- a/prototype-builder/src/orchestrator.ts
+++ b/prototype-builder/src/orchestrator.ts
@@ -27,7 +27,10 @@ export interface OgdOptions {
   maxRounds?: number;
   qualityThreshold?: number;
   costTracker?: CostTracker;
+  /** F425: prd 차원 LLM 의미 비교 활성화 (기본값 true) */
   useLlm?: boolean;
+  /** F426: 5차원 LLM 통합 판별 활성화 */
+  useLlmIntegrated?: boolean;
 }
 
 /**
@@ -48,7 +51,8 @@ export async function runOgdLoop(
   const maxRounds = options.maxRounds ?? 5;
   const qualityThreshold = options.qualityThreshold ?? 80;
   const costTracker = options.costTracker;
-  const useLlm = options.useLlm ?? false;
+  const useLlm = options.useLlm ?? true;           // F425: LLM 기본 활성화
+  const useLlmIntegrated = options.useLlmIntegrated ?? false; // F426: 통합 판별
 
   let bestScore = 0;
   let bestOutput = '';
@@ -74,7 +78,7 @@ export async function runOgdLoop(
     console.log(`[OGD] Generator succeeded (level: ${generated.level})`);
 
     // 2. Scorer: 5차원 품질 평가
-    const score = await evaluateQuality(job, job.workDir, { useLlm });
+    const score = await evaluateQuality(job, job.workDir, { useLlm, useLlmIntegrated });
     console.log(`[OGD] Score: ${score.total}/100 (dimensions: ${score.dimensions.map(d => `${d.dimension}=${(d.score * 100).toFixed(0)}`).join(', ')})`);
 
     // 3. 비용 추적

--- a/prototype-builder/src/scorer.ts
+++ b/prototype-builder/src/scorer.ts
@@ -20,6 +20,8 @@ import type {
   DimensionScore,
   ScoreDimension,
   TargetFeedback,
+  LlmDimensionResult,
+  LlmIntegratedEvaluation,
 } from './types.js';
 import { DIMENSION_WEIGHTS } from './types.js';
 
@@ -288,17 +290,26 @@ function prdScoreKeyword(
 }
 
 /**
- * PRD → 생성코드 LLM 비교 응답 타입
+ * PRD → 생성코드 LLM 비교 응답 타입 (F425 개선)
  */
+interface PrdRequirement {
+  id: number;
+  text: string;
+  implemented: boolean;
+  evidence: string | null;
+  fix?: string;
+}
+
 interface PrdLlmResponse {
-  implemented: number;
-  total: number;
-  missing: string[];
+  requirements: PrdRequirement[];
+  summary: { implemented: number; total: number; score: number };
 }
 
 /**
- * PRD LLM 비교 (M1 본구현)
- * Claude Sonnet API, temperature 0, 구조화 JSON 응답
+ * PRD LLM 의미론적 비교 (F425 본구현)
+ * - PRD에서 Must Have 요구사항을 구조화된 목록으로 추출
+ * - 각 요구사항의 코드 내 구현 여부를 의미적으로 판단
+ * - 미구현 항목에 구체적 수정 지시 포함
  */
 async function prdScoreWithLlm(
   job: PrototypeJob,
@@ -307,32 +318,40 @@ async function prdScoreWithLlm(
 ): Promise<DimensionScore> {
   const apiKey = process.env['ANTHROPIC_API_KEY'];
   if (!apiKey) {
-    // API 키 없으면 키워드 모드로 fallback
     return prdScoreKeyword(job.prdContent.toLowerCase(), code, weight);
   }
 
   const client = new Anthropic({ apiKey });
 
   const prompt = [
-    'PRD 문서의 Must Have 기능 목록과 생성된 코드를 비교하세요.',
+    '당신은 PRD 요구사항과 생성된 프로토타입 코드를 비교하는 전문가입니다.',
     '',
-    '## PRD',
-    job.prdContent.slice(0, 8000),
+    '## PRD 문서',
+    job.prdContent.slice(0, 6000),
     '',
     '## 생성된 코드',
-    code.slice(0, 12000),
+    code.slice(0, 10000),
     '',
     '## 지시사항',
-    '1. PRD에서 Must Have / 핵심 기능 항목을 추출하세요.',
-    '2. 생성된 코드에서 각 기능이 구현되었는지 확인하세요.',
-    '3. 아래 JSON 형식으로만 응답하세요 (마크다운 블록 없이 순수 JSON만):',
-    '{"implemented": 5, "total": 8, "missing": ["기능A", "기능B", "기능C"]}',
+    '1. PRD에서 Must Have / 핵심 기능 항목을 추출하세요 (최대 15개)',
+    '2. 각 요구사항이 코드에 의미적으로 구현되었는지 판단하세요',
+    '   - 단순 키워드 존재가 아니라 실제 기능 구현 여부를 확인하세요',
+    '3. 미구현 항목에는 구체적인 수정 지시를 작성하세요',
+    '4. 아래 JSON 형식으로만 응답하세요 (마크다운 블록 없이 순수 JSON):',
+    '',
+    JSON.stringify({
+      requirements: [
+        { id: 1, text: '사용자 로그인 기능', implemented: true, evidence: 'LoginForm 컴포넌트 존재', fix: null },
+        { id: 2, text: '대시보드 차트 표시', implemented: false, evidence: null, fix: 'Chart.tsx 컴포넌트 추가 필요' },
+      ],
+      summary: { implemented: 1, total: 2, score: 0.5 },
+    }),
   ].join('\n');
 
   try {
     const response = await client.messages.create({
       model: 'claude-sonnet-4-6',
-      max_tokens: 512,
+      max_tokens: 1024,
       temperature: 0,
       messages: [{ role: 'user', content: prompt }],
     });
@@ -343,25 +362,190 @@ async function prdScoreWithLlm(
       .join('\n')
       .trim();
 
-    // JSON 파싱 (```json 블록 또는 순수 JSON)
-    const jsonStr = text.replace(/^```json\s*/, '').replace(/```\s*$/, '').trim();
+    const jsonStr = text.replace(/^```json\s*/m, '').replace(/```\s*$/m, '').trim();
     const parsed = JSON.parse(jsonStr) as PrdLlmResponse;
 
-    const total = parsed.total || 1;
-    const score = Math.min(parsed.implemented / total, 1.0);
-    const missingPreview = parsed.missing.slice(0, 5).join(', ');
+    const { implemented, total } = parsed.summary;
+    const score = Math.min(implemented / Math.max(total, 1), 1.0);
+
+    const missing = parsed.requirements
+      .filter(r => !r.implemented)
+      .slice(0, 5)
+      .map(r => r.text);
 
     return {
       dimension: 'prd',
       score: Math.round(score * 100) / 100,
       weight,
       weighted: Math.round(score * weight * 100) / 100,
-      details: `LLM: ${parsed.implemented}/${total} implemented. Missing: ${missingPreview || 'none'}`,
+      details: `LLM: ${implemented}/${total} implemented. Missing: ${missing.join(', ') || 'none'}`,
     };
   } catch (err) {
-    // LLM 호출 실패 시 키워드 모드로 fallback
     console.log(`[Scorer] prdScore LLM failed, falling back to keyword: ${String(err).slice(0, 100)}`);
     return prdScoreKeyword(job.prdContent.toLowerCase(), code, weight);
+  }
+}
+
+// ─────────────────────────────────────────────
+// F426: 5차원 LLM 통합 판별
+// ─────────────────────────────────────────────
+
+/**
+ * LLM 통합 판별 응답 타입 (F426)
+ */
+interface LlmIntegratedResponse {
+  build: { score: number; rationale: string; fix: string | null };
+  ui: { score: number; rationale: string; fix: string | null };
+  functional: { score: number; rationale: string; fix: string | null };
+  prd: { score: number; rationale: string; fix: string | null };
+  code: { score: number; rationale: string; fix: string | null };
+}
+
+/**
+ * 5차원 LLM 통합 판별 (F426)
+ * - 정적 분석 결과를 컨텍스트로 단일 LLM 호출
+ * - LLM이 5차원 전체를 재평가하고 구체적 개선 지시 반환
+ * - 최종 점수 = LLM 판정 (정적 분석은 보조 데이터)
+ */
+export async function evaluateQualityWithLlm(
+  job: PrototypeJob,
+  workDir: string,
+): Promise<QualityScore> {
+  // Step 1: 정적 분석 실행 (보조 데이터)
+  const [buildResult, uiResult, funcResult, codeResult] = await Promise.all([
+    buildScore(workDir),
+    uiScore(workDir),
+    functionalScore(workDir),
+    codeScore(workDir),
+  ]);
+  const staticDimensions = [buildResult, uiResult, funcResult, codeResult];
+
+  const apiKey = process.env['ANTHROPIC_API_KEY'];
+  if (!apiKey) {
+    // API 키 없으면 prdScore 포함해 정적 분석 전체로 fallback
+    const prdResult = await prdScore(job, workDir, { useLlm: false });
+    const allDimensions = [...staticDimensions, prdResult];
+    const total = Math.round(allDimensions.reduce((s, d) => s + d.weighted, 0) * 100);
+    return {
+      total,
+      dimensions: allDimensions,
+      evaluatedAt: new Date().toISOString(),
+      round: job.round,
+      jobId: job.id,
+      staticAnalysis: allDimensions,
+    };
+  }
+
+  // Step 2: 소스 코드 요약 수집
+  const srcFiles = await collectSourceFiles(workDir);
+  const codeSummary = srcFiles.join('\n').slice(0, 8000);
+
+  // Step 3: 정적 분석 요약 문자열
+  const staticSummary = staticDimensions
+    .map(d => `${d.dimension}: ${Math.round(d.score * 100)} (${d.details})`)
+    .join('\n');
+
+  const client = new Anthropic({ apiKey });
+
+  const prompt = [
+    '당신은 React/TypeScript 프로토타입의 품질을 평가하는 시니어 엔지니어입니다.',
+    '',
+    '## 정적 분석 결과 (참고용)',
+    staticSummary,
+    '',
+    '## 소스 코드',
+    codeSummary || '(소스 파일 없음)',
+    '',
+    '## PRD 요구사항',
+    job.prdContent.slice(0, 3000),
+    '',
+    '## 평가 지시사항',
+    '정적 분석 결과를 참고하되, 코드를 직접 읽고 5개 차원을 0~100점으로 재평가하세요.',
+    '각 차원에 점수 근거와 (필요 시) 구체적 개선 지시를 작성하세요.',
+    '',
+    '차원 정의:',
+    '- build (20%): 빌드 안정성, 경고/에러 수',
+    '- ui (25%): 레이아웃 품질, 시맨틱 구조, 접근성, 디자인 완성도',
+    '- functional (20%): 인터랙티브 기능, 핸들러, 상태 관리',
+    '- prd (25%): PRD Must Have 요구사항 구현 완성도',
+    '- code (10%): 코드 품질, ESLint/TypeScript 준수',
+    '',
+    '순수 JSON으로만 응답하세요:',
+    JSON.stringify({
+      build: { score: 90, rationale: '빌드 성공, 경고 2건', fix: null },
+      ui: { score: 70, rationale: '시맨틱 구조 미흡', fix: 'header/main/footer 추가' },
+      functional: { score: 65, rationale: '핸들러 부족', fix: 'onClick 핸들러 추가' },
+      prd: { score: 80, rationale: '8/10 요구사항 구현', fix: '차트 컴포넌트 미구현' },
+      code: { score: 85, rationale: 'TS 에러 1건', fix: 'any 타입 제거' },
+    }),
+  ].join('\n');
+
+  try {
+    const response = await client.messages.create({
+      model: 'claude-sonnet-4-6',
+      max_tokens: 1024,
+      temperature: 0,
+      messages: [{ role: 'user', content: prompt }],
+    });
+
+    const text = response.content
+      .filter((block): block is Anthropic.TextBlock => block.type === 'text')
+      .map(block => block.text)
+      .join('\n')
+      .trim();
+
+    const jsonStr = text.replace(/^```json\s*/m, '').replace(/```\s*$/m, '').trim();
+    const llmResult = JSON.parse(jsonStr) as LlmIntegratedResponse;
+
+    // LLM 점수를 DimensionScore 배열로 변환
+    const dimensions: DimensionScore[] = (
+      ['build', 'ui', 'functional', 'prd', 'code'] as const
+    ).map(dim => {
+      const llm = llmResult[dim];
+      const score = Math.min(Math.max(llm.score / 100, 0), 1.0);
+      const weight = DIMENSION_WEIGHTS[dim];
+      return {
+        dimension: dim,
+        score: Math.round(score * 100) / 100,
+        weight,
+        weighted: Math.round(score * weight * 100) / 100,
+        details: `LLM: ${llm.score}/100 — ${llm.rationale}${llm.fix ? ` | Fix: ${llm.fix}` : ''}`,
+      };
+    });
+
+    const total = Math.round(dimensions.reduce((s, d) => s + d.weighted, 0) * 100);
+
+    const llmEvaluation: LlmIntegratedEvaluation = {
+      build: { score: llmResult.build.score, rationale: llmResult.build.rationale, fix: llmResult.build.fix },
+      ui: { score: llmResult.ui.score, rationale: llmResult.ui.rationale, fix: llmResult.ui.fix },
+      functional: { score: llmResult.functional.score, rationale: llmResult.functional.rationale, fix: llmResult.functional.fix },
+      prd: { score: llmResult.prd.score, rationale: llmResult.prd.rationale, fix: llmResult.prd.fix },
+      code: { score: llmResult.code.score, rationale: llmResult.code.rationale, fix: llmResult.code.fix },
+    };
+
+    return {
+      total,
+      dimensions,
+      evaluatedAt: new Date().toISOString(),
+      round: job.round,
+      jobId: job.id,
+      llmEvaluation,
+      staticAnalysis: staticDimensions,
+    };
+  } catch (err) {
+    console.log(`[Scorer] evaluateQualityWithLlm failed, falling back to static: ${String(err).slice(0, 100)}`);
+    // fallback: 정적 분석 전체
+    const prdResult = await prdScore(job, workDir, { useLlm: false });
+    const allDimensions = [...staticDimensions, prdResult];
+    const total = Math.round(allDimensions.reduce((s, d) => s + d.weighted, 0) * 100);
+    return {
+      total,
+      dimensions: allDimensions,
+      evaluatedAt: new Date().toISOString(),
+      round: job.round,
+      jobId: job.id,
+      staticAnalysis: allDimensions,
+    };
   }
 }
 
@@ -433,12 +617,17 @@ export async function codeScore(workDir: string): Promise<DimensionScore> {
 
 /**
  * 5차원 품질 평가 — 전체 통합
+ * useLlmIntegrated: F426 5차원 LLM 통합 판별 활성화 (evaluateQualityWithLlm 호출)
  */
 export async function evaluateQuality(
   job: PrototypeJob,
   workDir: string,
-  options: { useLlm?: boolean; skipBuild?: boolean } = {},
+  options: { useLlm?: boolean; skipBuild?: boolean; useLlmIntegrated?: boolean } = {},
 ): Promise<QualityScore> {
+  if (options.useLlmIntegrated) {
+    return evaluateQualityWithLlm(job, workDir);
+  }
+
   const dimensions: DimensionScore[] = [];
 
   // 병렬로 독립적인 평가 실행

--- a/prototype-builder/src/types.ts
+++ b/prototype-builder/src/types.ts
@@ -82,6 +82,22 @@ export interface DimensionScore {
   details: string;
 }
 
+/** LLM 차원별 판별 결과 (F426) */
+export interface LlmDimensionResult {
+  score: number;      // 0 ~ 100
+  rationale: string;
+  fix: string | null;
+}
+
+/** LLM 통합 판별 전체 결과 (F426) */
+export interface LlmIntegratedEvaluation {
+  build: LlmDimensionResult;
+  ui: LlmDimensionResult;
+  functional: LlmDimensionResult;
+  prd: LlmDimensionResult;
+  code: LlmDimensionResult;
+}
+
 /** 전체 품질 스코어 */
 export interface QualityScore {
   total: number;           // 0 ~ 100 (가중 평균 * 100)
@@ -89,6 +105,10 @@ export interface QualityScore {
   evaluatedAt: string;
   round: number;
   jobId: string;
+  /** F426: LLM 통합 판별 결과 (선택) */
+  llmEvaluation?: LlmIntegratedEvaluation;
+  /** F426: 원본 정적 분석 결과 (LLM 통합 시 보조 데이터) */
+  staticAnalysis?: DimensionScore[];
 }
 
 /** 타겟 피드백 */


### PR DESCRIPTION
## Summary
- **F425** PRD 정합성 LLM 판별: `prdScore` 키워드 매칭 → LLM 의미 비교 교체. requirements 배열 포맷으로 각 요구사항 의미적 구현 여부 판단, 미구현 항목 수정 지시 포함
- **F426** 5차원 LLM 통합 판별: `evaluateQualityWithLlm` 신규 함수. 정적 분석을 컨텍스트로 단일 LLM 호출로 5차원 재평가. `QualityScore`에 `llmEvaluation` + `staticAnalysis` 필드 추가
- orchestrator `useLlm` 기본값 `true` 변경 (F425 기본 활성화)
- 모든 LLM 경로에 API 키 없음 / 호출 실패 fallback 유지

## Test plan
- [x] `pnpm typecheck` 통과
- [x] 94/94 테스트 통과 (신규 6건: F425 2 + F426 4)
- [x] LLM fallback 시나리오 3종 커버 (API 키 없음 / 응답 파싱 실패 / API 호출 실패)
- [x] `evaluateQuality(useLlmIntegrated: true)` → `evaluateQualityWithLlm` 위임 검증

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)