### PR TITLE
fix: Google OAuth 로그인 에러 3건 수정

### DIFF
--- a/packages/web/public/_headers
+++ b/packages/web/public/_headers
@@ -1,5 +1,6 @@
 /*
   Cache-Control: no-cache, no-store, must-revalidate
+  Cross-Origin-Opener-Policy: same-origin-allow-popups
 
 /*.js
   Cache-Control: public, max-age=31536000, immutable

--- a/packages/web/src/lib/stores/auth-store.ts
+++ b/packages/web/src/lib/stores/auth-store.ts
@@ -61,7 +61,16 @@ function scheduleTokenRefresh() {
 }
 
 /** refreshToken으로 새 토큰 쌍을 발급받아 저장 */
+let pendingRefresh: Promise<boolean> | null = null;
+
 async function refreshAccessToken(): Promise<boolean> {
+  // 동시 다발 refresh 방지 — 이미 진행 중이면 같은 Promise 공유
+  if (pendingRefresh) return pendingRefresh;
+  pendingRefresh = doRefresh().finally(() => { pendingRefresh = null; });
+  return pendingRefresh;
+}
+
+async function doRefresh(): Promise<boolean> {
   const rt = localStorage.getItem("refreshToken");
   if (!rt) return false;
 

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -3,7 +3,6 @@ import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 import { router } from "./router";
 import { ThemeProvider } from "@/components/theme-provider";
-import { GoogleAuthProvider } from "@/components/google-auth-provider";
 import "./app/globals.css";
 
 import "@fontsource-variable/plus-jakarta-sans";
@@ -14,9 +13,7 @@ import "@fontsource-variable/jetbrains-mono";
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <ThemeProvider defaultTheme="dark">
-      <GoogleAuthProvider>
-        <RouterProvider router={router} />
-      </GoogleAuthProvider>
+      <RouterProvider router={router} />
     </ThemeProvider>
   </StrictMode>,
 );

--- a/packages/web/src/router.tsx
+++ b/packages/web/src/router.tsx
@@ -8,17 +8,27 @@ function RedirectDiscoveryDetail() {
   return <Navigate to={`/discovery/items/${id}`} replace />;
 }
 
+function Spinner() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="animate-spin h-8 w-8 border-4 border-primary border-t-transparent rounded-full" />
+    </div>
+  );
+}
+
 export const router = createBrowserRouter([
   {
     element: <LandingLayout />,
+    hydrateFallbackElement: <Spinner />,
     children: [
       { index: true, lazy: () => import("@/routes/landing") },
     ],
   },
-  { path: "login", lazy: () => import("@/routes/login") },
-  { path: "invite", lazy: () => import("@/routes/invite") },
+  { path: "login", lazy: () => import("@/routes/login"), hydrateFallbackElement: <Spinner /> },
+  { path: "invite", lazy: () => import("@/routes/invite"), hydrateFallbackElement: <Spinner /> },
   {
     element: <ProtectedRoute />,
+    hydrateFallbackElement: <Spinner />,
     children: [{
     element: <AppLayout />,
     children: [


### PR DESCRIPTION
## Summary
- COOP `same-origin-allow-popups` 헤더 추가 → Google GIS SDK 팝업 `postMessage` 차단 해소
- `hydrateFallbackElement` 추가 → React Router 7 lazy route hydration 경고 해소
- `refreshAccessToken` dedup 패턴 적용 → token rotation race condition 방지
- 미사용 `GoogleOAuthProvider` 중복 제거 → GIS SDK 이중 초기화 방지

## Test plan
- [ ] `https://fx.minu.best/login` 접속 → 콘솔 에러 3건 해소 확인
- [ ] Google 로그인 버튼 클릭 → 정상 인증 + /dashboard 이동
- [ ] 브라우저 새로고침 시 HydrateFallback 경고 없음
- [ ] 토큰 만료 시 refresh 한 번만 호출되는지 Network 탭 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)