### PR TITLE
fix: 대시보드 에러 수정 + 사이드바 CMS SSOT 리팩토링

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+### 세션 #224 (2026-04-07)
+**사이드바 IA 점검 + CMS SSOT 확정**:
+- ✅ sidebar.json(TinaCMS) ↔ 코드 Default 불일치 발견: Offerings 누락, Admin 단일그룹 vs MSA 5그룹
+- ✅ sidebar.json 동기화: Offerings 항목 추가, Admin→MSA 5서비스 그룹, badge "이관 예정"
+- ✅ CMS SSOT 리팩토링: DEFAULT_* 상수 ~140줄 삭제, sortAndFilter 헬퍼 도입, nullable 제거
+- ✅ navigation-loader.ts: try/catch fallback → 정적 import 전환 (빌드 타임 에러 감지)
+- ✅ 테스트 갱신: 소스 문자열 검사→JSON 구조 검사 전환 (22/22 pass)
+
+**검증 결과**: ✅ typecheck / test (22 pass)
+
+### 세션 #223 (2026-04-07)
+**대시보드 콘솔 에러 3건 수정**:
+- ✅ BASE_URL 중복 슬래시 해소 (biz-items.ts)
+- ✅ biz-items/summary 404 해소
+- ✅ _headers 파서 간섭 해소
+
+**검증 결과**: ✅ typecheck
+
 ### 세션 #222 (2026-04-07)
 **E2E flaky 해소 + 레거시 라우트 리다이렉트 수정**:
 - ✅ E2E 4건 flaky 해소 (onboarding-flow, org-members, sse-lifecycle, uncovered-pages)

--- a/packages/api/src/core/discovery/routes/biz-items.ts
+++ b/packages/api/src/core/discovery/routes/biz-items.ts
@@ -39,6 +39,42 @@ import { getAnalysisPathV82, type DiscoveryType } from "../services/analysis-pat
 
 export const bizItemsRoute = new Hono<{ Bindings: Env; Variables: TenantVariables }>();
 
