### PR TITLE
fix: GIS 이중 초기화 경고 + 로그인 페이지 레이아웃

### DIFF
--- a/packages/web/src/components/feature/InviteForm.tsx
+++ b/packages/web/src/components/feature/InviteForm.tsx
@@ -28,10 +28,7 @@ function useGoogleIdentity(onCredential: (credential: string) => void) {
   callbackRef.current = onCredential;
 
   useEffect(() => {
-    const script = document.createElement("script");
-    script.src = "https://accounts.google.com/gsi/client";
-    script.async = true;
-    script.onload = () => {
+    const initGis = () => {
       window.google?.accounts.id.initialize({
         client_id: GOOGLE_CLIENT_ID,
         callback: (res: { credential: string }) =>
@@ -48,6 +45,16 @@ function useGoogleIdentity(onCredential: (credential: string) => void) {
         });
       }
     };
+
+    if (window.google?.accounts.id) {
+      initGis();
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.src = "https://accounts.google.com/gsi/client";
+    script.async = true;
+    script.onload = initGis;
     document.head.appendChild(script);
     return () => { script.remove(); };
   }, []);

--- a/packages/web/src/routes/login.tsx
+++ b/packages/web/src/routes/login.tsx
@@ -20,10 +20,7 @@ function useGoogleIdentity(onCredential: (credential: string) => void) {
   callbackRef.current = onCredential;
 
   useEffect(() => {
-    const script = document.createElement("script");
-    script.src = "https://accounts.google.com/gsi/client";
-    script.async = true;
-    script.onload = () => {
+    const initGis = () => {
       window.google?.accounts.id.initialize({
         client_id: GOOGLE_CLIENT_ID,
         callback: (res: { credential: string }) =>
@@ -40,6 +37,17 @@ function useGoogleIdentity(onCredential: (credential: string) => void) {
         });
       }
     };
+
+    // GIS SDK가 이미 로드됐으면 재로드 없이 초기화만
+    if (window.google?.accounts.id) {
+      initGis();
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.src = "https://accounts.google.com/gsi/client";
+    script.async = true;
+    script.onload = initGis;
     document.head.appendChild(script);
     return () => { script.remove(); };
   }, []);
@@ -117,7 +125,7 @@ export function Component() {
   }
 
   return (
-    <div className="relative flex min-h-screen items-center justify-center overflow-hidden p-4"
+    <div className="relative flex h-screen items-center justify-center overflow-auto p-4"
       style={{ background: "var(--axis-color-gray-950, hsl(var(--background)))" }}
     >
       {/* ── Ambient grid ── */}


### PR DESCRIPTION
## Summary
- GIS SDK 중복 로딩 방지: `window.google.accounts.id` 존재 시 스크립트 재로드 없이 `initialize`만 호출
- 로그인 페이지 `min-h-screen` → `h-screen` 변경: 카드가 항상 뷰포트 중앙에 위치
- Closes #364

## Test plan
- [ ] 로그인 페이지 → 콘솔에 `initialize() is called multiple times` 경고 없음
- [ ] 로그인 폼이 항상 화면 중앙에 위치 (모바일/데스크톱)
- [ ] Google 로그인 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)