### PR TITLE
feat: Sprint 207 — F431 판별 피드백 구체화 (Phase 22-D 완료)

### DIFF
--- a/docs/01-plan/features/sprint-207.plan.md
+++ b/docs/01-plan/features/sprint-207.plan.md
@@ -1,0 +1,69 @@
+---
+code: FX-PLAN-S207
+title: Sprint 207 Plan — F431 판별 피드백 구체화
+version: "1.0"
+status: Active
+category: PLAN
+created: 2026-04-07
+updated: 2026-04-07
+author: autopilot
+f_items: F431
+req_codes: FX-REQ-423
+---
+
+# Sprint 207 Plan — F431 판별 피드백 구체화
+
+## §1. 목적
+
+**F431**: OGD(O-G-D) 루프에서 Discriminator의 평가 결과를 구체적 수정 지시(actionable instructions)로 변환하고, Generator의 다음 라운드 프롬프트에 자동 주입하여 루프 수렴 속도를 개선한다.
+
+## §2. 배경
+
+Phase 22-D (Sprint 207)의 마지막 F-item. Phase 19(Builder Evolution)에서 구축한 O-G-D 루프는 다음 문제를 안고 있다:
+
+| 문제 | 영향 |
+|------|------|
+| Discriminator 피드백이 일반적인 텍스트 ("개선 필요") | Generator가 무엇을 어떻게 바꿔야 할지 모름 |
+| 피드백이 구조화되지 않음 | 라운드마다 같은 문제가 반복됨 |
+| 루프가 수렴하지 않음 | MAX_ROUNDS(3) 소진 후에도 품질 미달 |
+
+## §3. 목표 상태
+
+- `OgdFeedbackConverterService`: 판별 결과 → 구체적 지시 변환 (LLM 활용)
+- `OgdDiscriminatorService`: 평가 + 구조화된 피드백 반환
+- `OgdOrchestratorService`: converter 호출 → Generator에 structured instructions 주입
+- `OgdGeneratorService`: structured instructions를 번호부여 목록으로 프롬프트에 주입
+
+## §4. 구현 범위
+
+### In Scope
+- `packages/api/src/core/harness/services/ogd-feedback-converter.ts` 신규 생성
+- `ogd-discriminator-service.ts` 업데이트 (structured 결과 반환)
+- `ogd-orchestrator-service.ts` 업데이트 (converter 호출 + structured feedback 전달)
+- `ogd-generator-service.ts` 업데이트 (structured instructions 주입 포맷 개선)
+- `packages/shared/src/ogd.ts` 업데이트 (`structuredInstructions` 필드 추가)
+- 유닛 테스트: `ogd-feedback-converter.test.ts`
+
+### Out of Scope
+- Vision API 연동 (F418 범위)
+- max-cli 통합 (F419 범위)
+- DB 스키마 변경
+
+## §5. 구현 전략
+
+```
+Discriminator.evaluate()
+  → raw feedback (기존)
+  → FeedbackConverterService.convert(rawFeedback, failedItems)
+      → LLM: "변환해줘" 프롬프트
+      → StructuredInstruction[] 반환
+  → OgdRound.structuredInstructions 저장
+  → Generator.generate(prd, structuredInstructions)
+      → 프롬프트: "## 이전 라운드 수정 지시\n1. ...\n2. ..."
+```
+
+## §6. 성공 기준
+
+- typecheck 통과
+- ogd-feedback-converter 유닛 테스트 통과
+- Design Gap 90% 이상