+// ─── GET /biz-items/summary — 대시보드 ToDo 요약 (F323) ───
+
+const STAGE_TO_NUMBER: Record<string, number> = {
+  REGISTERED: 1,
+  DISCOVERY: 2,
+  FORMALIZATION: 3,
+  REVIEW: 4,
+  DECISION: 5,
+  OFFERING: 6,
+  MVP: 6,
+};
+
+bizItemsRoute.get("/biz-items/summary", async (c) => {
+  const orgId = c.get("orgId");
+
+  const { results } = await c.env.DB
+    .prepare(
+      `SELECT bi.id AS biz_item_id, bi.title, ps.stage
+       FROM biz_items bi
+       LEFT JOIN pipeline_stages ps
+         ON ps.biz_item_id = bi.id AND ps.exited_at IS NULL
+       WHERE bi.org_id = ?
+       ORDER BY bi.created_at DESC`,
+    )
+    .bind(orgId)
+    .all<{ biz_item_id: string; title: string; stage: string | null }>();
+
+  const items = results.map((r) => ({
+    bizItemId: r.biz_item_id,
+    title: r.title,
+    currentStage: STAGE_TO_NUMBER[r.stage ?? "REGISTERED"] ?? 1,
+  }));
+
+  return c.json({ items });
+});
+
 // ─── POST /biz-items — 사업 아이템 등록 ───
 
 bizItemsRoute.post("/biz-items", async (c) => {

--- a/packages/web/content/navigation/sidebar.json
+++ b/packages/web/content/navigation/sidebar.json
@@ -13,11 +13,11 @@
       "sortOrder": 0,
       "visible": true,
       "collapsed": true,
-      "badge": "TBD",
+      "badge": "이관 예정",
       "items": [
-        { "href": "/collection/field", "label": "Field 수집", "iconKey": "Radio", "visible": false, "sortOrder": 0 },
-        { "href": "/collection/ideas", "label": "IDEA Portal", "iconKey": "ArrowUpFromLine", "visible": false, "sortOrder": 1 },
-        { "href": "/collection/screening", "label": "스크리닝", "iconKey": "ClipboardList", "visible": false, "sortOrder": 2 }
+        { "href": "/collection/field", "label": "Field 수집", "iconKey": "Radio", "visible": true, "sortOrder": 0 },
+        { "href": "/collection/ideas", "label": "IDEA Portal", "iconKey": "ArrowUpFromLine", "visible": true, "sortOrder": 1 },
+        { "href": "/collection/screening", "label": "스크리닝", "iconKey": "ClipboardList", "visible": true, "sortOrder": 2 }
       ]
     },
     {
@@ -41,9 +41,10 @@
       "visible": true,
       "items": [
         { "href": "/shaping/business-plan", "label": "사업기획서", "iconKey": "FileSignature", "visible": true, "sortOrder": 0 },
-        { "href": "/shaping/offering", "label": "Offering", "iconKey": "Package", "visible": true, "sortOrder": 1 },
-        { "href": "/shaping/prd", "label": "PRD", "iconKey": "FileText", "visible": true, "sortOrder": 2 },
-        { "href": "/shaping/prototype", "label": "Prototype", "iconKey": "Code", "visible": true, "sortOrder": 3 }
+        { "href": "/shaping/offerings", "label": "Offerings", "iconKey": "FileOutput", "visible": true, "sortOrder": 1 },
+        { "href": "/shaping/offering", "label": "Offering Pack", "iconKey": "Package", "visible": true, "sortOrder": 2 },
+        { "href": "/shaping/prd", "label": "PRD", "iconKey": "FileText", "visible": true, "sortOrder": 3 },
+        { "href": "/shaping/prototype", "label": "Prototype", "iconKey": "Code", "visible": true, "sortOrder": 4 }
       ]
     },
     {
@@ -78,10 +79,10 @@
       "sortOrder": 5,
       "visible": true,
       "collapsed": true,
-      "badge": "TBD",
+      "badge": "이관 예정",
       "items": [
-        { "href": "/gtm/outreach", "label": "대고객 선제안", "iconKey": "Send", "visible": false, "sortOrder": 0 },
-        { "href": "/gtm/pipeline", "label": "파이프라인", "iconKey": "GitBranch", "visible": false, "sortOrder": 1 }
+        { "href": "/gtm/outreach", "label": "대고객 선제안", "iconKey": "Send", "visible": true, "sortOrder": 0 },
+        { "href": "/gtm/pipeline", "label": "파이프라인", "iconKey": "GitBranch", "visible": true, "sortOrder": 1 }
       ]
     }
   ],
@@ -91,19 +92,64 @@
   ],
   "adminGroups": [
     {
-      "key": "admin-manage",
-      "label": "관리",
-      "iconKey": "Settings",
+      "key": "admin-auth",
+      "label": "Auth 서비스",
+      "iconKey": "Users",
       "sortOrder": 0,
       "visible": true,
+      "badge": "modules/auth",
       "items": [
         { "href": "/tokens", "label": "토큰/모델", "iconKey": "Coins", "visible": true, "sortOrder": 0 },
-        { "href": "/workspace", "label": "워크스페이스", "iconKey": "FolderKanban", "visible": true, "sortOrder": 1 },
-        { "href": "/agents", "label": "에이전트", "iconKey": "Bot", "visible": true, "sortOrder": 2 },
-        { "href": "/architecture", "label": "아키텍처", "iconKey": "Blocks", "visible": true, "sortOrder": 3 },
-        { "href": "/methodologies", "label": "방법론", "iconKey": "Library", "visible": true, "sortOrder": 4 },
-        { "href": "/projects", "label": "프로젝트", "iconKey": "FolderKanban", "visible": true, "sortOrder": 5 },
-        { "href": "/nps-dashboard", "label": "NPS 대시보드", "iconKey": "BarChart3", "visible": true, "sortOrder": 6 }
+        { "href": "/workspace", "label": "워크스페이스", "iconKey": "FolderKanban", "visible": true, "sortOrder": 1 }
+      ]
+    },
+    {
+      "key": "admin-portal",
+      "label": "Portal 서비스",
+      "iconKey": "LayoutDashboard",
+      "sortOrder": 1,
+      "visible": true,
+      "badge": "modules/portal",
+      "items": [
+        { "href": "/nps-dashboard", "label": "NPS 대시보드", "iconKey": "BarChart3", "visible": true, "sortOrder": 0 },
+        { "href": "/dashboard/metrics", "label": "운영 지표", "iconKey": "TrendingUp", "visible": true, "sortOrder": 1 },
+        { "href": "/projects", "label": "프로젝트", "iconKey": "FolderKanban", "visible": true, "sortOrder": 2 }
+      ]
+    },
+    {
+      "key": "admin-gate",
+      "label": "Gate 서비스",
+      "iconKey": "CheckCircle",
+      "sortOrder": 2,
+      "visible": true,
+      "badge": "modules/gate",
+      "items": [
+        { "href": "/orchestration", "label": "오케스트레이션", "iconKey": "Network", "visible": true, "sortOrder": 0 }
+      ]
+    },
+    {
+      "key": "admin-launch",
+      "label": "Launch 서비스",
+      "iconKey": "Rocket",
+      "sortOrder": 3,
+      "visible": true,
+      "badge": "modules/launch",
+      "items": [
+        { "href": "/prototype-dashboard", "label": "Prototype", "iconKey": "FlaskConical", "visible": true, "sortOrder": 0 },
+        { "href": "/builder-quality", "label": "Quality", "iconKey": "BarChart3", "visible": true, "sortOrder": 1 }
+      ]
+    },
+    {
+      "key": "admin-core",
+      "label": "Core (Foundry-X)",
+      "iconKey": "GitBranch",
+      "sortOrder": 4,
+      "visible": true,
+      "badge": "core",
+      "items": [
+        { "href": "/agents", "label": "에이전트", "iconKey": "Bot", "visible": true, "sortOrder": 0 },
+        { "href": "/architecture", "label": "아키텍처", "iconKey": "Blocks", "visible": true, "sortOrder": 1 },
+        { "href": "/methodologies", "label": "방법론", "iconKey": "Library", "visible": true, "sortOrder": 2 }
       ]
     }
   ]

