### PR TITLE
feat: Sprint 210 — F436 아이템 CRUD + F437 분석 대시보드

### DIFF
--- a/docs/02-design/features/fx-discovery-native.design.md
+++ b/docs/02-design/features/fx-discovery-native.design.md
@@ -279,49 +279,68 @@ src/routes/getting-started.tsx (재구축)
 ### 5.1 discovery-unified.tsx 재구축
 
 **As-Is:** 3탭 (대시보드/프로세스/BMC)
-**To-Be:** 아이템 카드 목록
+**To-Be:** 아이템 카드 목록 + 검색 + 상태 필터
 
 ```
 ┌─────────────────────────────────────────────────┐
 │ 내 아이템                              [+ 새 아이템] │
 │                                                 │
-│ 필터: [전체] [분석 중] [형상화 중] [완료]          │
+│ [🔍 아이템 검색...]                              │
+│ 필터: [전체] [대기] [분석 중] [분석 완료] [완료]   │
 ├─────────────────────────────────────────────────┤
 │                                                 │
 │ ┌──────────────┐  ┌──────────────┐              │
 │ │ AI 비서 도입   │  │ 클라우드 전환  │              │
-│ │ 🟢 분석 완료   │  │ 🔵 분석 중    │              │
-│ │ ████████ 100% │  │ ████░░░ 45%  │              │
-│ │ 3일 전 갱신   │  │ 방금 전       │              │
+│ │ [분석 중] 뱃지  │  │ [대기] 뱃지    │              │
+│ │ I — 아이디어형  │  │ T — 기술형    │              │
+│ │ 4월 1일 등록   │  │ 4월 2일 등록  │              │
 │ └──────────────┘  └──────────────┘              │
 │                                                 │
-│ ┌──────────────┐                                │
-│ │ 데이터 분석    │  아이템이 없어요.                │
-│ │ ⬜ 대기       │  [+ 새 아이템 등록]              │
-│ │ ░░░░░░░ 0%   │                                │
-│ │ 5분 전 등록   │                                │
-│ └──────────────┘                                │
+│ ─── 빈 상태 ───                                 │
+│  💡 아직 등록된 아이템이 없어요.                   │
+│  [+ 첫 아이템 등록하기]                           │
 └─────────────────────────────────────────────────┘
 ```
+
+> **진행률 표시 결정**: 목록 API(`GET /biz-items`)에 progress 미포함 — N+1 방지 목적.
+> 9기준 진행률은 아이템 상세 페이지(DiscoveryCriteriaPanel)에서만 표시.
 
 ### 5.2 아이템 카드 컴포넌트
 
 ```typescript
 // 새 컴포넌트: src/components/feature/discovery/BizItemCard.tsx
 interface BizItemCardProps {
-  item: BizItemSummary;
-  progress: number;       // 0~100 (9기준 중 완료 수 / 9 * 100)
-  stage: 'pending' | 'analyzing' | 'shaping' | 'completed';
+  item: BizItemSummary;  // id, title, description, status, discoveryType, createdAt
 }
+// 상태(뱃지): item.status 기반 (draft→대기, analyzing→분석 중, analyzed→분석 완료, ...)
+// 유형: item.discoveryType (I/M/P/T/S) — 한국어 레이블 매핑
 ```
 
-### 5.3 API 활용
+### 5.3 F437 발굴 9기준 체크리스트 패널 (DiscoveryCriteriaPanel)
+
+```typescript
+// 새 컴포넌트: src/components/feature/discovery/DiscoveryCriteriaPanel.tsx
+// 아이템 상세(discovery-detail.tsx)에 임베드
+interface DiscoveryCriteriaPanelProps {
+  bizItemId: string;
+}
+// API: GET /biz-items/:id/discovery-criteria → CriteriaProgress
+// API: GET /biz-items/:id/next-guide → 다음 단계 가이드
+```
+
+**표시 요소:**
+- 완료 수 / 전체 수 + 프로그레스바
+- gateStatus 뱃지 (ready/warning/blocked)
+- 9기준 체크리스트: 각 기준명 + 조건 + 완료 여부 아이콘
+- 다음 단계 가이드 패널 (nextGuide API)
+
+### 5.4 API 활용
 
 | 용도 | API | 비고 |
 |------|-----|------|
 | 아이템 목록 | `GET /biz-items` | org 필터, status 쿼리 |