--- a/docs/02-design/features/sprint-207.design.md
+++ b/docs/02-design/features/sprint-207.design.md
@@ -1,0 +1,192 @@
+---
+code: FX-DSGN-S207
+title: Sprint 207 Design — F431 판별 피드백 구체화
+version: "1.0"
+status: Active
+category: DSGN
+created: 2026-04-07
+updated: 2026-04-07
+author: autopilot
+f_items: F431
+req_codes: FX-REQ-423
+---
+
+# Sprint 207 Design — F431 판별 피드백 구체화
+
+## §1. 설계 목표
+
+LLM 판별 결과(raw feedback)를 "어떤 부분을 어떻게 고쳐야 하는지" 구체적인 수정 지시(StructuredInstruction)로 변환하고, Generator 프롬프트에 자동 주입하여 O-G-D 루프 수렴 속도를 개선한다.
+
+## §2. 타입 설계 (shared)
+
+### 2.1 `StructuredInstruction` (신규)
+
+```typescript
+// packages/shared/src/ogd.ts
+
+export interface StructuredInstruction {
+  /** 문제 항목 (체크리스트 항목명) */
+  issue: string;
+  /** 구체적 수정 지시 (동사형: "~하라") */
+  action: string;
+  /** CSS/HTML 예시 코드 스니펫 (선택) */
+  example?: string;
+}
+```
+
+### 2.2 `OgdRound` 업데이트
+
+```typescript
+export interface OgdRound {
+  // 기존 필드 유지
+  id: string;
+  jobId: string;
+  roundNumber: number;
+  qualityScore: number | null;
+  feedback: string | null;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  modelUsed: string;
+  passed: boolean;
+  createdAt: number;
+  // 신규
+  structuredInstructions?: StructuredInstruction[];
+}
+```
+
+## §3. `OgdFeedbackConverterService` 설계 (신규)
+
+**파일**: `packages/api/src/core/harness/services/ogd-feedback-converter.ts`
+
+```typescript
+export interface ConvertResult {
+  instructions: StructuredInstruction[];
+  inputTokens: number;
+  outputTokens: number;
+}
+
+export class OgdFeedbackConverterService {
+  constructor(private ai: Ai) {}
+
+  async convert(
+    rawFeedback: string,
+    failedItems: string[],
+  ): Promise<ConvertResult>;
+}
+```
+
+**LLM 프롬프트 설계**:
+```
+System: You are a UI code improvement advisor.
+Convert the quality evaluation feedback into specific, actionable code instructions.
+Each instruction must:
+1. Name the specific issue (from the failed checklist item)
+2. Give an exact action to take ("Replace X with Y", "Add Z at location W")
+3. Optionally provide a CSS/HTML code snippet example
+Output JSON: { instructions: [{issue, action, example?}] }
+
+User:
+Failed checklist items:
+- {failedItems}
+
+Raw feedback:
+{rawFeedback}
+```
+
+**실패 시 fallback**: LLM 파싱 실패 → failedItems에서 기본 지시 생성
+
+## §4. `OgdDiscriminatorService` 업데이트
+
+`EvaluateResult`에 `failedItems: string[]` 추가:
+
+```typescript
+interface EvaluateResult {
+  qualityScore: number;
+  feedback: string;
+  failedItems: string[];  // 신규: FAIL된 체크리스트 항목
+  inputTokens: number;
+  outputTokens: number;
+  passed: boolean;
+}
+```
+
+`evaluate()` 메서드: JSON 파싱 시 `items` 배열에서 `pass: false`인 항목의 `item` 텍스트 추출 → `failedItems` 반환.
+
+## §5. `OgdOrchestratorService` 업데이트
+
+`runLoop()` 변경:
+1. `discriminator.evaluate()` 호출 → `evalResult.failedItems` 획득
+2. 라운드가 통과하지 못한 경우: `feedbackConverter.convert(evalResult.feedback, evalResult.failedItems)` 호출
+3. `ogdRound.structuredInstructions` = converter 결과 저장
+4. `previousInstructions` = converter 결과 → 다음 Generator 호출 시 전달
+
+```typescript
+// runLoop() 시그니처 변경 없음 — 내부만 업데이트
+// FeedbackConverterService는 constructor에 주입
+constructor(
+  private db: D1Database,
+  private generator: OgdGeneratorService,
+  private discriminator: OgdDiscriminatorService,
+  private feedbackConverter: OgdFeedbackConverterService,  // 신규
+) {}
+```
+
+## §6. `OgdGeneratorService` 업데이트
+
+`generate()` 시그니처 변경:
+
+```typescript
+async generate(
+  prdContent: string,
+  previousFeedback?: string,              // 기존 유지 (하위 호환)
+  previousInstructions?: StructuredInstruction[],  // 신규
+): Promise<GenerateResult>
+```
+
+**주입 포맷** (previousInstructions 있을 때 우선):
+```
+## 이전 라운드 수정 지시 (반드시 모두 적용할 것)
+
+1. [issue1]
+   수정 지시: action1
+   예시: `example1`
+
+2. [issue2]
+   수정 지시: action2
+```
+
+instructions가 없고 `previousFeedback`만 있으면 기존 방식 사용 (하위 호환).
+
+## §7. Worker 파일 매핑
+
+| 파일 | 변경 유형 | 내용 |
+|------|-----------|------|
+| `packages/shared/src/ogd.ts` | 수정 | `StructuredInstruction` 추가, `OgdRound.structuredInstructions` 추가 |
+| `packages/shared/src/index.ts` | 수정 | `StructuredInstruction` export 추가 |
+| `packages/api/src/core/harness/services/ogd-feedback-converter.ts` | 신규 | `OgdFeedbackConverterService` |
+| `packages/api/src/core/harness/services/ogd-discriminator-service.ts` | 수정 | `failedItems` 반환 |
+| `packages/api/src/core/harness/services/ogd-orchestrator-service.ts` | 수정 | converter 주입 + 호출 |
+| `packages/api/src/core/harness/services/ogd-generator-service.ts` | 수정 | structured instructions 주입 |
+| `packages/api/src/core/harness/services/__tests__/ogd-feedback-converter.test.ts` | 신규 | 유닛 테스트 |
+
+## §8. 테스트 설계
+
+**`ogd-feedback-converter.test.ts`**:
+1. `convert()` - LLM mock이 JSON 반환 → `StructuredInstruction[]` 파싱 성공
+2. `convert()` - LLM 파싱 실패 → failedItems 기반 fallback instructions 반환
+3. `convert()` - failedItems 빈 배열 → 빈 instructions 반환
+
+## §9. Gap Analysis 기준 (Design vs Implementation)
+
+| 항목 | 설계 | 구현 확인 포인트 |
+|------|------|-----------------|
+| StructuredInstruction 타입 | shared/ogd.ts | 인터페이스 존재 여부 |
+| OgdRound.structuredInstructions | shared/ogd.ts | 옵셔널 필드 존재 |
+| OgdFeedbackConverterService | 신규 파일 | convert() 메서드 |
+| failedItems 추출 | discriminator | EvaluateResult.failedItems |
+| converter 호출 | orchestrator | !passed 시 converter.convert() |
+| structured instructions 저장 | orchestrator | ogdRound.structuredInstructions |
+| 주입 포맷 개선 | generator | "## 이전 라운드 수정 지시" 섹션 |
+| fallback 동작 | converter | 파싱 실패 시 failedItems 기반 |
+| 유닛 테스트 3건 | test file | 모두 통과 |

