### PR TITLE
feat: Sprint 205 — F427 Vision API 시각 평가 + F428 max-cli 본격 통합

### DIFF
--- a/docs/01-plan/features/sprint-205.plan.md
+++ b/docs/01-plan/features/sprint-205.plan.md
@@ -1,0 +1,96 @@
+---
+code: FX-PLAN-S205
+title: Sprint 205 — Vision API 시각 평가 + max-cli 본격 통합
+version: "1.0"
+status: Active
+category: PLAN
+created: 2026-04-07
+updated: 2026-04-07
+author: Sinclair Seo
+---
+
+# Sprint 205 Plan — F427 Vision API 시각 평가 + F428 max-cli 본격 통합
+
+## Executive Summary
+
+| 항목 | 내용 |
+|------|------|
+| Sprint | 205 |
+| F-items | F427, F428 |
+| Phase | 22-D (Prototype Builder v2, M4) |
+| PRD | `docs/specs/fx-builder-v2/prd-final.md` |
+| 목표 | Vision API로 UI 시각 평가 고도화 + max-cli 율 제한 백오프 통합 |
+
+---
+
+## 1. 목적 및 배경
+
+Phase 22-D Builder v2 M4 마일스톤의 일환으로:
+
+- **F427**: 기존 `uiScore`는 DOM 정적 분석(태그 다양성, Tailwind 비율 등)만으로 UI 품질을 측정하여 실제 시각적 완성도를 반영하지 못함. Claude Vision API로 스크린샷 기반 시각 평가를 추가해 ui 차원 정확도를 향상.
+- **F428**: max-cli PoC(F384)는 완료했으나 rate limit 발생 시 즉시 실패 처리. 지수 백오프 재시도 + API fallback 자동 전환으로 실운영 안정성 확보. generation_mode를 비용 추적에 기록.
+
+---
+
+## 2. F-item 상세
+
+### F427: Vision API 시각 평가 (FX-REQ-419)
+
+**범위:**
+- `prototype-builder/src/vision-evaluator.ts` 신규 생성
+- Chromium `--headless` 스크린샷 캡처 (available) 또는 HTML 텍스트 fallback
+- Claude Vision API 호출 → 레이아웃/색상/타이포/계층구조/반응형 5항목 평가
+- `scorer.ts` `evaluateQuality`에 `useVisionApi?: boolean` 옵션 추가
+- ui 차원 점수를 Vision 결과로 대체 (정적 분석은 보조 컨텍스트)
+
+**구현 전략:**
+```
+1. Chromium 존재 확인 (google-chrome / chromium / chromium-browser)
+2. 있으면: 빌드된 dist/index.html을 headless로 열어 PNG 스크린샷 → base64
+3. 없으면: HTML 소스를 텍스트로 Claude에 전달 (텍스트 기반 시각 평가)
+4. Claude API (claude-sonnet-4-6) vision 호출
+5. JSON 응답: layout / color / typography / hierarchy / responsive 각 0~100점
+6. 평균 → DimensionScore (ui 차원)
+```
+
+### F428: max-cli 본격 통합 (FX-REQ-420)
+
+**범위:**
+- `prototype-builder/src/types.ts`: `CostRecord`에 `generation_mode?: GenerationMode` 추가
+- `prototype-builder/src/fallback.ts`: `retryWithBackoff` 유틸 + `runMaxCli` 재시도 로직
+- `prototype-builder/src/cost-tracker.ts`: `recordCli` → `generation_mode` 파라미터 포함
+- Rate limit 감지: stderr/stdout에 `rate limit` / `429` / `overloaded` 키워드 탐지
+- 백오프 전략: 초기 1s → 2s → 4s (최대 3회 재시도)
+
+---
+
+## 3. 구현 파일 목록
+
+| 파일 | 변경 | 설명 |
+|------|------|------|
+| `prototype-builder/src/vision-evaluator.ts` | 신규 | F427 핵심 모듈 |
+| `prototype-builder/src/types.ts` | 수정 | CostRecord generation_mode |
+| `prototype-builder/src/fallback.ts` | 수정 | retryWithBackoff + runMaxCli 강화 |
+| `prototype-builder/src/cost-tracker.ts` | 수정 | recordCli generation_mode 파라미터 |
+| `prototype-builder/src/scorer.ts` | 수정 | useVisionApi 옵션 통합 |
+| `prototype-builder/src/__tests__/vision-evaluator.test.ts` | 신규 | F427 단위 테스트 |
+| `prototype-builder/src/__tests__/fallback.test.ts` | 신규 | F428 재시도 로직 테스트 |
+
+---
+
+## 4. 의존성
+
+- `@anthropic-ai/sdk` (기존 의존성) — Vision API 호출
+- `child_process` (Node.js 내장) — Chromium 스크린샷
+- 신규 npm 패키지 없음 (zero-dependency 유지)
+
+---
+
+## 5. 완료 기준
+
+- [ ] `vision-evaluator.ts` 구현 및 단위 테스트 통과
+- [ ] `fallback.ts` 재시도 로직 구현 및 테스트 통과
+- [ ] `evaluateQuality({ useVisionApi: true })` 호출 시 Vision 점수 반영
+- [ ] `CostRecord.generation_mode` 필드 존재
+- [ ] `pnpm typecheck` 통과
+- [ ] `pnpm test` 통과