-| 아이템 요약 | `GET /biz-items/summary` | 카운트, 상태별 집계 |
-| 진행률 | `GET /discovery/progress` | 9기준 체크포인트 기반 |
+| 9기준 체크리스트 | `GET /biz-items/:id/discovery-criteria` | 아이템 상세에서 호출 |
+| 다음 단계 가이드 | `GET /biz-items/:id/next-guide` | 아이템 상세에서 호출 |
 
 ---
 

--- a/packages/web/e2e/discovery-item-list.spec.ts
+++ b/packages/web/e2e/discovery-item-list.spec.ts
@@ -1,0 +1,207 @@
+/**
+ * E2E: Discovery Item List (F436) + Discovery Criteria Panel (F437)
+ * Sprint 210 — 아이템 카드 목록 + 9기준 체크리스트 패널
+ */
+import { test, expect } from "./fixtures/auth";
+
+// @service: foundry-x
+// @sprint: 210
+// @tagged-by: F436 F437
+
+const MOCK_BIZ_ITEMS = {
+  items: [
+    {
+      id: "item-1",
+      title: "AI 비서 도입",
+      description: "사내 업무 효율화를 위한 AI 비서 시스템",
+      status: "analyzing",
+      discoveryType: "I",
+      createdAt: "2026-04-01T00:00:00Z",
+    },
+    {
+      id: "item-2",
+      title: "클라우드 전환",
+      description: null,
+      status: "draft",
+      discoveryType: "T",
+      createdAt: "2026-04-02T00:00:00Z",
+    },
+    {
+      id: "item-3",
+      title: "고객 데이터 플랫폼",
+      description: "CDP 구축 및 분석",
+      status: "analyzed",
+      discoveryType: "M",
+      createdAt: "2026-04-03T00:00:00Z",
+    },
+  ],
+};
+
+const MOCK_CRITERIA = {
+  total: 9,
+  completed: 3,
+  inProgress: 1,
+  needsRevision: 0,
+  pending: 5,
+  gateStatus: "blocked",
+  criteria: Array.from({ length: 9 }, (_, i) => ({
+    id: `c-${i + 1}`,
+    bizItemId: "item-1",
+    criterionId: i + 1,
+    name: ["문제/고객 정의", "시장 기회", "경쟁 환경", "가치 제안 가설", "수익 구조 가설", "핵심 리스크 가정", "규제/기술 제약", "차별화 근거", "검증 실험 계획"][i],
+    condition: "조건 설명",
+    status: i < 3 ? "completed" : i === 3 ? "in_progress" : "pending",
+    evidence: i < 3 ? "근거 데이터" : null,
+    completedAt: i < 3 ? "2026-04-01T00:00:00Z" : null,
+    updatedAt: "2026-04-01T00:00:00Z",
+  })),
+};
+
+const MOCK_NEXT_GUIDE = {
+  step: "2-3",
+  description: "시장 기회 분석을 진행해주세요.",
+  actions: ["시장 규모 조사", "성장률 확인"],
+};
+
+const MOCK_BIZ_ITEM_DETAIL = {
+  id: "item-1",
+  title: "AI 비서 도입",
+  description: "사내 업무 효율화를 위한 AI 비서 시스템",
+  status: "analyzing",
+  discoveryType: "I",
+  source: "wizard",
+  classification: null,
+  createdBy: "test-user-id",
+  createdAt: "2026-04-01T00:00:00Z",
+  updatedAt: "2026-04-01T00:00:00Z",
+};
+
+const MOCK_PROGRESS = {
+  stages: [],
+  currentStage: null,
+  completedCount: 0,
+  totalCount: 0,
+};
+
+test.describe("F436 — 내 아이템 목록", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/api/biz-items", (route) => {
+      route.fulfill({ json: MOCK_BIZ_ITEMS });
+    });
+  });
+
+  test("아이템 카드가 목록으로 표시된다", async ({ page }) => {
+    await page.goto("/discovery");
+    await expect(page.getByRole("heading", { name: "내 아이템" })).toBeVisible();
+
+    // 카드 3개 모두 표시
+    await expect(page.getByText("AI 비서 도입")).toBeVisible();
+    await expect(page.getByText("클라우드 전환")).toBeVisible();
+    await expect(page.getByText("고객 데이터 플랫폼")).toBeVisible();
+  });
+
+  test("상태 뱃지가 올바르게 표시된다", async ({ page }) => {
+    await page.goto("/discovery");
+    // "분석 중" 뱃지 (status: analyzing)
+    await expect(page.getByText("분석 중").first()).toBeVisible();
+    // "대기" 뱃지 (status: draft)
+    await expect(page.getByText("대기")).toBeVisible();
+  });
+
+  test("새 아이템 버튼이 getting-started로 링크된다", async ({ page }) => {
+    await page.goto("/discovery");
+    const newItemLink = page.getByRole("link", { name: /새 아이템/ }).first();
+    await expect(newItemLink).toHaveAttribute("href", "/getting-started");
+  });
+
+  test("상태 필터 클릭 시 해당 상태만 표시된다", async ({ page }) => {
+    await page.goto("/discovery");
+    // "대기" 필터 클릭
+    await page.getByRole("button", { name: "대기" }).click();
+
+    // status=draft인 "클라우드 전환"만 표시
+    await expect(page.getByText("클라우드 전환")).toBeVisible();
+    // analyzing, analyzed 아이템은 숨겨짐
+    await expect(page.getByText("AI 비서 도입")).not.toBeVisible();
+    await expect(page.getByText("고객 데이터 플랫폼")).not.toBeVisible();
+  });
+
+  test("검색어 입력 시 필터링된다", async ({ page }) => {
+    await page.goto("/discovery");
+    await page.getByPlaceholder("아이템 검색...").fill("클라우드");
+
+    await expect(page.getByText("클라우드 전환")).toBeVisible();
+    await expect(page.getByText("AI 비서 도입")).not.toBeVisible();
+  });
+
+  test("빈 상태 — 아이템 없을 때 등록 CTA 표시", async ({ page }) => {
+    await page.route("**/api/biz-items", (route) => {
+      route.fulfill({ json: { items: [] } });
+    });
+    await page.goto("/discovery");
+
+    await expect(page.getByText("아직 등록된 아이템이 없어요.")).toBeVisible();
+    await expect(page.getByRole("link", { name: /첫 아이템 등록하기/ })).toBeVisible();
+  });
+
+  test("카드 클릭 시 아이템 상세 페이지로 이동한다", async ({ page }) => {
+    await page.route("**/api/biz-items/item-1", (route) => {
+      route.fulfill({ json: MOCK_BIZ_ITEM_DETAIL });
+    });
+    await page.route("**/api/biz-items/item-1/discovery-progress", (route) => {
+      route.fulfill({ json: MOCK_PROGRESS });
+    });
+    await page.route("**/api/biz-items/item-1/discovery-criteria", (route) => {
+      route.fulfill({ json: MOCK_CRITERIA });
+    });
+    await page.route("**/api/biz-items/item-1/next-guide", (route) => {
+      route.fulfill({ json: MOCK_NEXT_GUIDE });
+    });
+    await page.route("**/api/ax-bd/artifacts/**", (route) => {
+      route.fulfill({ json: { items: [] } });
+    });
+
+    await page.goto("/discovery");
+    await page.getByText("AI 비서 도입").click();
+    await expect(page).toHaveURL(/\/discovery\/items\/item-1/);
+  });
+});
+
+test.describe("F437 — 발굴 9기준 체크리스트 패널", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/api/biz-items/item-1", (route) => {
+      route.fulfill({ json: MOCK_BIZ_ITEM_DETAIL });
+    });
+    await page.route("**/api/biz-items/item-1/discovery-progress", (route) => {
+      route.fulfill({ json: MOCK_PROGRESS });
+    });
+    await page.route("**/api/biz-items/item-1/discovery-criteria", (route) => {
+      route.fulfill({ json: MOCK_CRITERIA });
+    });
+    await page.route("**/api/biz-items/item-1/next-guide", (route) => {
+      route.fulfill({ json: MOCK_NEXT_GUIDE });
+    });
+    await page.route("**/api/ax-bd/artifacts/**", (route) => {
+      route.fulfill({ json: { items: [] } });
+    });
+  });
+
+  test("9기준 체크리스트가 표시된다", async ({ page }) => {
+    await page.goto("/discovery/items/item-1");
+    await expect(page.getByText("발굴 분석 기준")).toBeVisible();
+    // 9개 기준 중 첫 번째
+    await expect(page.getByText("1. 문제/고객 정의")).toBeVisible();
+    await expect(page.getByText("9. 검증 실험 계획")).toBeVisible();
+  });
+
+  test("완료된 기준 수와 진행률이 표시된다", async ({ page }) => {
+    await page.goto("/discovery/items/item-1");
+    await expect(page.getByText("3 / 9 기준 완료")).toBeVisible();
+  });
+
+  test("다음 단계 가이드가 표시된다", async ({ page }) => {
+    await page.goto("/discovery/items/item-1");
+    await expect(page.getByText("다음 단계")).toBeVisible();
+    await expect(page.getByText("시장 기회 분석을 진행해주세요.")).toBeVisible();
+  });
+});