--- a/packages/api/src/__tests__/ogd-feedback-converter.test.ts
+++ b/packages/api/src/__tests__/ogd-feedback-converter.test.ts
@@ -1,0 +1,73 @@
+// F431: OgdFeedbackConverterService 유닛 테스트 (Sprint 207)
+import { describe, it, expect, vi } from "vitest";
+import { OgdFeedbackConverterService } from "../core/harness/services/ogd-feedback-converter.js";
+
+function makeAi(response: string) {
+  return {
+    run: vi.fn().mockResolvedValue({ response }),
+  } as unknown as Ai;
+}
+
+describe("OgdFeedbackConverterService", () => {
+  describe("convert()", () => {
+    it("LLM이 유효한 JSON 반환 시 StructuredInstruction[] 파싱 성공", async () => {
+      const mockResponse = JSON.stringify({
+        instructions: [
+          {
+            issue: "과용 폰트(Arial, Inter, system-ui) 대신 전문 폰트 또는 Google Fonts를 사용한다",
+            action: "font-family: Arial 을 font-family: 'Noto Sans', sans-serif 로 교체하고 Google Fonts CDN 링크를 <head>에 추가하라",
+            example: "<link href=\"https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;700&display=swap\" rel=\"stylesheet\">",
+          },
+          {
+            issue: "모바일 화면을 위한 미디어 쿼리(@media)가 적용되어 있다",
+            action: "@media (max-width: 768px) { .container { padding: 16px; flex-direction: column; } } 를 CSS 끝에 추가하라",
+          },
+        ],
+      });
+
+      const svc = new OgdFeedbackConverterService(makeAi(mockResponse));
+      const result = await svc.convert(
+        "Font and mobile responsiveness issues found.",
+        [
+          "과용 폰트(Arial, Inter, system-ui) 대신 전문 폰트 또는 Google Fonts를 사용한다",
+          "모바일 화면을 위한 미디어 쿼리(@media)가 적용되어 있다",
+        ],
+      );
+
+      expect(result.instructions).toHaveLength(2);
+      const [inst0, inst1] = result.instructions;
+      expect(inst0?.issue).toContain("과용 폰트");
+      expect(inst0?.action).toContain("Noto Sans");
+      expect(inst0?.example).toContain("googleapis.com");
+      expect(inst1?.issue).toContain("미디어 쿼리");
+      expect(inst1?.example).toBeUndefined();
+      expect(result.inputTokens).toBeGreaterThan(0);
+      expect(result.outputTokens).toBeGreaterThan(0);
+    });
+
+    it("LLM 파싱 실패 시 failedItems 기반 fallback instructions 반환", async () => {
+      const svc = new OgdFeedbackConverterService(makeAi("This is not valid JSON at all!"));
+      const failedItems = [
+        "CTA(Call-to-Action) 버튼이 존재한다",
+        "반응형 레이아웃이 적용되어 있다",
+      ];
+
+      const result = await svc.convert("Some vague feedback.", failedItems);
+
+      expect(result.instructions).toHaveLength(2);
+      const [fb0, fb1] = result.instructions;
+      expect(fb0?.issue).toBe(failedItems[0]);
+      expect(fb0?.action).toContain("Fix the following issue");
+      expect(fb1?.issue).toBe(failedItems[1]);
+    });
+
+    it("failedItems 빈 배열 + rawFeedback 없음 → 빈 instructions 반환", async () => {
+      const svc = new OgdFeedbackConverterService(makeAi("{}"));
+      const result = await svc.convert("", []);
+
+      expect(result.instructions).toHaveLength(0);
+      expect(result.inputTokens).toBe(0);
+      expect(result.outputTokens).toBe(0);
+    });
+  });
+});