--- a/packages/web/public/_headers
+++ b/packages/web/public/_headers
@@ -12,4 +12,3 @@
 
 /admin/assets/*
   Cache-Control: public, max-age=31536000, immutable
-/* SPA _redirects restore — deploy trigger */

--- a/packages/web/src/__tests__/sidebar-ia.test.tsx
+++ b/packages/web/src/__tests__/sidebar-ia.test.tsx
@@ -1,46 +1,55 @@
 // ─── F398: 사이드바 IA 개편 테스트 (Sprint 185) ───
+// SSOT: content/navigation/sidebar.json (CMS-driven)
 
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "fs";
 import { resolve } from "path";
 
-const sidebarPath = resolve(process.cwd(), "src/components/sidebar.tsx");
-const sidebarContent = readFileSync(sidebarPath, "utf-8");
+const sidebarJsonPath = resolve(process.cwd(), "content/navigation/sidebar.json");
+const sidebarJson = JSON.parse(readFileSync(sidebarJsonPath, "utf-8"));
 
 describe("사이드바 IA 개편 — 이관 예정 라벨", () => {
   it("'이관 예정' badge가 2개 이상 존재 (수집 + GTM)", () => {
-    const matches = sidebarContent.match(/badge:\s*["']이관 예정["']/g) ?? [];
-    expect(matches.length).toBeGreaterThanOrEqual(2);
+    const groupsWithBadge = sidebarJson.processGroups.filter(
+      (g: { badge?: string }) => g.badge === "이관 예정",
+    );
+    expect(groupsWithBadge.length).toBeGreaterThanOrEqual(2);
   });
 
   it("collect 그룹에 이관 예정 라벨 (TBD 없음)", () => {
-    expect(sidebarContent).not.toMatch(/key:\s*["']collect["'][^}]*badge:\s*["']TBD["']/s);
+    const collect = sidebarJson.processGroups.find(
+      (g: { key: string }) => g.key === "collect",
+    );
+    expect(collect).toBeDefined();
+    expect(collect.badge).toBe("이관 예정");
   });
 });
 
 describe("사이드바 IA 개편 — 서비스 경계 그룹", () => {
+  const adminKeys = (sidebarJson.adminGroups ?? []).map((g: { key: string }) => g.key);
+
   it("admin-auth 그룹 존재", () => {
-    expect(sidebarContent).toContain('"admin-auth"');
+    expect(adminKeys).toContain("admin-auth");
   });
 
   it("admin-portal 그룹 존재", () => {
-    expect(sidebarContent).toContain('"admin-portal"');
+    expect(adminKeys).toContain("admin-portal");
   });
 
   it("admin-gate 그룹 존재", () => {
-    expect(sidebarContent).toContain('"admin-gate"');
+    expect(adminKeys).toContain("admin-gate");
   });
 
   it("admin-launch 그룹 존재", () => {
-    expect(sidebarContent).toContain('"admin-launch"');
+    expect(adminKeys).toContain("admin-launch");
   });
 
   it("admin-core 그룹 존재", () => {
-    expect(sidebarContent).toContain('"admin-core"');
+    expect(adminKeys).toContain("admin-core");
   });
 
-  it("DEFAULT_ADMIN_GROUPS 배열 사용", () => {
-    expect(sidebarContent).toContain("DEFAULT_ADMIN_GROUPS");
+  it("CMS sidebar.json을 SSOT로 사용", () => {
+    expect(sidebarJson.navId).toBe("main-sidebar");
   });
 });
 

--- a/packages/web/src/__tests__/sidebar-visibility.test.tsx
+++ b/packages/web/src/__tests__/sidebar-visibility.test.tsx
@@ -112,11 +112,12 @@ describe("Sidebar role-based visibility", () => {
     expect(screen.queryByText("아키텍처")).not.toBeInTheDocument();
   });
 
-  it("T-06: Admin 로그인 시 관리 그룹 헤더 노출", () => {
+  it("T-06: Admin 로그인 시 MSA 서비스 그룹 헤더 노출", () => {
     mockedUseUserRole.mockReturnValue({ role: "admin", isAdmin: true });
     renderSidebar();
-    // F322: 외부 서비스 그룹 제거, 관리 그룹만 검증
-    expect(screen.getAllByText("관리").length).toBeGreaterThan(0);
+    // Phase 20: MSA 5개 서비스 그룹 (Auth/Portal/Gate/Launch/Core)
+    expect(screen.getAllByText("Auth 서비스").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Core (Foundry-X)").length).toBeGreaterThan(0);
   });
 
   it("T-07: F322 — 수집 그룹은 collapsed+TBD (items visible:false)", () => {
@@ -145,8 +146,9 @@ describe("Sidebar role-based visibility", () => {
     // F322: 지식/외부 서비스 그룹 제거
     expect(screen.queryByText("지식")).not.toBeInTheDocument();
     expect(screen.queryByText("외부 서비스")).not.toBeInTheDocument();
-    // Admin 전용 그룹은 미노출
-    expect(screen.queryByText("관리")).not.toBeInTheDocument();
+    // Admin 전용 MSA 그룹은 미노출
+    expect(screen.queryByText("Auth 서비스")).not.toBeInTheDocument();
+    expect(screen.queryByText("Core (Foundry-X)")).not.toBeInTheDocument();
   });
 
   it("Member: 하단에 위키+설정 표시", () => {

--- a/packages/web/src/components/sidebar.tsx
+++ b/packages/web/src/components/sidebar.tsx
@@ -4,45 +4,13 @@ import { Link } from "react-router-dom";
 import { useLocation } from "react-router-dom";
 import { useState, useEffect, useCallback, useMemo } from "react";
 import {
-  LayoutDashboard,
-  BookOpen,
-  Blocks,
-  ClipboardList,
-  Bot,
-  Coins,
-  BarChart3,
   Menu,
-  Search,
   LogIn,
   LogOut,
-  Rocket,
-  FileText,
-  FolderKanban,
   ChevronRight,
-  Inbox,
-  TrendingUp,
-  Settings,
-  Map,
-  Radio,
-  ArrowUpFromLine,
-  PenTool,
-  FileSignature,
-  Package,
-  CheckCircle,
-  GitBranch,
-  Target,
-  Library,
-  Users,
-  ClipboardCheck,
-  Code,
-  Send,
-  Activity,
-  FlaskConical,
-  FileOutput,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { loadSidebarConfig, getIcon } from "@/lib/navigation-loader";
-import type { SidebarConfig } from "@/lib/navigation-loader";
 import { Button } from "@/components/ui/button";
 import { useAuthStore } from "@/lib/stores/auth-store";
 import {
@@ -98,205 +66,45 @@ export function isVisible(
   return true;
 }
 
-const DEFAULT_TOP_ITEMS: NavItem[] = [
-  { href: "/dashboard", label: "대시보드", icon: LayoutDashboard },
-  { href: "/getting-started", label: "시작하기", icon: Rocket },
-];
-
-/* ── 프로세스 6단계: 수집→발굴→형상화→검증/공유→제품화→GTM ── */
-
-const DEFAULT_PROCESS_GROUPS: NavGroup[] = [
-  {
-    key: "collect",
-    label: "1. 수집",
-    icon: Inbox,
-    stageColor: "bg-axis-blue",
-    collapsed: true,
-    badge: "이관 예정",
-    items: [
-      { href: "/collection/field", label: "Field 수집", icon: Radio },
-      { href: "/collection/ideas", label: "IDEA Portal", icon: ArrowUpFromLine },
-      { href: "/collection/screening", label: "스크리닝", icon: ClipboardList },
-    ],
-  },
-  {
-    key: "discover",
-    label: "2. 발굴",
-    icon: Search,
-    stageColor: "bg-axis-violet",
-    items: [
-      { href: "/discovery", label: "발굴", icon: Map },
-      { href: "/discovery/report", label: "평가 결과서", icon: ClipboardCheck },
-    ],
-  },
-  {
-    key: "shape",
-    label: "3. 형상화",
-    icon: PenTool,
-    stageColor: "bg-axis-warm",
-    items: [
-      { href: "/shaping/business-plan", label: "사업기획서", icon: FileSignature },
-      { href: "/shaping/offerings", label: "Offerings", icon: FileOutput },
-      { href: "/shaping/offering", label: "Offering Pack", icon: Package },
-      { href: "/shaping/prd", label: "PRD", icon: FileText },
-      { href: "/shaping/prototype", label: "Prototype", icon: Code },
-    ],
-  },
-  {
-    key: "validate",
-    label: "4. 검증",
-    icon: CheckCircle,
-    stageColor: "bg-axis-green",
-    items: [
-      { href: "/validation", label: "검증", icon: CheckCircle },
-      { href: "/validation/share", label: "산출물 공유", icon: Users },
-    ],
-  },
-  {
-    key: "productize",
-    label: "5. 제품화",
-    icon: Rocket,
-    stageColor: "bg-axis-indigo",
-    items: [
-      { href: "/product", label: "제품화", icon: Target },
-      { href: "/product/offering-pack", label: "Offering Pack", icon: Package },
-    ],
-  },
-  {
-    key: "gtm",
-    label: "6. GTM",
-    icon: TrendingUp,
-    stageColor: "bg-axis-rose",
-    collapsed: true,
-    badge: "이관 예정",
-    items: [
-      { href: "/gtm/outreach", label: "대고객 선제안", icon: Send },
-      { href: "/gtm/pipeline", label: "파이프라인", icon: GitBranch },
-    ],
-  },
-];
-
-const DEFAULT_ADMIN_GROUPS: NavGroup[] = [
-  {
-    key: "admin-auth",
-    label: "Auth 서비스",
-    icon: Users,
-    visibility: "admin",
-    badge: "modules/auth",
-    items: [
-      { href: "/tokens", label: "토큰/모델", icon: Coins },
-      { href: "/workspace", label: "워크스페이스", icon: FolderKanban },
-    ],
-  },
-  {
-    key: "admin-portal",
-    label: "Portal 서비스",
-    icon: LayoutDashboard,
-    visibility: "admin",
-    badge: "modules/portal",
-    items: [
-      { href: "/nps-dashboard", label: "NPS 대시보드", icon: BarChart3 },
-      { href: "/dashboard/metrics", label: "운영 지표", icon: TrendingUp },
-      { href: "/projects", label: "프로젝트", icon: FolderKanban },
-    ],
-  },
-  {
-    key: "admin-gate",
-    label: "Gate 서비스",
-    icon: CheckCircle,
-    visibility: "admin",
-    badge: "modules/gate",
-    items: [
-      { href: "/orchestration", label: "오케스트레이션", icon: Activity },
-    ],
-  },
-  {
-    key: "admin-launch",
-    label: "Launch 서비스",
-    icon: Rocket,
-    visibility: "admin",
-    badge: "modules/launch",
-    items: [
-      { href: "/prototype-dashboard", label: "Prototype", icon: FlaskConical },
-      { href: "/builder-quality", label: "Quality", icon: BarChart3 },
-    ],
-  },
-  {
-    key: "admin-core",
-    label: "Core (Foundry-X)",
-    icon: GitBranch,
-    visibility: "admin",
-    badge: "core",
-    items: [
-      { href: "/agents", label: "에이전트", icon: Bot },
-      { href: "/architecture", label: "아키텍처", icon: Blocks },
-      { href: "/methodologies", label: "방법론", icon: Library },
-    ],
-  },
-];
-
-const DEFAULT_MEMBER_BOTTOM_ITEMS: NavItem[] = [
-  { href: "/wiki", label: "위키", icon: BookOpen },
-  { href: "/settings", label: "설정", icon: Settings },
-];
-
 /* ------------------------------------------------------------------ */
-/*  CMS-driven Navigation (TinaCMS content → NavItem/NavGroup)         */
+/*  CMS-driven Navigation (SSOT: content/navigation/sidebar.json)      */
+/*  sidebar.json이 없으면 빌드 에러 → drift 즉시 감지                    */
 /* ------------------------------------------------------------------ */
 
-const cmsNav: SidebarConfig | null = loadSidebarConfig();
+const cmsNav = loadSidebarConfig()!;
 
 function cmsItemToNav(item: { href: string; label: string; iconKey: string }): NavItem {
   return { href: item.href, label: item.label, icon: getIcon(item.iconKey) };
 }
 
-const topItems: NavItem[] = cmsNav
-  ? cmsNav.topItems
-      .filter((i) => i.visible !== false)
-      .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0))
-      .map(cmsItemToNav)
-  : DEFAULT_TOP_ITEMS;
+function sortAndFilter<T extends { visible?: boolean; sortOrder?: number }>(items: T[]): T[] {
+  return items
+    .filter((i) => i.visible !== false)
+    .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0));
+}
 
-const processGroups: NavGroup[] = cmsNav
-  ? cmsNav.processGroups
-      .filter((g) => g.visible !== false)
-      .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0))
-      .map((g) => ({
-        key: g.key,
-        label: g.label,
-        icon: getIcon(g.iconKey ?? g.items[0]?.iconKey ?? "HelpCircle"),
-        stageColor: g.stageColor,
-        collapsed: g.collapsed,
-        badge: g.badge,
-        items: g.items
-          .filter((i) => i.visible !== false)
-          .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0))
-          .map(cmsItemToNav),
-      }))
-  : DEFAULT_PROCESS_GROUPS;
+const topItems: NavItem[] = sortAndFilter(cmsNav.topItems).map(cmsItemToNav);
 
-const memberBottomItems: NavItem[] = cmsNav
-  ? cmsNav.bottomItems
-      .filter((i) => i.visible !== false)
-      .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0))
-      .map(cmsItemToNav)
-  : DEFAULT_MEMBER_BOTTOM_ITEMS;
+const processGroups: NavGroup[] = sortAndFilter(cmsNav.processGroups).map((g) => ({
+  key: g.key,
+  label: g.label,
+  icon: getIcon(g.iconKey ?? g.items[0]?.iconKey ?? "HelpCircle"),
+  stageColor: g.stageColor,
+  collapsed: g.collapsed,
+  badge: g.badge,
+  items: sortAndFilter(g.items).map(cmsItemToNav),
+}));
 
-const adminGroups: NavGroup[] = cmsNav?.adminGroups
-  ? cmsNav.adminGroups
-      .filter((g) => g.visible !== false)
-      .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0))
-      .map((g) => ({
-        key: g.key,
-        label: g.label,
-        icon: getIcon(g.iconKey ?? "Settings"),
-        visibility: "admin" as Visibility,
-        items: g.items
-          .filter((i) => i.visible !== false)
-          .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0))
-          .map(cmsItemToNav),
-      }))
-  : DEFAULT_ADMIN_GROUPS;
+const memberBottomItems: NavItem[] = sortAndFilter(cmsNav.bottomItems).map(cmsItemToNav);
+
+const adminGroups: NavGroup[] = sortAndFilter(cmsNav.adminGroups ?? []).map((g) => ({
+  key: g.key,
+  label: g.label,
+  icon: getIcon(g.iconKey ?? "Settings"),
+  visibility: "admin" as Visibility,
+  badge: g.badge,
+  items: sortAndFilter(g.items).map(cmsItemToNav),
+}));
 
 /* ------------------------------------------------------------------ */
 /*  Collapsible Group State (localStorage 영속)                        */

--- a/packages/web/src/lib/navigation-loader.ts
+++ b/packages/web/src/lib/navigation-loader.ts
@@ -18,6 +18,7 @@ import {
   ClipboardList,
   Code,
   Coins,
+  FileOutput,
   FileSignature,
   FileText,
   FlaskConical,
@@ -91,6 +92,7 @@ const iconMap: Record<string, LucideIcon> = {
   ClipboardList,
   Code,
   Coins,
+  FileOutput,
   FileSignature,
   FileText,
   FlaskConical,
@@ -123,18 +125,10 @@ export function getIcon(key: string): LucideIcon {
   return iconMap[key] ?? HelpCircle;
 }
 
-/* ── Loader ── */
+/* ── Loader (SSOT: content/navigation/sidebar.json) ── */
+// sidebar.json이 없으면 빌드 에러 — fallback 없이 즉시 감지
+import sidebarData from "../../content/navigation/sidebar.json";
 
-let sidebarData: SidebarConfig | null = null;
-try {
-  // Vite resolves this at build time — if the file doesn't exist, the build still succeeds
-  // because we catch the error and fall back to null.
-  const mod = await import("../../content/navigation/sidebar.json");
-  sidebarData = mod.default as SidebarConfig;
-} catch {
-  sidebarData = null;
-}
-
-export function loadSidebarConfig(): SidebarConfig | null {
-  return sidebarData;
+export function loadSidebarConfig(): SidebarConfig {
+  return sidebarData as SidebarConfig;
 }

--- a/packages/web/src/routes/dashboard.metrics.tsx
+++ b/packages/web/src/routes/dashboard.metrics.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { fetchApi, BASE_URL } from "@/lib/api-client";
+import { fetchApi } from "@/lib/api-client";
 import { AgentUsageChart } from "@/components/feature/AgentUsageChart";
 import { SkillReuseChart } from "@/components/feature/SkillReuseChart";
 import { RuleEffectChart } from "@/components/feature/RuleEffectChart";
@@ -26,10 +26,10 @@ export function Component() {
     async function load() {
       try {
         const [ov, eff, usage, reuse] = await Promise.all([
-          fetchApi<MetricsOverview>(`${BASE_URL}/metrics/overview`),
-          fetchApi<RuleEffectivenessResponse>(`${BASE_URL}/guard-rail/effectiveness`),
-          fetchApi<AgentUsageResponse>(`${BASE_URL}/metrics/agent-usage`),
-          fetchApi<SkillReuseResponse>(`${BASE_URL}/metrics/skill-reuse`),
+          fetchApi<MetricsOverview>("/metrics/overview"),
+          fetchApi<RuleEffectivenessResponse>("/guard-rail/effectiveness"),
+          fetchApi<AgentUsageResponse>("/metrics/agent-usage"),
+          fetchApi<SkillReuseResponse>("/metrics/skill-reuse"),
         ]);
         setOverview(ov);
         setEffectiveness(eff);


### PR DESCRIPTION
## Summary
- 대시보드 콘솔 에러 3건 수정 (BASE_URL 중복, biz-items/summary 404, _headers 파서 간섭)
- 사이드바 CMS sidebar.json ↔ 코드 DEFAULT 불일치 해소 (Offerings 누락, Admin 단일→MSA 5그룹)
- CMS SSOT 리팩토링: DEFAULT_* 상수 ~140줄 삭제, 정적 import 전환, nullable 제거

## Changes
- `sidebar.json`: Offerings 항목 추가, Admin→MSA 5서비스 그룹, badge 동기화
- `sidebar.tsx`: DEFAULT 상수 제거, sortAndFilter 헬퍼 도입 (-272/+131)
- `navigation-loader.ts`: try/catch fallback → 정적 import
- 테스트 2개 갱신: 소스 문자열→JSON 구조 검사 전환

## Test plan
- [x] typecheck: 0 errors
- [x] sidebar-ia.test.tsx: 9/9 pass
- [x] sidebar-visibility.test.tsx: 13/13 pass
- [x] gstack browse로 로컬 사이드바 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)