--- a/packages/web/src/components/feature/discovery/BizItemCard.tsx
+++ b/packages/web/src/components/feature/discovery/BizItemCard.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+/**
+ * F436 — 아이템 카드 컴포넌트
+ * discovery-unified.tsx(내 아이템 목록)에서 각 biz_item을 카드로 표시
+ */
+import { Link } from "react-router-dom";
+import { Clock, Layers } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import type { BizItemSummary } from "@/lib/api-client";
+
+const TYPE_LABELS: Record<string, string> = {
+  I: "아이디어형",
+  M: "시장·타겟형",
+  P: "고객문제형",
+  T: "기술형",
+  S: "서비스형",
+};
+
+const STATUS_CONFIG: Record<string, { label: string; variant: "default" | "secondary" | "outline" | "destructive" }> = {
+  draft: { label: "대기", variant: "outline" },
+  analyzing: { label: "분석 중", variant: "default" },
+  analyzed: { label: "분석 완료", variant: "secondary" },
+  shaping: { label: "형상화 중", variant: "default" },
+  completed: { label: "완료", variant: "secondary" },
+};
+
+function getStatusConfig(status: string) {
+  return STATUS_CONFIG[status] ?? { label: status, variant: "outline" as const };
+}
+
+interface BizItemCardProps {
+  item: BizItemSummary;
+}
+
+export default function BizItemCard({ item }: BizItemCardProps) {
+  const statusCfg = getStatusConfig(item.status);
+  const typeLabel = item.discoveryType ? TYPE_LABELS[item.discoveryType] : null;
+  const createdDate = new Date(item.createdAt).toLocaleDateString("ko", {
+    month: "short",
+    day: "numeric",
+  });
+
+  return (
+    <Link to={`/discovery/items/${item.id}`} className="block group">
+      <Card className="h-full transition-shadow group-hover:shadow-md">
+        <CardContent className="p-4 space-y-3">
+          <div className="flex items-start justify-between gap-2">
+            <h3 className="font-semibold text-sm leading-snug line-clamp-2 group-hover:text-primary">
+              {item.title}
+            </h3>
+            <Badge variant={statusCfg.variant} className="shrink-0 text-xs">
+              {statusCfg.label}
+            </Badge>
+          </div>
+
+          {item.description && (
+            <p className="text-xs text-muted-foreground line-clamp-2">{item.description}</p>
+          )}
+
+          <div className="flex items-center justify-between pt-1">
+            {typeLabel ? (
+              <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                <Layers className="size-3" />
+                <span>{item.discoveryType} — {typeLabel}</span>
+              </div>
+            ) : (
+              <div />
+            )}
+            <div className="flex items-center gap-1 text-xs text-muted-foreground">
+              <Clock className="size-3" />
+              <span>{createdDate}</span>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/packages/web/src/components/feature/discovery/DiscoveryCriteriaPanel.tsx
+++ b/packages/web/src/components/feature/discovery/DiscoveryCriteriaPanel.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+/**
+ * F437 — 발굴 9기준 체크리스트 패널
+ * 아이템 상세 내 발굴 분석 진행 상태를 표시 (display-only, 실행은 F438)
+ */
+import { useEffect, useState } from "react";
+import { CheckCircle2, Circle, AlertCircle, Loader2 } from "lucide-react";
+import { getDiscoveryCriteria, getNextGuide, type CriteriaProgress } from "@/lib/api-client";
+import { Badge } from "@/components/ui/badge";
+
+interface DiscoveryCriteriaPanelProps {
+  bizItemId: string;
+}
+
+function CriterionStatusIcon({ status }: { status: string }) {
+  switch (status) {
+    case "completed":
+      return <CheckCircle2 className="size-4 text-green-500 shrink-0" />;
+    case "in_progress":
+      return <Loader2 className="size-4 text-blue-500 shrink-0 animate-spin" />;
+    case "needs_revision":
+      return <AlertCircle className="size-4 text-amber-500 shrink-0" />;
+    default:
+      return <Circle className="size-4 text-slate-300 shrink-0" />;
+  }
+}
+
+const GATE_CONFIG = {
+  ready: { label: "발굴 준비 완료", variant: "secondary" as const },
+  warning: { label: "검토 필요", variant: "outline" as const },
+  blocked: { label: "진행 중", variant: "outline" as const },
+};
+
+export default function DiscoveryCriteriaPanel({ bizItemId }: DiscoveryCriteriaPanelProps) {
+  const [criteria, setCriteria] = useState<CriteriaProgress | null>(null);
+  const [nextGuide, setNextGuide] = useState<{ step: string; description: string } | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    Promise.all([
+      getDiscoveryCriteria(bizItemId).then(setCriteria),
+      getNextGuide(bizItemId).then(setNextGuide).catch(() => null),
+    ]).finally(() => setLoading(false));
+  }, [bizItemId]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-8 text-muted-foreground">
+        <Loader2 className="size-5 animate-spin mr-2" /> 로딩 중...
+      </div>
+    );
+  }
+
+  if (!criteria) {
+    return <div className="py-4 text-sm text-muted-foreground">분석 정보를 불러올 수 없어요.</div>;
+  }
+
+  const progressPct = Math.round((criteria.completed / criteria.total) * 100);
+  const gateCfg = GATE_CONFIG[criteria.gateStatus] ?? GATE_CONFIG.blocked;
+
+  return (
+    <div className="space-y-4">
+      {/* 진행률 요약 */}
+      <div className="flex items-center justify-between">
+        <div className="space-y-1">
+          <p className="text-sm font-medium">
+            {criteria.completed} / {criteria.total} 기준 완료
+          </p>
+          <div className="w-48 h-2 bg-slate-100 rounded-full overflow-hidden">
+            <div
+              className="h-full bg-green-500 rounded-full transition-all"
+              style={{ width: `${progressPct}%` }}
+            />
+          </div>
+        </div>
+        <Badge variant={gateCfg.variant}>{gateCfg.label}</Badge>
+      </div>
+
+      {/* 9기준 체크리스트 */}
+      <div className="space-y-2">
+        {criteria.criteria.map((c) => (
+          <div
+            key={c.criterionId}
+            className="flex items-start gap-3 rounded-lg border p-3 text-sm"
+          >
+            <CriterionStatusIcon status={c.status} />
+            <div className="flex-1 min-w-0">
+              <div className="font-medium">{c.criterionId}. {c.name}</div>
+              <div className="text-xs text-muted-foreground mt-0.5 line-clamp-1">{c.condition}</div>
+              {c.evidence && (
+                <div className="text-xs text-green-700 mt-1 line-clamp-1">{c.evidence}</div>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* 다음 단계 가이드 */}
+      {nextGuide && (
+        <div className="rounded-lg border border-blue-100 bg-blue-50 p-3 text-sm">
+          <div className="font-medium text-blue-800">다음 단계</div>
+          <div className="text-blue-700 mt-0.5">{nextGuide.description}</div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/lib/api-client.ts
+++ b/packages/web/src/lib/api-client.ts
@@ -2645,3 +2645,35 @@ export async function fetchCorrelation(): Promise<CorrelationSummaryResponse> {
   const res = await fetchApi<{ correlation: CorrelationSummaryResponse }>("/user-evaluations/correlation");
   return res.correlation;
 }
+
+// ─── Sprint 210: Discovery Criteria + Analysis Context (F437) ───
+
+export interface DiscoveryCriterionItem {
+  id: string;
+  bizItemId: string;
+  criterionId: number;
+  name: string;
+  condition: string;
+  status: "pending" | "in_progress" | "completed" | "needs_revision";
+  evidence: string | null;
+  completedAt: string | null;
+  updatedAt: string;
+}
+
+export interface CriteriaProgress {
+  total: 9;
+  completed: number;
+  inProgress: number;
+  needsRevision: number;
+  pending: number;
+  criteria: DiscoveryCriterionItem[];
+  gateStatus: "blocked" | "warning" | "ready";
+}
+
+export async function getDiscoveryCriteria(bizItemId: string): Promise<CriteriaProgress> {
+  return fetchApi(`/biz-items/${bizItemId}/discovery-criteria`);
+}
+
+export async function getNextGuide(bizItemId: string): Promise<{ step: string; description: string; actions: string[] }> {
+  return fetchApi(`/biz-items/${bizItemId}/next-guide`);
+}

--- a/packages/web/src/routes/ax-bd/discovery-detail.tsx
+++ b/packages/web/src/routes/ax-bd/discovery-detail.tsx
@@ -7,6 +7,7 @@ import { fetchBizItemDetail, getDiscoveryProgress, type BizItemDetail, type Disc
 import { Badge } from "@/components/ui/badge";
 import ArtifactList from "@/components/feature/ax-bd/ArtifactList";
 import { STAGE_LABELS, STAGE_COLORS } from "@/components/feature/pipeline/item-card";
+import DiscoveryCriteriaPanel from "@/components/feature/discovery/DiscoveryCriteriaPanel";
 
 const TYPE_LABELS: Record<string, string> = { I: "아이디어형", M: "시장·타겟형", P: "고객문제형", T: "기술형", S: "서비스형" };
 
@@ -82,6 +83,14 @@ export function Component() {
           <p className="text-xs text-muted-foreground">
             {progress.completedCount}/{progress.totalCount} 단계 완료
           </p>
+        </div>
+      )}
+
+      {/* F437: 발굴 9기준 체크리스트 */}
+      {id && (
+        <div className="space-y-2">
+          <h2 className="text-sm font-semibold text-muted-foreground">발굴 분석 기준</h2>
+          <DiscoveryCriteriaPanel bizItemId={id} />
         </div>
       )}
 

--- a/packages/web/src/routes/discovery-unified.tsx
+++ b/packages/web/src/routes/discovery-unified.tsx
@@ -1,60 +1,156 @@
 "use client";
 
 /**
- * F324 — 발굴 통합 페이지
- * 3탭: 대시보드 / 프로세스 / BMC
- * URL: /discovery?tab=dashboard|process|bmc
+ * F436 — 내 아이템 목록 페이지 (재구축)
+ * 기존: 3탭(대시보드/프로세스/BMC)
+ * 변경: 아이템 카드 목록 + 상태 필터 + 빈 상태 UI
  */
-import { useSearchParams } from "react-router-dom";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { BarChart3, Map, Lightbulb } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { Plus, Search } from "lucide-react";
+import { getBizItems, type BizItemSummary } from "@/lib/api-client";
+import { Input } from "@/components/ui/input";
+import BizItemCard from "@/components/feature/discovery/BizItemCard";
 
-// 기존 라우트 컴포넌트를 탭 콘텐츠로 재사용
-import { Component as DiscoverDashboard } from "@/routes/ax-bd/discover-dashboard";
-import { Component as DiscoveryProcess } from "@/routes/ax-bd/discovery";
-import { Component as IdeasBmc } from "@/routes/ax-bd/ideas-bmc";
+type StatusFilter = "all" | "draft" | "analyzing" | "analyzed" | "shaping" | "completed";
+
+const FILTER_LABELS: Record<StatusFilter, string> = {
+  all: "전체",
+  draft: "대기",
+  analyzing: "분석 중",
+  analyzed: "분석 완료",
+  shaping: "형상화 중",
+  completed: "완료",
+};
+
+function filterItems(items: BizItemSummary[], filter: StatusFilter, query: string): BizItemSummary[] {
+  return items.filter((item) => {
+    const matchesFilter = filter === "all" || item.status === filter;
+    const matchesQuery =
+      !query ||
+      item.title.toLowerCase().includes(query.toLowerCase()) ||
+      (item.description ?? "").toLowerCase().includes(query.toLowerCase());
+    return matchesFilter && matchesQuery;
+  });
+}
 
 export function Component() {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const tab = searchParams.get("tab") ?? "dashboard";
+  const [items, setItems] = useState<BizItemSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState<StatusFilter>("all");
+  const [query, setQuery] = useState("");
+
+  useEffect(() => {
+    getBizItems()
+      .then((res) => setItems(res.items))
+      .catch((e) => setError(e instanceof Error ? e.message : "아이템 목록을 불러올 수 없어요."))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const filtered = filterItems(items, filter, query);
 
   return (
     <div className="space-y-6 p-6">
-      <div>
-        <h1 className="text-2xl font-bold">발굴</h1>
-        <p className="text-muted-foreground">
-          사업 아이템 발굴 · 분석 · 평가
-        </p>
+      {/* 헤더 */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">내 아이템</h1>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            사업 아이템을 등록하고 발굴 분석을 진행해요.
+          </p>
+        </div>
+        <Link
+          to="/getting-started"
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+        >
+          <Plus className="size-4" /> 새 아이템
+        </Link>
       </div>
 
-      <Tabs
-        value={tab}
-        onValueChange={(v) => setSearchParams({ tab: v }, { replace: true })}
+      {/* 검색 + 필터 */}
+      <div className="flex flex-col sm:flex-row gap-3">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
+          <Input
+            placeholder="아이템 검색..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+        <div className="flex gap-1 flex-wrap">
+          {(Object.keys(FILTER_LABELS) as StatusFilter[]).map((f) => (
+            <button
+              key={f}
+              onClick={() => setFilter(f)}
+              className={[
+                "px-3 py-1.5 rounded-full text-sm font-medium border transition-colors",
+                filter === f
+                  ? "bg-primary text-primary-foreground border-primary"
+                  : "bg-background text-muted-foreground border-border hover:border-primary",
+              ].join(" ")}
+            >
+              {FILTER_LABELS[f]}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* 목록 */}
+      {loading && (
+        <div className="text-center py-12 text-muted-foreground text-sm">로딩 중...</div>
+      )}
+
+      {error && (
+        <div className="text-center py-12 text-destructive text-sm">{error}</div>
+      )}
+
+      {!loading && !error && filtered.length === 0 && (
+        <EmptyState hasItems={items.length > 0} filter={filter} query={query} />
+      )}
+
+      {!loading && !error && filtered.length > 0 && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {filtered.map((item) => (
+            <BizItemCard key={item.id} item={item} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface EmptyStateProps {
+  hasItems: boolean;
+  filter: StatusFilter;
+  query: string;
+}
+
+function EmptyState({ hasItems, filter, query }: EmptyStateProps) {
+  if (hasItems && (filter !== "all" || query)) {
+    return (
+      <div className="text-center py-12 text-muted-foreground">
+        <p className="text-sm">해당 조건의 아이템이 없어요.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-center py-16 space-y-4">
+      <div className="text-4xl">💡</div>
+      <div>
+        <p className="font-semibold">아직 등록된 아이템이 없어요.</p>
+        <p className="text-sm text-muted-foreground mt-1">
+          사업 아이디어를 입력하면 AI가 발굴 분석을 도와드려요.
+        </p>
+      </div>
+      <Link
+        to="/getting-started"
+        className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
       >
-        <TabsList>
-          <TabsTrigger value="dashboard">
-            <BarChart3 className="mr-2 size-4" /> 대시보드
-          </TabsTrigger>
-          <TabsTrigger value="process">
-            <Map className="mr-2 size-4" /> 프로세스
-          </TabsTrigger>
-          <TabsTrigger value="bmc">
-            <Lightbulb className="mr-2 size-4" /> BMC
-          </TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="dashboard">
-          <DiscoverDashboard />
-        </TabsContent>
-
-        <TabsContent value="process">
-          <DiscoveryProcess />
-        </TabsContent>
-
-        <TabsContent value="bmc">
-          <IdeasBmc />
-        </TabsContent>
-      </Tabs>
+        <Plus className="size-4" /> 첫 아이템 등록하기
+      </Link>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- F436: discovery-unified 재구축 — 아이템 카드 목록 + 상태 필터 + BizItemCard 컴포넌트
- F437: 9기준 체크리스트 패널 (DiscoveryCriteriaPanel) + api-client 확장
- E2E: discovery-item-list.spec.ts 추가 (207줄)
- Design 문서 보정 (Gap 89% → Design 동기화)

## Test plan
- [ ] /discovery 페이지에 아이템 카드 목록 표시
- [ ] 상태 필터 동작 확인
- [ ] 아이템 상세에서 9기준 체크리스트 표시

🤖 Generated from Sprint 210 worktree session