--- a/packages/api/src/core/harness/services/ogd-discriminator-service.ts
+++ b/packages/api/src/core/harness/services/ogd-discriminator-service.ts
@@ -1,4 +1,5 @@
 // ─── F355: O-G-D Discriminator Service (Sprint 160) ───
+// F431: failedItems 반환 추가 (Sprint 207)
 // HTML 프로토타입 품질 평가 + Pass/Fail 판정
 
 import { OGD_THRESHOLD } from "@foundry-x/shared";
@@ -6,6 +7,8 @@ import { OGD_THRESHOLD } from "@foundry-x/shared";
 interface EvaluateResult {
   qualityScore: number;
   feedback: string;
+  /** F431: FAIL된 체크리스트 항목 목록 (FeedbackConverter에 전달) */
+  failedItems: string[];
   inputTokens: number;
   outputTokens: number;
   passed: boolean;
@@ -45,18 +48,32 @@ export class OgdDiscriminatorService {
     // Parse response — try JSON first, fallback to heuristic
     let qualityScore = 0;
     let feedback = "";
+    let failedItems: string[] = [];
     try {
       const jsonMatch = raw.match(/\{[\s\S]*\}/);
       if (jsonMatch) {
-        const parsed = JSON.parse(jsonMatch[0]);
+        const parsed = JSON.parse(jsonMatch[0]) as {
+          qualityScore?: number;
+          feedback?: string;
+          items?: Array<{ item?: string; pass?: boolean; reason?: string }>;
+        };
         qualityScore = Math.max(0, Math.min(1, Number(parsed.qualityScore) || 0));
         feedback = parsed.feedback || "";
+        // F431: FAIL 항목 추출
+        if (Array.isArray(parsed.items)) {
+          failedItems = parsed.items
+            .filter((it) => it.pass === false)
+            .map((it) => it.item ?? "")
+            .filter(Boolean);
+        }
       }
     } catch {
       // Heuristic: count PASS keywords
       const passCount = (raw.match(/PASS/gi) || []).length;
       qualityScore = checklist.length > 0 ? passCount / checklist.length : 0;
       feedback = raw.slice(0, 500);
+      // Heuristic fallback: assume all items failed if score is low
+      failedItems = qualityScore < 0.5 ? [...checklist] : [];
     }
 
     const inputTokens = Math.ceil((systemPrompt.length + userPrompt.length) / 4);
@@ -65,6 +82,7 @@ export class OgdDiscriminatorService {
     return {
       qualityScore,
       feedback,
+      failedItems,
       inputTokens,
       outputTokens,
       passed: qualityScore >= OGD_THRESHOLD,

--- a/packages/api/src/core/harness/services/ogd-feedback-converter.ts
+++ b/packages/api/src/core/harness/services/ogd-feedback-converter.ts
@@ -1,0 +1,118 @@
+// ─── F431: OGD Feedback Converter Service (Sprint 207) ───
+// LLM 판별 결과(raw feedback + failedItems) → 구체적 수정 지시(StructuredInstruction[]) 변환
+
+import type { StructuredInstruction } from "@foundry-x/shared";
+
+export interface ConvertResult {
+  instructions: StructuredInstruction[];
+  inputTokens: number;
+  outputTokens: number;
+}
+
+export class OgdFeedbackConverterService {
+  constructor(private ai: Ai) {}
+
+  async convert(
+    rawFeedback: string,
+    failedItems: string[],
+  ): Promise<ConvertResult> {
+    if (failedItems.length === 0 && !rawFeedback.trim()) {
+      return { instructions: [], inputTokens: 0, outputTokens: 0 };
+    }
+
+    const systemPrompt = [
+      "You are a UI code improvement advisor.",
+      "Convert quality evaluation feedback into specific, actionable code instructions.",
+      "Each instruction must:",
+      "1. Name the specific issue (from the failed checklist item)",
+      "2. Give an exact action to take (e.g., \"Replace Arial with Google Fonts Noto Sans\")",
+      "3. Optionally provide a short CSS/HTML code snippet as example",
+      "Output ONLY valid JSON: { \"instructions\": [{\"issue\": string, \"action\": string, \"example\"?: string}] }",
+      "No markdown fences, no explanations — just the JSON object.",
+    ].join(" ");
+
+    const failedSection =
+      failedItems.length > 0
+        ? `Failed checklist items:\n${failedItems.map((item, i) => `${i + 1}. ${item}`).join("\n")}`
+        : "";
+
+    const userPrompt = [
+      failedSection,
+      failedSection ? "" : undefined,
+      `Raw feedback from discriminator:\n${rawFeedback}`,
+    ]
+      .filter((s) => s !== undefined)
+      .join("\n");
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const response = await (this.ai as any).run("@cf/meta/llama-3.1-8b-instruct", {
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: userPrompt },
+        ],
+        max_tokens: 1024,
+      }) as { response?: string };
+
+      const raw = response.response ?? "";
+      const inputTokens = Math.ceil((systemPrompt.length + userPrompt.length) / 4);
+      const outputTokens = Math.ceil(raw.length / 4);
+
+      const parsed = this.parseInstructions(raw);
+      if (parsed) {
+        return { instructions: parsed, inputTokens, outputTokens };
+      }
+
+      // Fallback: failedItems에서 기본 지시 생성
+      return {
+        instructions: this.buildFallbackInstructions(failedItems),
+        inputTokens,
+        outputTokens,
+      };
+    } catch {
+      return {
+        instructions: this.buildFallbackInstructions(failedItems),
+        inputTokens: 0,
+        outputTokens: 0,
+      };
+    }
+  }
+
+  private parseInstructions(raw: string): StructuredInstruction[] | null {
+    try {
+      const jsonMatch = raw.match(/\{[\s\S]*\}/);
+      if (!jsonMatch) return null;
+      const parsed = JSON.parse(jsonMatch[0]) as { instructions?: unknown[] };
+      if (!Array.isArray(parsed.instructions)) return null;
+
+      const instructions: StructuredInstruction[] = [];
+      for (const item of parsed.instructions) {
+        if (
+          typeof item === "object" &&
+          item !== null &&
+          "issue" in item &&
+          "action" in item &&
+          typeof (item as Record<string, unknown>).issue === "string" &&
+          typeof (item as Record<string, unknown>).action === "string"
+        ) {
+          const typedItem = item as Record<string, unknown>;
+          instructions.push({
+            issue: typedItem.issue as string,
+            action: typedItem.action as string,
+            example: typeof typedItem.example === "string" ? typedItem.example : undefined,
+          });
+        }
+      }
+      return instructions.length > 0 ? instructions : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private buildFallbackInstructions(failedItems: string[]): StructuredInstruction[] {
+    return failedItems.map((item) => ({
+      issue: item,
+      action: `Fix the following issue: ${item}`,
+    }));
+  }
+}

--- a/packages/api/src/core/harness/services/ogd-generator-service.ts
+++ b/packages/api/src/core/harness/services/ogd-generator-service.ts
@@ -1,7 +1,9 @@
 // ─── F355: O-G-D Generator Service (Sprint 160) ───
 // PRD → HTML 프로토타입 생성 (Haiku 모델 기반)
 // F423: impeccable 디자인 스킬 통합 (Sprint 203)
+// F431: structured instructions 주입 포맷 개선 (Sprint 207)
 
+import type { StructuredInstruction } from "@foundry-x/shared";
 import { getImpeccableReference } from "../../../data/impeccable-reference.js";
 
 interface GenerateResult {
@@ -20,6 +22,7 @@ export class OgdGeneratorService {
   async generate(
     prdContent: string,
     previousFeedback?: string,
+    previousInstructions?: StructuredInstruction[],
   ): Promise<GenerateResult> {
     const designReference = getImpeccableReference();
 
@@ -37,7 +40,28 @@ export class OgdGeneratorService {
     ].join("\n");
 
     let userPrompt = `PRD:\n${prdContent}`;
-    if (previousFeedback) {
+
+    // F431: structured instructions 우선 주입 (구체적 지시가 있으면 일반 피드백보다 우선)
+    if (previousInstructions && previousInstructions.length > 0) {
+      const instructionLines = previousInstructions.map((inst, i) => {
+        const lines = [
+          `${i + 1}. [${inst.issue}]`,
+          `   수정 지시: ${inst.action}`,
+        ];
+        if (inst.example) {
+          lines.push(`   예시: \`${inst.example}\``);
+        }
+        return lines.join("\n");
+      });
+      userPrompt += [
+        "",
+        "",
+        "## 이전 라운드 수정 지시 (반드시 모두 적용할 것)",
+        "",
+        ...instructionLines,
+      ].join("\n");
+    } else if (previousFeedback) {
+      // 하위 호환: structured instructions 없을 때 기존 방식 사용
       userPrompt += `\n\nPrevious round feedback (improve these areas):\n${previousFeedback}`;
     }
 

--- a/packages/api/src/core/harness/services/ogd-orchestrator-service.ts
+++ b/packages/api/src/core/harness/services/ogd-orchestrator-service.ts
@@ -1,10 +1,12 @@
 // ─── F355: O-G-D Orchestrator Service (Sprint 160) ───
+// F431: FeedbackConverter 주입 + structured instructions 전달 (Sprint 207)
 // Generator → Discriminator → Feedback 루프 관리
 
 import { OGD_MAX_ROUNDS } from "@foundry-x/shared";
-import type { OgdRound, OgdSummary } from "@foundry-x/shared";
+import type { OgdRound, OgdSummary, StructuredInstruction } from "@foundry-x/shared";
 import { OgdGeneratorService } from "./ogd-generator-service.js";
 import { OgdDiscriminatorService } from "./ogd-discriminator-service.js";
+import { OgdFeedbackConverterService } from "./ogd-feedback-converter.js";
 
 interface OgdRoundRow {
   id: string;
@@ -50,6 +52,7 @@ export class OgdOrchestratorService {
     private db: D1Database,
     private generator: OgdGeneratorService,
     private discriminator: OgdDiscriminatorService,
+    private feedbackConverter?: OgdFeedbackConverterService,
   ) {}
 
   async runLoop(
@@ -64,17 +67,32 @@ export class OgdOrchestratorService {
     let passed = false;
     let totalCostUsd = 0;
     let previousFeedback: string | undefined;
+    let previousInstructions: StructuredInstruction[] | undefined;
 
     for (let round = 1; round <= OGD_MAX_ROUNDS; round++) {
-      // Generator: PRD + 이전 피드백 → HTML
-      const genResult = await this.generator.generate(prdContent, previousFeedback);
+      // Generator: PRD + 이전 피드백(or structured instructions) → HTML
+      const genResult = await this.generator.generate(prdContent, previousFeedback, previousInstructions);
 
-      // Discriminator: HTML + 체크리스트 → 스코어
+      // Discriminator: HTML + 체크리스트 → 스코어 + failedItems
       const evalResult = await this.discriminator.evaluate(genResult.html, checklist);
+
+      // F431: Feedback → Structured Instructions 변환
+      let convertCost = 0;
+      let structuredInstructions: StructuredInstruction[] | undefined;
+      if (!evalResult.passed && this.feedbackConverter) {
+        const convertResult = await this.feedbackConverter.convert(
+          evalResult.feedback,
+          evalResult.failedItems,
+        );
+        structuredInstructions = convertResult.instructions.length > 0
+          ? convertResult.instructions
+          : undefined;
+        convertCost = estimateCost(convertResult.inputTokens, convertResult.outputTokens);
+      }
 
       const totalInput = genResult.inputTokens + evalResult.inputTokens;
       const totalOutput = genResult.outputTokens + evalResult.outputTokens;
-      const roundCost = estimateCost(totalInput, totalOutput);
+      const roundCost = estimateCost(totalInput, totalOutput) + convertCost;
       totalCostUsd += roundCost;
 
       // DB에 라운드 기록
@@ -105,6 +123,7 @@ export class OgdOrchestratorService {
         modelUsed: genResult.modelUsed,
         passed: evalResult.passed,
         createdAt: now,
+        structuredInstructions,  // F431
       };
       rounds.push(ogdRound);
 
@@ -119,8 +138,9 @@ export class OgdOrchestratorService {
         break;
       }
 
-      // 다음 라운드에 피드백 전달
-      previousFeedback = evalResult.feedback;
+      // F431: 다음 라운드에 structured instructions 우선 전달, 없으면 raw feedback
+      previousInstructions = structuredInstructions;
+      previousFeedback = structuredInstructions ? undefined : evalResult.feedback;
     }
 
     // prototype_jobs 갱신

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -378,6 +378,7 @@ export type {
   OgdStatus,
   OgdRound,
   OgdSummary,
+  StructuredInstruction,
 } from './ogd.js';
 
 // F356: Prototype Feedback types (Sprint 160, Phase 16)

--- a/packages/shared/src/ogd.ts
+++ b/packages/shared/src/ogd.ts
@@ -1,6 +1,17 @@
 // F355: O-G-D Quality Loop shared types (Sprint 160)
+// F431: StructuredInstruction + OgdRound.structuredInstructions (Sprint 207)
 
 export type OgdStatus = "pending" | "running" | "passed" | "failed" | "max_rounds";
+
+/** F431: 판별 피드백 구체화 — 구체적 수정 지시 단위 */
+export interface StructuredInstruction {
+  /** 문제 항목 (체크리스트 항목명) */
+  issue: string;
+  /** 구체적 수정 지시 (동사형: "~하라") */
+  action: string;
+  /** CSS/HTML 예시 코드 스니펫 (선택) */
+  example?: string;
+}
 
 export interface OgdRound {
   id: string;
@@ -14,6 +25,8 @@ export interface OgdRound {
   modelUsed: string;
   passed: boolean;
   createdAt: number;
+  /** F431: 구체적 수정 지시 목록 (다음 라운드 Generator에 주입됨) */
+  structuredInstructions?: StructuredInstruction[];
 }
 
 export interface OgdSummary {


### PR DESCRIPTION
## Sprint 207 — F431 (Phase 22-D FINAL)
- F431: LLM 판별→구체적 수정 지시 변환 + Generator 자동 주입
- Match Rate: 100%
- Phase 22-D Builder v2 전체 완료 (F423~F431, 9/9)

🤖 Sprint 207 autopilot (Sonnet 4.6)