--- a/docs/02-design/features/sprint-205.design.md
+++ b/docs/02-design/features/sprint-205.design.md
@@ -1,0 +1,136 @@
+---
+code: FX-DSGN-S205
+title: Sprint 205 Design — Vision API 시각 평가 + max-cli 본격 통합
+version: "1.0"
+status: Active
+category: DSGN
+created: 2026-04-07
+updated: 2026-04-07
+author: Sinclair Seo
+---
+
+# Sprint 205 Design — F427 Vision API + F428 max-cli
+
+## 1. 아키텍처 결정
+
+### F427: Vision API 시각 평가
+
+**스크린샷 전략**: 2-tier fallback
+- **Tier 1**: Chromium `--headless=new --screenshot` → PNG → base64 → Claude Vision API
+- **Tier 2**: HTML/CSS 소스 텍스트 → Claude API 텍스트 평가 (ANTHROPIC_API_KEY 필요)
+- **Tier 3**: API 키 없음 → 기본값 50점 반환 (파이프라인 중단 없음)
+
+**평가 항목** (각 0~100점):
+| 항목 | 설명 |
+|------|------|
+| layout | 요소 배치, 여백 일관성, 시각적 균형 |
+| color | 색상 팔레트 일관성, 대비, impeccable 준수 |
+| typography | 폰트 계층, 가독성, 크기/두께 시스템 |
+| hierarchy | 주요 정보 부각, 정보 구조 |
+| responsive | 유연한 레이아웃 동작 가능성 |
+| **overall** | 5항목 평균 → ui 차원 score |
+
+**scorer.ts 통합**:
+```typescript
+// useVisionApi: true → visionEvaluateUi() 호출
+// useVisionApi: false/없음 → 기존 uiScore() 호출 (하위호환 유지)
+evaluateQuality(job, workDir, { useVisionApi: true })
+```
+
+### F428: max-cli 본격 통합
+
+**재시도 전략**: 지수 백오프
+```
+시도 1 → rate limit? → 대기 1s → 시도 2 → rate limit? → 대기 2s → 시도 3
+                            → rate limit? → 대기 4s → 시도 4 (마지막)
+→ 모두 실패 → API fallback
+```
+
+**Rate limit 감지 패턴**:
+- `rate.?limit` (대소문자 무관)
+- `429` (HTTP 상태코드)
+- `too.?many.?requests`
+- `overloaded`
+- `capacity`
+
+**generation_mode 추적**:
+```typescript
+// CostRecord에 generation_mode 필드 추가
+interface CostRecord {
+  generation_mode?: 'max-cli' | 'cli' | 'api' | 'fallback';
+  // ...기존 필드
+}
+```
+
+---
+
+## 2. 파일 구조
+
+```
+prototype-builder/src/
+├── vision-evaluator.ts      # F427 신규 — Vision API 시각 평가
+├── types.ts                 # F428 수정 — CostRecord.generation_mode 추가
+├── fallback.ts              # F428 수정 — isRateLimitError, retryWithBackoff, runMaxCli 강화
+├── cost-tracker.ts          # F428 수정 — recordCli(mode), recordWithMode 추가
+├── scorer.ts                # F427 수정 — evaluateQuality useVisionApi 옵션
+└── __tests__/
+    └── vision-evaluator.test.ts  # F427+F428 테스트 (16 tests)
+```
+
+---
+
+## 3. 인터페이스
+
+### vision-evaluator.ts
+
+```typescript
+interface VisionEvalResult {
+  layout: number;       // 0~100
+  color: number;
+  typography: number;
+  hierarchy: number;
+  responsive: number;
+  overall: number;      // 5항목 평균
+  rationale: string;
+  method: 'screenshot' | 'html-text';
+}
+
+function visionEvaluateUi(workDir: string, options?: { apiKey?: string; chromiumPath?: string }): Promise<VisionEvalResult>
+function visionResultToDimensionScore(result: VisionEvalResult): DimensionScore
+function findChromium(): Promise<string | null>
+function captureScreenshot(htmlPath: string, chromiumPath: string): Promise<string | null>
+```
+
+### fallback.ts 신규 exports
+
+```typescript
+function isRateLimitError(message: string): boolean
+function retryWithBackoff<T>(fn: () => Promise<T>, options?: RetryOptions): Promise<T>
+// runMaxCli 반환 타입 변경: + retryCount: number
+```
+
+---
+
+## 4. 테스트 커버리지
+
+| 테스트 파일 | 테스트 수 | 대상 |
+|------------|---------|------|
+| vision-evaluator.test.ts | 16 | visionResultToDimensionScore, isRateLimitError, retryWithBackoff |
+| 기존 테스트 | 94 | executor, scorer, fallback, state-machine, cli-poc, orchestrator |
+| **합계** | **110** | — |
+
+---
+
+## 5. Gap Analysis 기준
+
+| 항목 | 기준 | 판정 방법 |
+|------|------|----------|
+| vision-evaluator.ts 존재 | PASS/FAIL | 파일 존재 + export 확인 |
+| VisionEvalResult 타입 | PASS/FAIL | TypeScript 컴파일 성공 |
+| visionResultToDimensionScore | PASS/FAIL | dimension='ui' + score 범위 |
+| isRateLimitError | PASS/FAIL | rate limit 패턴 감지 |
+| retryWithBackoff | PASS/FAIL | 지수 백오프 재시도 |
+| CostRecord.generation_mode | PASS/FAIL | 타입 정의 존재 |
+| evaluateQuality useVisionApi | PASS/FAIL | 옵션 존재 + visionEvaluateUi 호출 |
+| 테스트 16건 통과 | PASS/FAIL | vitest 결과 |
+| typecheck 통과 | PASS/FAIL | tsc --noEmit |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,22 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/debug@4.1.13)(@types/node@20.19.37)(jiti@2.6.1)(jsdom@29.0.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.12.12(@types/node@20.19.37)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/gate-x-sdk:
+    dependencies:
+      commander:
+        specifier: ^12.0.0
+        version: 12.1.0
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.37
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@20.19.37)(jiti@2.6.1)(jsdom@29.0.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.12.12(@types/node@20.19.37)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
+
   packages/gate-x-web:
     dependencies:
       react:

--- a/prototype-builder/src/__tests__/vision-evaluator.test.ts
+++ b/prototype-builder/src/__tests__/vision-evaluator.test.ts
@@ -1,0 +1,170 @@
+/**
+ * F427: vision-evaluator 단위 테스트
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  isRateLimitError,
+  retryWithBackoff,
+} from '../fallback.js';
+import {
+  visionResultToDimensionScore,
+} from '../vision-evaluator.js';
+import type { VisionEvalResult } from '../vision-evaluator.js';
+
+// ─────────────────────────────────────────────
+// F427: visionResultToDimensionScore
+// ─────────────────────────────────────────────
+
+describe('visionResultToDimensionScore', () => {
+  function makeVisionResult(overrides: Partial<VisionEvalResult> = {}): VisionEvalResult {
+    return {
+      layout: 80,
+      color: 70,
+      typography: 75,
+      hierarchy: 65,
+      responsive: 60,
+      overall: 70,
+      rationale: '전반적으로 양호',
+      method: 'html-text',
+      ...overrides,
+    };
+  }
+
+  it('overall 점수를 0~1 범위 score로 변환해요', () => {
+    const result = makeVisionResult({ overall: 80 });
+    const score = visionResultToDimensionScore(result);
+    expect(score.score).toBe(0.80);
+    expect(score.dimension).toBe('ui');
+  });
+
+  it('가중치 0.25를 곱해 weighted를 계산해요', () => {
+    const result = makeVisionResult({ overall: 60 });
+    const score = visionResultToDimensionScore(result);
+    expect(score.weight).toBe(0.25);
+    expect(score.weighted).toBeCloseTo(0.15, 2);
+  });
+
+  it('details에 5개 항목 점수를 포함해요', () => {
+    const result = makeVisionResult({ layout: 90, color: 80, typography: 85, hierarchy: 70, responsive: 75 });
+    const score = visionResultToDimensionScore(result);
+    expect(score.details).toContain('layout=90');
+    expect(score.details).toContain('color=80');
+    expect(score.details).toContain('typo=85');
+    expect(score.details).toContain('hierarchy=70');
+    expect(score.details).toContain('responsive=75');
+  });
+
+  it('overall 0이면 score=0, weighted=0이에요', () => {
+    const result = makeVisionResult({ overall: 0 });
+    const score = visionResultToDimensionScore(result);
+    expect(score.score).toBe(0);
+    expect(score.weighted).toBe(0);
+  });
+
+  it('overall 100이면 score=1.0이에요', () => {
+    const result = makeVisionResult({ overall: 100 });
+    const score = visionResultToDimensionScore(result);
+    expect(score.score).toBe(1.0);
+    expect(score.weighted).toBeCloseTo(0.25, 2);
+  });
+
+  it('method 정보를 details에 포함해요', () => {
+    const screenshotResult = makeVisionResult({ method: 'screenshot' });
+    const htmlResult = makeVisionResult({ method: 'html-text' });
+    expect(visionResultToDimensionScore(screenshotResult).details).toContain('screenshot');
+    expect(visionResultToDimensionScore(htmlResult).details).toContain('html-text');
+  });
+});
+
+// ─────────────────────────────────────────────
+// F428: isRateLimitError
+// ─────────────────────────────────────────────
+
+describe('isRateLimitError', () => {
+  it('rate limit 키워드를 감지해요', () => {
+    expect(isRateLimitError('Error: rate limit exceeded')).toBe(true);
+    expect(isRateLimitError('rate-limit hit')).toBe(true);
+    expect(isRateLimitError('ratelimit error')).toBe(true);
+  });
+
+  it('429 상태코드를 감지해요', () => {
+    expect(isRateLimitError('HTTP 429 Too Many Requests')).toBe(true);
+    expect(isRateLimitError('status: 429')).toBe(true);
+  });
+
+  it('overloaded 키워드를 감지해요', () => {
+    expect(isRateLimitError('API overloaded, please try again')).toBe(true);
+  });
+
+  it('too many requests를 감지해요', () => {
+    expect(isRateLimitError('Too Many Requests')).toBe(true);
+    expect(isRateLimitError('too-many-requests error')).toBe(true);
+  });
+
+  it('일반 에러는 rate limit으로 감지하지 않아요', () => {
+    expect(isRateLimitError('ENOENT: no such file or directory')).toBe(false);
+    expect(isRateLimitError('TypeError: Cannot read property')).toBe(false);
+    expect(isRateLimitError('Build failed')).toBe(false);
+    expect(isRateLimitError('')).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────
+// F428: retryWithBackoff
+// ─────────────────────────────────────────────
+
+describe('retryWithBackoff', () => {
+  it('성공하면 즉시 결과를 반환해요', async () => {
+    const fn = vi.fn().mockResolvedValue('ok');
+    const result = await retryWithBackoff(fn, { maxRetries: 3, initialDelayMs: 1 });
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('rate limit 에러 시 재시도해요', async () => {
+    const fn = vi.fn()
+      .mockRejectedValueOnce(new Error('rate limit exceeded'))
+      .mockRejectedValueOnce(new Error('429 Too Many Requests'))
+      .mockResolvedValue('success');
+
+    const onRetry = vi.fn();
+    const result = await retryWithBackoff(fn, {
+      maxRetries: 3,
+      initialDelayMs: 1,
+      onRetry,
+    });
+
+    expect(result).toBe('success');
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(onRetry).toHaveBeenCalledTimes(2);
+  });
+
+  it('rate limit이 아닌 에러는 즉시 throw해요', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('ENOENT: file not found'));
+
+    await expect(
+      retryWithBackoff(fn, { maxRetries: 3, initialDelayMs: 1 }),
+    ).rejects.toThrow('ENOENT');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('maxRetries 소진 후에도 실패하면 throw해요', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('rate limit always'));
+
+    await expect(
+      retryWithBackoff(fn, { maxRetries: 2, initialDelayMs: 1 }),
+    ).rejects.toThrow('rate limit always');
+    expect(fn).toHaveBeenCalledTimes(3); // 최초 1회 + 재시도 2회
+  });
+
+  it('onRetry 콜백에 attempt 번호와 delay를 전달해요', async () => {
+    const fn = vi.fn()
+      .mockRejectedValueOnce(new Error('rate limit'))
+      .mockResolvedValue('done');
+
+    const onRetry = vi.fn();
+    await retryWithBackoff(fn, { maxRetries: 3, initialDelayMs: 100, onRetry });
+
+    expect(onRetry).toHaveBeenCalledWith(1, 100, expect.stringContaining('rate limit'));
+  });
+});

--- a/prototype-builder/src/cost-tracker.ts
+++ b/prototype-builder/src/cost-tracker.ts
@@ -1,4 +1,4 @@
-import type { CostRecord, BuilderConfig } from './types.js';
+import type { CostRecord, BuilderConfig, GenerationMode } from './types.js';
 
 // Anthropic 가격표 (2026-04 기준, USD per 1M tokens)
 const MODEL_PRICING: Record<string, { input: number; output: number }> = {
@@ -54,8 +54,13 @@ export class CostTracker {
 
   /**
    * CLI 구독 모드 비용 기록 ($0)
+   * F428: generation_mode 파라미터 추가
    */
-  recordCli(jobId: string, round: number): CostRecord {
+  recordCli(
+    jobId: string,
+    round: number,
+    mode: GenerationMode = 'max-cli',
+  ): CostRecord {
     const entry: CostRecord = {
       jobId,
       round,
@@ -64,9 +69,31 @@ export class CostTracker {
       outputTokens: 0,
       cost: 0,
       timestamp: Date.now(),
+      generation_mode: mode,
     };
     this.records.push(entry);
     return entry;
+  }
+
+  /**
+   * API 비용 기록 (generation_mode 포함)
+   * F428: generation_mode 파라미터 추가
+   */
+  recordWithMode(
+    jobId: string,
+    round: number,
+    model: string,
+    inputTokens: number,
+    outputTokens: number,
+    mode: GenerationMode,
+  ): CostRecord {
+    const entry = this.record(jobId, round, model, inputTokens, outputTokens);
+    // record()가 반환한 entry에 generation_mode 추가
+    const last = this.records[this.records.length - 1];
+    if (last && last.jobId === jobId && last.round === round) {
+      (last as CostRecord).generation_mode = mode;
+    }
+    return { ...entry, generation_mode: mode };
   }
 
   /**

--- a/prototype-builder/src/fallback.ts
+++ b/prototype-builder/src/fallback.ts
@@ -10,6 +10,69 @@ const execFileAsync = promisify(execFile);
 
 export type FallbackLevel = 'max-cli' | 'api' | 'ensemble';
 
+// ─────────────────────────────────────────────
+// F428: Rate Limit 감지 + 지수 백오프
+// ─────────────────────────────────────────────
+
+/** rate limit / 과부하 에러 메시지 패턴 */
+const RATE_LIMIT_PATTERNS = [
+  /rate.?limit/i,
+  /429/,
+  /too.?many.?requests/i,
+  /overloaded/i,
+  /capacity/i,
+];
+
+/**
+ * 에러 메시지가 rate limit 에러인지 확인
+ */
+export function isRateLimitError(message: string): boolean {
+  return RATE_LIMIT_PATTERNS.some(pattern => pattern.test(message));
+}
+
+/**
+ * 지수 백오프 재시도 유틸
+ * - 초기 지연: initialDelayMs (기본 1000ms)
+ * - 배수: 2x (1s → 2s → 4s)
+ * - 최대 재시도: maxRetries (기본 3)
+ * - rate limit 에러만 재시도, 다른 에러는 즉시 실패
+ */
+export async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  options: {
+    maxRetries?: number;
+    initialDelayMs?: number;
+    onRetry?: (attempt: number, delayMs: number, error: string) => void;
+  } = {},
+): Promise<T> {
+  const maxRetries = options.maxRetries ?? 3;
+  const initialDelayMs = options.initialDelayMs ?? 1000;
+
+  let lastError: Error | null = null;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      const message = String(err);
+      lastError = err instanceof Error ? err : new Error(message);
+
+      if (attempt < maxRetries && isRateLimitError(message)) {
+        const delayMs = initialDelayMs * Math.pow(2, attempt);
+        options.onRetry?.(attempt + 1, delayMs, message.slice(0, 100));
+        console.log(`[Builder] Rate limit detected. Retry ${attempt + 1}/${maxRetries} in ${delayMs}ms`);
+        await new Promise(resolve => setTimeout(resolve, delayMs));
+        continue;
+      }
+
+      // rate limit이 아닌 에러 or 재시도 소진 → 즉시 throw
+      throw lastError;
+    }
+  }
+
+  throw lastError ?? new Error('retryWithBackoff: exhausted');
+}
+
 export interface FallbackResult {
   level: FallbackLevel;
   output: string;
@@ -226,12 +289,17 @@ export async function fallbackToApi(
 
 /**
  * Claude Max CLI --bare 모드로 코드 생성 (구독 $0)
+ *
+ * F428: 지수 백오프 재시도 포함 (rate limit 에러 시 최대 3회)
+ * - 재시도 간격: 1s → 2s → 4s
+ * - rate limit 아닌 에러: 즉시 실패 (fallback → API)
  */
 export async function runMaxCli(
   job: PrototypeJob,
   round: number,
   cliPath: string = 'claude',
-): Promise<{ success: boolean; output: string }> {
+  options: { maxRetries?: number; retryDelayMs?: number } = {},
+): Promise<{ success: boolean; output: string; retryCount: number }> {
   const prompt = buildGeneratorPrompt(job, round);
   const args = [
     '--bare',
@@ -241,17 +309,29 @@ export async function runMaxCli(
     '--output-format', 'json',
   ];
 
+  let retryCount = 0;
+
   try {
-    const { stdout } = await execFileAsync(cliPath, args, {
-      cwd: job.workDir,
-      timeout: 5 * 60 * 1000,  // 5분 (Max 구독은 여유)
-      env: { ...process.env },  // ANTHROPIC_API_KEY 불필요 (구독 인증)
-    });
+    const stdout = await retryWithBackoff(
+      async () => {
+        const result = await execFileAsync(cliPath, args, {
+          cwd: job.workDir,
+          timeout: 5 * 60 * 1000,  // 5분
+          env: { ...process.env },  // ANTHROPIC_API_KEY 불필요 (구독 인증)
+        });
+        return result.stdout;
+      },
+      {
+        maxRetries: options.maxRetries ?? 3,
+        initialDelayMs: options.retryDelayMs ?? 1000,
+        onRetry: (attempt) => { retryCount = attempt; },
+      },
+    );
 
     const filesWritten = await writeGeneratedFiles(stdout, job.workDir);
-    return { success: filesWritten > 0, output: stdout };
+    return { success: filesWritten > 0, output: stdout, retryCount };
   } catch {
-    return { success: false, output: '' };
+    return { success: false, output: '', retryCount };
   }
 }
 
@@ -273,9 +353,12 @@ export async function executeWithFallback(
     console.log(`[Builder] Trying Max CLI generator (${cliPath})...`);
     const maxCliResult = await runMaxCli(job, round, cliPath);
     if (maxCliResult.success) {
+      if (maxCliResult.retryCount > 0) {
+        console.log(`[Builder] Max CLI succeeded after ${maxCliResult.retryCount} retries`);
+      }
       return { level: 'max-cli', output: maxCliResult.output, success: true };
     }
-    console.log(`[Builder] Max CLI failed, falling back to API`);
+    console.log(`[Builder] Max CLI failed (retries: ${maxCliResult.retryCount}), falling back to API`);
   } else {
     console.log(`[Builder] SKIP_CLI=true, using API directly`);
   }

--- a/prototype-builder/src/scorer.ts
+++ b/prototype-builder/src/scorer.ts
@@ -24,6 +24,7 @@ import type {
   LlmIntegratedEvaluation,
 } from './types.js';
 import { DIMENSION_WEIGHTS } from './types.js';
+import { visionEvaluateUi, visionResultToDimensionScore } from './vision-evaluator.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -618,11 +619,18 @@ export async function codeScore(workDir: string): Promise<DimensionScore> {
 /**
  * 5차원 품질 평가 — 전체 통합
  * useLlmIntegrated: F426 5차원 LLM 통합 판별 활성화 (evaluateQualityWithLlm 호출)
+ * useVisionApi: F427 Vision API 시각 평가 활성화 (ui 차원을 Vision 점수로 대체)
  */
 export async function evaluateQuality(
   job: PrototypeJob,
   workDir: string,
-  options: { useLlm?: boolean; skipBuild?: boolean; useLlmIntegrated?: boolean } = {},
+  options: {
+    useLlm?: boolean;
+    skipBuild?: boolean;
+    useLlmIntegrated?: boolean;
+    /** F427: Vision API로 ui 차원 평가 활성화 */
+    useVisionApi?: boolean;
+  } = {},
 ): Promise<QualityScore> {
   if (options.useLlmIntegrated) {
     return evaluateQualityWithLlm(job, workDir);
@@ -630,12 +638,17 @@ export async function evaluateQuality(
 
   const dimensions: DimensionScore[] = [];
 
+  // ui 차원: Vision API 또는 정적 분석 선택
+  const uiEvaluator = options.useVisionApi
+    ? visionEvaluateUi(workDir).then(visionResultToDimensionScore)
+    : uiScore(workDir);
+
   // 병렬로 독립적인 평가 실행
   const [buildResult, uiResult, funcResult, prdResult, codeResult] = await Promise.all([
     options.skipBuild
       ? Promise.resolve<DimensionScore>({ dimension: 'build', score: 1, weight: 0.2, weighted: 0.2, details: 'Skipped (pre-built)' })
       : buildScore(workDir),
-    uiScore(workDir),
+    uiEvaluator,
     functionalScore(workDir),
     prdScore(job, workDir, { useLlm: options.useLlm }),
     codeScore(workDir),

--- a/prototype-builder/src/types.ts
+++ b/prototype-builder/src/types.ts
@@ -41,6 +41,8 @@ export interface CostRecord {
   outputTokens: number;
   cost: number;
   timestamp: number;
+  /** F428: 실제 생성 모드 (max-cli / api / fallback 등) */
+  generation_mode?: GenerationMode;
 }
 
 export interface BuilderConfig {

--- a/prototype-builder/src/vision-evaluator.ts
+++ b/prototype-builder/src/vision-evaluator.ts
@@ -1,0 +1,374 @@
+/**
+ * F427: Vision API 시각 평가
+ *
+ * 빌드된 프로토타입의 스크린샷을 Claude Vision API로 전송하여
+ * UI 시각 품질을 평가한다.
+ *
+ * 평가 항목: 레이아웃 균형 / 색상 조화 / 타이포그래피 / 시각 계층구조 / 반응형
+ *
+ * 스크린샷 전략:
+ * 1. Chromium headless 스크린샷 (google-chrome / chromium)
+ * 2. 없으면: HTML 소스 기반 텍스트 평가 (fallback)
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import Anthropic from '@anthropic-ai/sdk';
+import type { DimensionScore } from './types.js';
+import { DIMENSION_WEIGHTS } from './types.js';
+
+const execFileAsync = promisify(execFile);
+
+// ─────────────────────────────────────────────
+// 타입 정의
+// ─────────────────────────────────────────────
+
+export interface VisionEvalResult {
+  layout: number;        // 레이아웃 균형 0~100
+  color: number;         // 색상 조화 0~100
+  typography: number;    // 타이포그래피 0~100
+  hierarchy: number;     // 시각 계층구조 0~100
+  responsive: number;    // 반응형 0~100
+  overall: number;       // 평균 점수 0~100
+  rationale: string;     // 평가 근거
+  method: 'screenshot' | 'html-text';  // 평가 방법
+}
+
+interface VisionApiResponse {
+  layout: number;
+  color: number;
+  typography: number;
+  hierarchy: number;
+  responsive: number;
+  rationale: string;
+}
+
+// ─────────────────────────────────────────────
+// Chromium 탐색
+// ─────────────────────────────────────────────
+
+const CHROMIUM_CANDIDATES = [
+  'google-chrome',
+  'google-chrome-stable',
+  'chromium',
+  'chromium-browser',
+  '/usr/bin/google-chrome',
+  '/usr/bin/chromium',
+  '/usr/bin/chromium-browser',
+];
+
+export async function findChromium(): Promise<string | null> {
+  for (const candidate of CHROMIUM_CANDIDATES) {
+    try {
+      await execFileAsync('which', [candidate], { timeout: 3000 });
+      return candidate;
+    } catch {
+      // 다음 후보 시도
+    }
+  }
+  return null;
+}
+
+// ─────────────────────────────────────────────
+// 스크린샷 캡처
+// ─────────────────────────────────────────────
+
+/**
+ * Chromium headless로 HTML 파일 스크린샷 캡처 → PNG base64 반환
+ */
+export async function captureScreenshot(
+  htmlPath: string,
+  chromiumPath: string,
+): Promise<string | null> {
+  const tmpFile = path.join(os.tmpdir(), `fx-vision-${Date.now()}.png`);
+
+  try {
+    await execFileAsync(
+      chromiumPath,
+      [
+        '--headless=new',
+        '--no-sandbox',
+        '--disable-gpu',
+        '--disable-dev-shm-usage',
+        `--screenshot=${tmpFile}`,
+        '--window-size=1280,800',
+        `file://${htmlPath}`,
+      ],
+      { timeout: 30_000 },
+    );
+
+    const buffer = await fs.readFile(tmpFile);
+    const base64 = buffer.toString('base64');
+
+    // 임시 파일 정리
+    await fs.unlink(tmpFile).catch(() => undefined);
+
+    return base64;
+  } catch {
+    await fs.unlink(tmpFile).catch(() => undefined);
+    return null;
+  }
+}
+
+// ─────────────────────────────────────────────
+// Claude API 호출 (Vision 또는 텍스트)
+// ─────────────────────────────────────────────
+
+const VISION_SYSTEM_PROMPT = [
+  '당신은 UI/UX 전문가입니다. 프로토타입의 시각적 품질을 5개 항목에서 0~100점으로 평가하세요.',
+  '',
+  '평가 기준:',
+  '- layout (레이아웃 균형): 요소 배치, 여백 일관성, 시각적 균형',
+  '- color (색상 조화): 색상 팔레트 일관성, 대비, impeccable 디자인 원칙 준수',
+  '- typography (타이포그래피): 폰트 계층, 가독성, 크기/두께 시스템',
+  '- hierarchy (시각 계층구조): 주요 정보가 시각적으로 부각되는지, 정보 구조',
+  '- responsive (반응형): 레이아웃이 다양한 화면에서 유연하게 동작할지',
+  '',
+  '순수 JSON으로만 응답하세요 (마크다운 없이):',
+].join('\n');
+
+function buildVisionEvalExample(): string {
+  return JSON.stringify({
+    layout: 75,
+    color: 60,
+    typography: 80,
+    hierarchy: 70,
+    responsive: 65,
+    rationale: '레이아웃 균형 양호. 색상이 단조로움(회색 계열 과다). 타이포 계층 명확. 계층구조 개선 여지. 반응형 기본 구현.',
+  } satisfies VisionApiResponse);
+}
+
+/**
+ * Claude Vision API로 스크린샷 이미지를 평가
+ */
+async function evaluateWithScreenshot(
+  base64Image: string,
+  client: Anthropic,
+): Promise<VisionApiResponse> {
+  const response = await client.messages.create({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 512,
+    temperature: 0,
+    system: VISION_SYSTEM_PROMPT,
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image',
+            source: {
+              type: 'base64',
+              media_type: 'image/png',
+              data: base64Image,
+            },
+          },
+          {
+            type: 'text',
+            text: `위 프로토타입 스크린샷을 평가하세요.\n\n응답 형식 예시:\n${buildVisionEvalExample()}`,
+          },
+        ],
+      },
+    ],
+  });
+
+  const text = response.content
+    .filter((b): b is Anthropic.TextBlock => b.type === 'text')
+    .map(b => b.text)
+    .join('\n')
+    .trim();
+
+  const jsonStr = text.replace(/^```json\s*/m, '').replace(/```\s*$/m, '').trim();
+  return JSON.parse(jsonStr) as VisionApiResponse;
+}
+
+/**
+ * Claude 텍스트 API로 HTML 코드를 시각적으로 평가 (스크린샷 없을 때 fallback)
+ */
+async function evaluateWithHtmlText(
+  htmlContent: string,
+  cssContent: string,
+  client: Anthropic,
+): Promise<VisionApiResponse> {
+  const prompt = [
+    '아래 HTML/CSS 코드를 읽고, 실제 렌더링된 모습을 상상하여 시각적 품질을 평가하세요.',
+    '',
+    '## HTML',
+    htmlContent.slice(0, 4000),
+    '',
+    '## CSS/TSX 코드',
+    cssContent.slice(0, 4000),
+    '',
+    `응답 형식 예시:\n${buildVisionEvalExample()}`,
+  ].join('\n');
+
+  const response = await client.messages.create({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 512,
+    temperature: 0,
+    system: VISION_SYSTEM_PROMPT,
+    messages: [{ role: 'user', content: prompt }],
+  });
+
+  const text = response.content
+    .filter((b): b is Anthropic.TextBlock => b.type === 'text')
+    .map(b => b.text)
+    .join('\n')
+    .trim();
+
+  const jsonStr = text.replace(/^```json\s*/m, '').replace(/```\s*$/m, '').trim();
+  return JSON.parse(jsonStr) as VisionApiResponse;
+}
+
+// ─────────────────────────────────────────────
+// 소스 파일 수집 헬퍼
+// ─────────────────────────────────────────────
+
+async function readBuildArtifacts(workDir: string): Promise<{ html: string; css: string }> {
+  const distIndex = path.join(workDir, 'dist', 'index.html');
+  const srcIndex = path.join(workDir, 'index.html');
+
+  let html = '';
+  try {
+    html = await fs.readFile(distIndex, 'utf-8');
+  } catch {
+    try {
+      html = await fs.readFile(srcIndex, 'utf-8');
+    } catch {
+      html = '';
+    }
+  }
+
+  // CSS/TSX 소스 수집
+  const cssLines: string[] = [];
+  const srcDir = path.join(workDir, 'src');
+  try {
+    await collectCssAndJsx(srcDir, cssLines);
+  } catch {
+    // src/ 없으면 skip
+  }
+
+  return { html, css: cssLines.join('\n') };
+}
+
+async function collectCssAndJsx(dir: string, lines: string[]): Promise<void> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await collectCssAndJsx(full, lines);
+    } else if (entry.name.endsWith('.css') || entry.name.endsWith('.tsx') || entry.name.endsWith('.ts')) {
+      try {
+        const content = await fs.readFile(full, 'utf-8');
+        lines.push(`// ${entry.name}\n${content.slice(0, 800)}`);
+      } catch {
+        // skip
+      }
+    }
+    // 총 합산이 8000자 넘으면 중단
+    if (lines.join('\n').length > 8000) break;
+  }
+}
+
+// ─────────────────────────────────────────────
+// 메인 평가 함수
+// ─────────────────────────────────────────────
+
+/**
+ * Vision API로 UI 차원 점수 산출 (F427)
+ *
+ * 우선순위:
+ * 1. Chromium 스크린샷 → Vision API
+ * 2. HTML 텍스트 → Claude API (fallback)
+ * 3. API 키 없음 → 정적 분석 점수 그대로 반환 (0.5 기본값)
+ */
+export async function visionEvaluateUi(
+  workDir: string,
+  options: {
+    apiKey?: string;
+    chromiumPath?: string;
+  } = {},
+): Promise<VisionEvalResult> {
+  const apiKey = options.apiKey ?? process.env['ANTHROPIC_API_KEY'];
+
+  if (!apiKey) {
+    return {
+      layout: 50, color: 50, typography: 50, hierarchy: 50, responsive: 50,
+      overall: 50,
+      rationale: 'ANTHROPIC_API_KEY not set — using default score',
+      method: 'html-text',
+    };
+  }
+
+  const client = new Anthropic({ apiKey });
+  const { html, css } = await readBuildArtifacts(workDir);
+
+  // 스크린샷 시도
+  let parsed: VisionApiResponse | null = null;
+  let method: 'screenshot' | 'html-text' = 'html-text';
+
+  const chromiumPath = options.chromiumPath ?? await findChromium();
+  if (chromiumPath) {
+    const distIndex = path.join(workDir, 'dist', 'index.html');
+    const srcIndex = path.join(workDir, 'index.html');
+    const htmlFile = await fs.access(distIndex).then(() => distIndex).catch(() => srcIndex);
+
+    const base64 = await captureScreenshot(htmlFile, chromiumPath);
+    if (base64) {
+      try {
+        parsed = await evaluateWithScreenshot(base64, client);
+        method = 'screenshot';
+      } catch {
+        parsed = null; // fallback to HTML text
+      }
+    }
+  }
+
+  // HTML 텍스트 fallback
+  if (!parsed) {
+    try {
+      parsed = await evaluateWithHtmlText(html, css, client);
+    } catch (err) {
+      console.log(`[Vision] evaluateWithHtmlText failed: ${String(err).slice(0, 100)}`);
+      return {
+        layout: 50, color: 50, typography: 50, hierarchy: 50, responsive: 50,
+        overall: 50,
+        rationale: `Vision API failed: ${String(err).slice(0, 100)}`,
+        method: 'html-text',
+      };
+    }
+  }
+
+  // 점수 정규화 (0~100 범위 보장)
+  const clamp = (v: number) => Math.max(0, Math.min(100, Math.round(v)));
+  const layout = clamp(parsed.layout);
+  const color = clamp(parsed.color);
+  const typography = clamp(parsed.typography);
+  const hierarchy = clamp(parsed.hierarchy);
+  const responsive = clamp(parsed.responsive);
+  const overall = Math.round((layout + color + typography + hierarchy + responsive) / 5);
+
+  return { layout, color, typography, hierarchy, responsive, overall, rationale: parsed.rationale, method };
+}
+
+/**
+ * Vision 평가 결과를 DimensionScore(ui)로 변환
+ */
+export function visionResultToDimensionScore(result: VisionEvalResult): DimensionScore {
+  const weight = DIMENSION_WEIGHTS.ui;
+  const score = result.overall / 100;
+
+  return {
+    dimension: 'ui',
+    score: Math.round(score * 100) / 100,
+    weight,
+    weighted: Math.round(score * weight * 100) / 100,
+    details: [
+      `Vision(${result.method}): layout=${result.layout}, color=${result.color},`,
+      `typo=${result.typography}, hierarchy=${result.hierarchy}, responsive=${result.responsive}`,
+      `| ${result.rationale.slice(0, 100)}`,
+    ].join(' '),
+  };
+}


### PR DESCRIPTION
## Summary

- **F427**: `vision-evaluator.ts` 신규 — Chromium headless 스크린샷 → Claude Vision API 5항목 시각 평가(layout/color/typography/hierarchy/responsive). 스크린샷 불가 시 HTML 텍스트 평가로 자동 fallback
- **F428**: `retryWithBackoff` 유틸 + `runMaxCli` 지수 백오프(1s→2s→4s, 최대 3회). `CostRecord.generation_mode` 필드 추가, `isRateLimitError` rate limit 패턴 감지

## Changes

| 파일 | 변경 |
|------|------|
| `prototype-builder/src/vision-evaluator.ts` | 신규 — F427 핵심 |
| `prototype-builder/src/types.ts` | CostRecord.generation_mode 추가 |
| `prototype-builder/src/fallback.ts` | retryWithBackoff + runMaxCli 강화 |
| `prototype-builder/src/cost-tracker.ts` | recordCli(mode), recordWithMode |
| `prototype-builder/src/scorer.ts` | evaluateQuality useVisionApi 옵션 |
| `prototype-builder/src/__tests__/vision-evaluator.test.ts` | 신규 16 tests |

## Test Results

- **110/110 tests passed** (신규 16건 포함)
- `pnpm typecheck` ✅

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)