### PR TITLE
fix: 대시보드 콘솔 에러 3건 수정

### DIFF
--- a/packages/api/src/core/discovery/routes/biz-items.ts
+++ b/packages/api/src/core/discovery/routes/biz-items.ts
@@ -39,6 +39,42 @@ import { getAnalysisPathV82, type DiscoveryType } from "../services/analysis-pat
 
 export const bizItemsRoute = new Hono<{ Bindings: Env; Variables: TenantVariables }>();
 
+// ─── GET /biz-items/summary — 대시보드 ToDo 요약 (F323) ───
+
+const STAGE_TO_NUMBER: Record<string, number> = {
+  REGISTERED: 1,
+  DISCOVERY: 2,
+  FORMALIZATION: 3,
+  REVIEW: 4,
+  DECISION: 5,
+  OFFERING: 6,
+  MVP: 6,
+};
+
+bizItemsRoute.get("/biz-items/summary", async (c) => {
+  const orgId = c.get("orgId");
+
+  const { results } = await c.env.DB
+    .prepare(
+      `SELECT bi.id AS biz_item_id, bi.title, ps.stage
+       FROM biz_items bi
+       LEFT JOIN pipeline_stages ps
+         ON ps.biz_item_id = bi.id AND ps.exited_at IS NULL
+       WHERE bi.org_id = ?
+       ORDER BY bi.created_at DESC`,
+    )
+    .bind(orgId)
+    .all<{ biz_item_id: string; title: string; stage: string | null }>();
+
+  const items = results.map((r) => ({
+    bizItemId: r.biz_item_id,
+    title: r.title,
+    currentStage: STAGE_TO_NUMBER[r.stage ?? "REGISTERED"] ?? 1,
+  }));
+
+  return c.json({ items });
+});
+
 // ─── POST /biz-items — 사업 아이템 등록 ───
 
 bizItemsRoute.post("/biz-items", async (c) => {

--- a/packages/web/public/_headers
+++ b/packages/web/public/_headers
@@ -12,4 +12,3 @@
 
 /admin/assets/*
   Cache-Control: public, max-age=31536000, immutable
-/* SPA _redirects restore — deploy trigger */

--- a/packages/web/src/routes/dashboard.metrics.tsx
+++ b/packages/web/src/routes/dashboard.metrics.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { fetchApi, BASE_URL } from "@/lib/api-client";
+import { fetchApi } from "@/lib/api-client";
 import { AgentUsageChart } from "@/components/feature/AgentUsageChart";
 import { SkillReuseChart } from "@/components/feature/SkillReuseChart";
 import { RuleEffectChart } from "@/components/feature/RuleEffectChart";
@@ -26,10 +26,10 @@ export function Component() {
     async function load() {
       try {
         const [ov, eff, usage, reuse] = await Promise.all([
-          fetchApi<MetricsOverview>(`${BASE_URL}/metrics/overview`),
-          fetchApi<RuleEffectivenessResponse>(`${BASE_URL}/guard-rail/effectiveness`),
-          fetchApi<AgentUsageResponse>(`${BASE_URL}/metrics/agent-usage`),
-          fetchApi<SkillReuseResponse>(`${BASE_URL}/metrics/skill-reuse`),
+          fetchApi<MetricsOverview>("/metrics/overview"),
+          fetchApi<RuleEffectivenessResponse>("/guard-rail/effectiveness"),
+          fetchApi<AgentUsageResponse>("/metrics/agent-usage"),
+          fetchApi<SkillReuseResponse>("/metrics/skill-reuse"),
         ]);
         setOverview(ov);
         setEffectiveness(eff);


### PR DESCRIPTION
## Summary
- **dashboard.metrics.tsx**: `fetchApi`에 `BASE_URL` 중복 전달 제거 — URL이 `BASE_URL/BASE_URL/path`로 이중 생성되던 버그
- **biz-items.ts**: `GET /biz-items/summary` 라우트 추가 — TodoSection(F323)이 호출하는 미구현 엔드포인트 404 해소
- **_headers**: Cloudflare Pages 파서를 방해하는 잘못된 주석 제거 — `/* ... */` 형식이 경로 패턴으로 해석되어 200 rewrite 실패

## Test plan
- [x] Web typecheck 통과
- [x] biz-items 관련 테스트 77건 통과
- [x] pipeline 테스트 9건 통과
- [ ] 배포 후 `curl -sI https://fx.minu.best/dashboard` → 200 확인
- [ ] 배포 후 대시보드 콘솔 에러 0건 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)