### PR TITLE
feat: Sprint 214 — F443 자료 기반 발굴 입력 (Phase 25-A)

### DIFF
--- a/docs/01-plan/features/sprint-214.plan.md
+++ b/docs/01-plan/features/sprint-214.plan.md
@@ -1,0 +1,83 @@
+---
+code: FX-PLAN-S214
+title: Sprint 214 Plan — F443 자료 기반 발굴 입력
+version: 1.0
+status: Active
+category: PLAN
+created: 2026-04-08
+updated: 2026-04-08
+author: Sinclair Seo
+sprint: 214
+f-items: F443
+phase: 25-A
+---
+
+# Sprint 214 Plan — F443 자료 기반 발굴 입력
+
+## Executive Summary
+
+| 항목 | 내용 |
+|------|------|
+| Sprint | 214 |
+| F-item | F443 |
+| Phase | 25-A (Discovery Pipeline v2) |
+| 선행 Sprint | 213 (F441 파일 업로드 + F442 문서 파싱) |
+| 목표 | 파싱된 문서를 아이템 등록 + 발굴 분석 컨텍스트로 자동 연결 |
+
+## 1. 배경 및 목적
+
+Sprint 213(F441+F442)에서 R2 파일 업로드 인프라와 문서 파싱 엔진이 완성되었다.
+Sprint 214(F443)는 그 결과물을 **실제 발굴 플로우에 통합**하는 연결 레이어다.
+
+파싱된 텍스트를 활용해:
+1. 아이템 제목/설명을 AI가 자동 제안
+2. 분석 실행 시 문서 내용을 컨텍스트로 주입
+3. 아이템 상세 페이지에서 첨부 자료를 관리
+
+## 2. 구현 범위
+
+### 2.1 API (packages/api)
+
+| 컴포넌트 | 파일 | 내용 |
+|----------|------|------|
+| 문서 기반 아이템 추출 서비스 | `core/files/services/document-extract-service.ts` | 파싱 텍스트 → AI 요약으로 title/description 추출 |
+| 아이템 추출 API | `core/files/routes/files.ts` 추가 | `POST /api/files/extract-item` |
+| 분석 컨텍스트 주입 | `core/discovery/routes/biz-items.ts` 수정 | 분석 실행 시 `uploaded_files + parsed_documents` 컨텍스트 조회 |
+
+### 2.2 Web (packages/web)
+
+| 컴포넌트 | 파일 | 내용 |
+|----------|------|------|
+| 온보딩 위저드 확장 | `routes/getting-started.tsx` 수정 | Step 0.5: 자료 업로드 (선택) 추가 |
+| 첨부 자료 패널 | `components/feature/discovery/AttachedFilesPanel.tsx` 신규 | 파일 목록 + 파싱 상태 표시 |
+| 아이템 상세 탭 추가 | `routes/ax-bd/discovery-detail.tsx` 수정 | "첨부 자료" 4번째 탭 추가 |
+| api-client 확장 | `lib/api-client.ts` 수정 | extractItemFromDocuments, fetchFiles 함수 추가 |
+
+## 3. 선행 조건
+
+| 조건 | 상태 |
+|------|------|
+| F441: 파일 업로드 인프라 (uploaded_files D1 테이블, presign API) | ✅ Sprint 213 |
+| F442: 문서 파싱 엔진 (parsed_documents D1 테이블, /parse API) | ✅ Sprint 213 |
+| FileUploadZone 컴포넌트 | ✅ Sprint 213 |
+
+## 4. 제약 사항
+
+- Workers AI 사용 (외부 AI API 없이 Cloudflare Workers AI로 요약)
+- 자료 업로드는 온보딩 위저드에서 **선택(optional)** — 건너뛰기 가능
+- 분석 컨텍스트 주입은 기존 분석 실행 API 수정 (신규 API 아님)
+
+## 5. 완료 기준 (Definition of Done)
+
+- [ ] `POST /api/files/extract-item` — 파싱 결과 → AI 제목/설명 추출
+- [ ] 분석 실행 시 첨부 파일 파싱 결과 컨텍스트 자동 포함
+- [ ] getting-started.tsx에 자료 업로드 스텝 (건너뛰기 가능)
+- [ ] discovery-detail.tsx에 "첨부 자료" 탭 추가
+- [ ] typecheck + test 통과
+
+## 6. 리스크
+
+| 리스크 | 대응 |
+|--------|------|
+| Workers AI 응답 지연 | extract-item은 비동기 제안 (blocking 아님) |
+| 파싱 결과 없는 경우 | 컨텍스트 주입 시 graceful fallback (빈 배열) |

--- a/docs/02-design/features/sprint-214.design.md
+++ b/docs/02-design/features/sprint-214.design.md
@@ -1,0 +1,226 @@
+---
+code: FX-DSGN-S214
+title: Sprint 214 Design — F443 자료 기반 발굴 입력
+version: 1.0
+status: Active
+category: DSGN
+created: 2026-04-08
+updated: 2026-04-08
+author: Sinclair Seo
+sprint: 214
+f-items: F443
+phase: 25-A
+---
+
+# Sprint 214 Design — F443 자료 기반 발굴 입력
+
+## 1. 아키텍처 개요
+
+F441(파일 업로드)+F442(파싱 엔진) 위에 **통합 레이어**를 추가한다.
+
+```
+[온보딩 위저드] --파일 업로드--> [F441 R2 + uploaded_files]
+                                         |
+                               [F442 parsed_documents]
+                                         |
+                    ┌────────────────────┴───────────────────┐
+                    ↓                                         ↓
+          POST /files/extract-item                 분석 실행 시 컨텍스트 주입
+          (AI: 제목/설명 자동 추출)                (generate-business-plan,
+                    ↓                              generate-prd에 docs[] 포함)
+          getting-started Step 0.5                 
+          자동 필드 채우기                           
+                                         |
+                            [아이템 상세 "첨부 자료" 탭]
+                            (업로드 파일 목록 + 파싱 상태)
+```
+
+## 2. API 설계
+
+### 2.1 신규: POST /api/files/extract-item
+
+파싱된 문서에서 아이템 제목/설명을 AI로 추출한다.
+
+**Request**:
+```json
+{ "biz_item_id": "optional-existing-item-id", "file_ids": ["uuid1", "uuid2"] }
+```
+
+**Response**:
+```json
+{
+  "title": "AI 추출 제목",
+  "description": "AI 추출 요약 설명",
+  "confidence": 0.85
+}
+```
+
+**구현**: `core/files/services/document-extract-service.ts`
+- `parsed_documents` 조회 (file_ids 기준)
+- Workers AI (`@cf/meta/llama-3.1-8b-instruct`) 호출
+- 제목 (50자 이내), 설명 (200자 이내) 추출
+
+### 2.2 수정: GET /api/files
+
+기존 파라미터 `biz_item_id` 유지. 응답에 `parsed_status` 필드 추가:
+```json
+{
+  "files": [
+    {
+      "id": "...", "filename": "...", "status": "parsed",
+      "parsed_at": 1234567890, "page_count": 5
+    }
+  ]
+}
+```
+
+파싱 결과 JOIN:
+```sql
+SELECT f.*, pd.parsed_at, pd.page_count
+FROM uploaded_files f
+LEFT JOIN parsed_documents pd ON pd.file_id = f.id
+WHERE f.tenant_id = ? AND f.biz_item_id = ?
+```
+
+### 2.3 수정: POST /api/biz-items/:id/generate-business-plan
+
+분석 실행 시 `parsed_documents` 자동 조회 후 LLM 프롬프트에 포함:
+
+```typescript
+// 기존 코드에 추가
+const parsedDocs = await c.env.DB.prepare(`
+  SELECT pd.content_text, f.filename
+  FROM parsed_documents pd
+  JOIN uploaded_files f ON f.id = pd.file_id
+  WHERE f.biz_item_id = ? AND f.tenant_id = ?
+  ORDER BY pd.parsed_at DESC LIMIT 3
+`).bind(id, orgId).all();
+
+const documentContext = parsedDocs.results.map(d => 
+  `[${d.filename}]\n${String(d.content_text).slice(0, 2000)}`
+);
+```
+
+`BpGenerationInput`에 `documentContext?: string[]` 필드 추가.
+`refineWithLlm`의 instructions에 문서 컨텍스트 섹션 추가.
+
+### 2.4 수정: POST /api/biz-items/:id/generate-prd
+
+동일 패턴으로 `documentContext` 추가. `PrdGeneratorService.generate()`의 프롬프트에 반영.
+
+## 3. Web 설계
+
+### 3.1 getting-started.tsx 확장
+
+기존: `["아이디어 입력", "AI 분석", "확인 & 등록"]` (3단계)
+변경: `["자료 업로드", "아이디어 입력", "AI 분석", "확인 & 등록"]` (4단계, Step 0 = 자료 업로드)
+
+**Step 0 동작**:
+1. `FileUploadZone` 렌더 (bizItemId는 없으므로 파일만 업로드, 임시 file_ids 저장)
+2. 업로드 완료 → `POST /api/files/extract-item` 호출
+3. 추출된 `title/description`을 Step 1 입력 필드에 자동 채움
+4. "건너뛰기" 버튼으로 Step 0 생략 가능
+
+**State 추가**:
+```typescript
+const [uploadedFileIds, setUploadedFileIds] = useState<string[]>([]);
+const [extractedTitle, setExtractedTitle] = useState("");
+const [extractedDesc, setExtractedDesc] = useState("");
+```
+
+### 3.2 AttachedFilesPanel 컴포넌트 (신규)
+
+`packages/web/src/components/feature/discovery/AttachedFilesPanel.tsx`
+
+```
+Props:
+  bizItemId: string
+  apiBaseUrl?: string
+
+UI:
+  [업로드 버튼]
+  ┌──────────────────────────────┐
+  │ 📄 문서명.pdf  ✅ 파싱 완료  │
+  │ 📄 슬라이드.pptx  ⏳ 파싱 중 │
+  │ [+ 파일 추가]                │
+  └──────────────────────────────┘
+  [파싱 완료 파일: N개]
+```
+
+**동작**:
+- Mount 시 `GET /api/files?biz_item_id=:id` 조회
+- 파일 클릭 → 파싱 결과 미리보기 (텍스트 요약)
+- 삭제 버튼 → `DELETE /api/files/:id`
+
+### 3.3 discovery-detail.tsx 탭 추가
+
+기존 탭: `기본정보 | 발굴분석 | 형상화`
+추가 탭: `기본정보 | 발굴분석 | 형상화 | 첨부 자료`
+
+```tsx
+<TabsTrigger value="files">첨부 자료</TabsTrigger>
+...
+<TabsContent value="files" className="mt-4">
+  <AttachedFilesPanel bizItemId={id!} />
+</TabsContent>
+```
+
+### 3.4 api-client.ts 추가 함수
+
+```typescript
+export interface UploadedFileMeta {
+  id: string;
+  filename: string;
+  mime_type: string;
+  status: string;
+  size_bytes: number;
+  created_at: number;
+  parsed_at?: number;
+  page_count?: number;
+}
+
+export async function fetchFiles(bizItemId: string): Promise<UploadedFileMeta[]>;
+export async function deleteFile(fileId: string): Promise<void>;
+export async function extractItemFromDocuments(fileIds: string[]): Promise<{
+  title: string; description: string; confidence: number;
+}>;
+```
+
+## 4. D1 변경
+
+신규 마이그레이션 없음. 기존 `uploaded_files` + `parsed_documents` JOIN으로 충분.
+
+## 5. Worker 파일 매핑
+
+| Worker | 담당 파일 | 내용 |
+|--------|-----------|------|
+| W1 (API) | `core/files/services/document-extract-service.ts` (신규) | AI 추출 서비스 |
+| W1 (API) | `core/files/routes/files.ts` | extract-item 엔드포인트 추가, GET /files JOIN 개선 |
+| W1 (API) | `core/offering/services/business-plan-generator.ts` | documentContext 필드 + refineWithLlm 수정 |
+| W1 (API) | `core/offering/services/business-plan-template.ts` | BpDataBundle에 documentContext 추가 |
+| W1 (API) | `core/discovery/routes/biz-items.ts` | generate-business-plan + generate-prd 수정 |
+| W2 (Web) | `routes/getting-started.tsx` | Step 0 자료 업로드 추가 |
+| W2 (Web) | `components/feature/discovery/AttachedFilesPanel.tsx` (신규) | 첨부 자료 패널 |
+| W2 (Web) | `routes/ax-bd/discovery-detail.tsx` | "첨부 자료" 탭 추가 |
+| W2 (Web) | `lib/api-client.ts` | fetchFiles, deleteFile, extractItemFromDocuments 추가 |
+
+## 6. 테스트 계획
+
+| 대상 | 테스트 파일 | 케이스 |
+|------|------------|--------|
+| document-extract-service | `core/files/services/__tests__/document-extract.test.ts` | 텍스트 있음, 빈 텍스트, Workers AI mock |
+| GET /files (JOIN) | `core/files/routes/__tests__/files.test.ts` | parsed_at/page_count 포함 응답 |
+| POST /files/extract-item | `core/files/routes/__tests__/files.test.ts` | 정상 추출, 파일 없음 |
+
+## 7. 갭 분석 체크리스트
+
+| 항목 | 구현 대상 | 검증 방법 |
+|------|-----------|-----------|
+| extract-item API 존재 | files.ts POST /files/extract-item | curl 또는 테스트 |
+| AI 제목/설명 추출 | document-extract-service.ts | 단위 테스트 |
+| 온보딩 위저드 Step 0 | getting-started.tsx | UI 확인 (4단계) |
+| 건너뛰기 버튼 | getting-started.tsx | UI 확인 |
+| 첨부 자료 탭 | discovery-detail.tsx | UI 확인 (4번째 탭) |
+| AttachedFilesPanel | AttachedFilesPanel.tsx | 파일 목록 렌더 |
+| 분석 시 문서 컨텍스트 주입 | business-plan-generator.ts | 프롬프트 포함 여부 |
+| typecheck 통과 | 전체 | turbo typecheck |

--- a/packages/api/src/core/discovery/routes/biz-items.ts
+++ b/packages/api/src/core/discovery/routes/biz-items.ts
@@ -830,6 +830,20 @@ bizItemsRoute.post("/biz-items/:id/generate-business-plan", async (c) => {
   const prdService = new PrdGeneratorService(c.env.DB, null as never);
   const prd = await prdService.getLatest(id);
 
+  // F443: 첨부 문서 파싱 결과 컨텍스트 조회
+  const { results: docRows } = await c.env.DB.prepare(
+    `SELECT f.filename, pd.content_text
+     FROM parsed_documents pd
+     JOIN uploaded_files f ON f.id = pd.file_id
+     WHERE f.biz_item_id = ? AND f.tenant_id = ?
+     ORDER BY pd.parsed_at DESC LIMIT 3`,
+  )
+    .bind(id, orgId)
+    .all<{ filename: string; content_text: string }>();
+  const documentContext = docRows.map(
+    (d) => `[${d.filename}]\n${d.content_text.slice(0, 2000)}`,
+  );
+
   const runner = createAgentRunner(c.env);
   const bpService = new BusinessPlanGeneratorService(c.env.DB, runner);
 
@@ -851,6 +865,7 @@ bizItemsRoute.post("/biz-items/:id/generate-business-plan", async (c) => {
     templateType,
     tone,
     length,
+    documentContext,
   });
 
   return c.json(bp, 201);

--- a/packages/api/src/core/files/index.ts
+++ b/packages/api/src/core/files/index.ts
@@ -1,6 +1,8 @@
 /**
  * core/files — F441+F442: 파일 업로드 + 문서 파싱 (Sprint 213)
+ * F443: 문서 기반 아이템 추출 (Sprint 214)
  */
 export { filesRoute } from "./routes/files.js";
 export { fileService } from "./services/file-service.js";
 export { documentParserService } from "./services/document-parser-service.js";
+export { documentExtractService } from "./services/document-extract-service.js";

--- a/packages/api/src/core/files/routes/files.ts
+++ b/packages/api/src/core/files/routes/files.ts
@@ -1,12 +1,20 @@
 /**
  * F441+F442: 파일 업로드 + 문서 파싱 라우트 (Sprint 213)
+ * F443: 문서 기반 아이템 추출 + GET /files JOIN 개선 (Sprint 214)
  */
 import { Hono } from "hono";
+import { z } from "zod";
 import type { Env } from "../../../env.js";
 import type { TenantVariables } from "../../../middleware/tenant.js";
 import { PresignFileSchema, ConfirmFileSchema } from "../schemas/file.js";
 import { fileService } from "../services/file-service.js";
 import { documentParserService } from "../services/document-parser-service.js";
+import { documentExtractService } from "../services/document-extract-service.js";
+
+const ExtractItemSchema = z.object({
+  file_ids: z.array(z.string()).min(1).max(10),
+  biz_item_id: z.string().optional(),
+});
 
 export const filesRoute = new Hono<{ Bindings: Env; Variables: TenantVariables }>();
 
@@ -48,12 +56,53 @@ filesRoute.post("/files/confirm", async (c) => {
   }
 });
 
-// ─── F441: GET /files — 파일 목록 ───
+// ─── F441: GET /files — 파일 목록 (F443: parsed_at/page_count JOIN 추가) ───
 filesRoute.get("/files", async (c) => {
   const orgId = c.get("orgId");
   const bizItemId = c.req.query("biz_item_id");
-  const files = await fileService.list(c.env, orgId, bizItemId);
-  return c.json({ files });
+
+  // parsed_documents와 JOIN하여 파싱 상태 포함 반환
+  let query: string;
+  let bindings: (string | undefined)[];
+  if (bizItemId) {
+    query = `SELECT f.*, pd.parsed_at, pd.page_count
+             FROM uploaded_files f
+             LEFT JOIN parsed_documents pd ON pd.file_id = f.id
+             WHERE f.tenant_id = ? AND f.biz_item_id = ?
+             ORDER BY f.created_at DESC`;
+    bindings = [orgId, bizItemId];
+  } else {
+    query = `SELECT f.*, pd.parsed_at, pd.page_count
+             FROM uploaded_files f
+             LEFT JOIN parsed_documents pd ON pd.file_id = f.id
+             WHERE f.tenant_id = ?
+             ORDER BY f.created_at DESC
+             LIMIT 50`;
+    bindings = [orgId];
+  }
+
+  const { results } = await c.env.DB.prepare(query).bind(...bindings).all();
+  return c.json({ files: results });
+});
+
+// ─── F443: PATCH /files/:id — 파일 메타 업데이트 (biz_item_id 연결) ───
+filesRoute.patch("/files/:id", async (c) => {
+  const orgId = c.get("orgId");
+  const fileId = c.req.param("id");
+  const body = await c.req.json<{ biz_item_id?: string }>().catch(() => ({}));
+
+  const file = await fileService.getById(c.env, orgId, fileId);
+  if (!file) return c.json({ error: "파일을 찾을 수 없어요" }, 404);
+
+  if (body.biz_item_id !== undefined) {
+    await c.env.DB.prepare(
+      `UPDATE uploaded_files SET biz_item_id = ? WHERE id = ? AND tenant_id = ?`,
+    )
+      .bind(body.biz_item_id, fileId, orgId)
+      .run();
+  }
+
+  return c.json({ ok: true });
 });
 
 // ─── F441: DELETE /files/:id — 파일 삭제 ───
@@ -171,4 +220,34 @@ filesRoute.get("/files/:id/parsed", async (c) => {
     ...parsed,
     content_structured: JSON.parse(parsed.content_structured ?? "{}"),
   });
+});
+
+// ─── F443: POST /files/extract-item — 파싱 결과에서 아이템 정보 AI 추출 ───
+filesRoute.post("/files/extract-item", async (c) => {
+  const orgId = c.get("orgId");
+  const body = await c.req.json();
+  const validation = ExtractItemSchema.safeParse(body);
+
+  if (!validation.success) {
+    return c.json({ error: "file_ids 배열이 필요해요", details: validation.error.flatten() }, 400);
+  }
+
+  const { file_ids } = validation.data;
+
+  try {
+    const parsedTexts = await documentExtractService.fetchParsedTexts(c.env.DB, {
+      fileIds: file_ids,
+      tenantId: orgId,
+    });
+
+    if (parsedTexts.length === 0) {
+      return c.json({ error: "파싱된 문서가 없어요. 먼저 /parse를 호출하세요" }, 404);
+    }
+
+    const extracted = await documentExtractService.extractItemInfo(c.env.AI, parsedTexts);
+    return c.json(extracted);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "추출에 실패했어요";
+    return c.json({ error: msg }, 500);
+  }
 });

--- a/packages/api/src/core/files/services/__tests__/document-extract.test.ts
+++ b/packages/api/src/core/files/services/__tests__/document-extract.test.ts
@@ -1,0 +1,83 @@
+/**
+ * F443: 문서 기반 아이템 추출 서비스 단위 테스트 (Sprint 214)
+ */
+import { describe, it, expect, vi } from "vitest";
+import { DocumentExtractService } from "../document-extract-service.js";
+import type { Ai } from "@cloudflare/workers-types";
+
+// Workers AI mock
+function makeAi(response: string): Ai {
+  return {
+    run: vi.fn().mockResolvedValue({ response }),
+  } as unknown as Ai;
+}
+
+describe("DocumentExtractService", () => {
+  const svc = new DocumentExtractService();
+
+  describe("extractItemInfo", () => {
+    it("빈 배열이면 빈 결과 반환", async () => {
+      const ai = makeAi("");
+      const result = await svc.extractItemInfo(ai, []);
+      expect(result.title).toBe("");
+      expect(result.description).toBe("");
+      expect(result.confidence).toBe(0);
+    });
+
+    it("Workers AI가 JSON을 반환하면 파싱", async () => {
+      const ai = makeAi('{"title":"AI 기반 사내 지식 관리","description":"임직원의 내부 문서를 AI로 검색하는 시스템","confidence":0.9}');
+      const result = await svc.extractItemInfo(ai, [
+        { filename: "test.pdf", content_text: "내용" },
+      ]);
+      expect(result.title).toBe("AI 기반 사내 지식 관리");
+      expect(result.description).toContain("임직원");
+      expect(result.confidence).toBe(0.9);
+    });
+
+    it("JSON이 텍스트 안에 섞여 있어도 파싱", async () => {
+      const ai = makeAi('결과입니다: {"title":"추출 제목","description":"추출 설명","confidence":0.8} 끝');
+      const result = await svc.extractItemInfo(ai, [
+        { filename: "doc.docx", content_text: "문서 내용" },
+      ]);
+      expect(result.title).toBe("추출 제목");
+    });
+
+    it("Workers AI가 유효하지 않은 JSON 반환 시 파일명으로 fallback", async () => {
+      const ai = makeAi("유효하지 않은 응답");
+      const result = await svc.extractItemInfo(ai, [
+        { filename: "사업기획서_v2.pdf", content_text: "내용" },
+      ]);
+      expect(result.title).toBe("사업기획서_v2");
+      expect(result.confidence).toBe(0.1);
+    });
+
+    it("Workers AI 예외 시 파일명으로 fallback", async () => {
+      const ai = { run: vi.fn().mockRejectedValue(new Error("AI 오류")) } as unknown as Ai;
+      const result = await svc.extractItemInfo(ai, [
+        { filename: "proposal.pptx", content_text: "내용" },
+      ]);
+      expect(result.title).toBe("proposal");
+      expect(result.confidence).toBe(0.1);
+    });
+
+    it("제목을 100자로 슬라이싱", async () => {
+      const longTitle = "A".repeat(150);
+      const ai = makeAi(`{"title":"${longTitle}","description":"설명","confidence":0.5}`);
+      const result = await svc.extractItemInfo(ai, [{ filename: "f.pdf", content_text: "x" }]);
+      expect(result.title.length).toBeLessThanOrEqual(100);
+    });
+
+    it("최대 3개 문서만 처리", async () => {
+      const ai = makeAi('{"title":"제목","description":"설명","confidence":0.7}');
+      const docs = Array.from({ length: 5 }, (_, i) => ({
+        filename: `doc${i}.pdf`,
+        content_text: "x",
+      }));
+      await svc.extractItemInfo(ai, docs);
+      const callArgs = (ai.run as ReturnType<typeof vi.fn>).mock.calls[0] as [string, { prompt: string }];
+      const prompt = callArgs[1].prompt;
+      // 최대 3개 파일명만 포함
+      expect((prompt.match(/\[doc/g) ?? []).length).toBeLessThanOrEqual(3);
+    });
+  });
+});

--- a/packages/api/src/core/files/services/document-extract-service.ts
+++ b/packages/api/src/core/files/services/document-extract-service.ts
@@ -1,0 +1,120 @@
+/**
+ * F443: 문서 기반 아이템 자동 추출 서비스 (Sprint 214)
+ * 파싱된 텍스트에서 Workers AI로 사업 아이템 제목/설명을 추출한다.
+ */
+
+import type { Ai } from "@cloudflare/workers-types";
+
+export interface ExtractedItemInfo {
+  title: string;
+  description: string;
+  confidence: number;
+}
+
+const MAX_CHARS_PER_DOC = 2000;
+const MAX_DOCS = 3;
+
+export class DocumentExtractService {
+  async extractItemInfo(
+    ai: Ai,
+    parsedTexts: Array<{ filename: string; content_text: string }>,
+  ): Promise<ExtractedItemInfo> {
+    if (parsedTexts.length === 0) {
+      return { title: "", description: "", confidence: 0 };
+    }
+
+    // 문서 텍스트를 합쳐서 컨텍스트 구성 (최대 MAX_DOCS개, 각 MAX_CHARS_PER_DOC자)
+    const docContext = parsedTexts
+      .slice(0, MAX_DOCS)
+      .map((d) => `[${d.filename}]\n${d.content_text.slice(0, MAX_CHARS_PER_DOC)}`)
+      .join("\n\n---\n\n");
+
+    const prompt = `당신은 B2B 사업 기획 전문가입니다.
+아래 문서 내용을 분석하여 핵심 사업 아이디어를 한 문장 제목과 간결한 설명으로 추출해주세요.
+
+[문서 내용]
+${docContext}
+
+반드시 아래 JSON 형식으로만 답변하세요 (다른 텍스트 없이):
+{"title": "50자 이내 사업 아이디어 제목", "description": "200자 이내 핵심 내용 요약", "confidence": 0.0~1.0}`;
+
+    try {
+      const response = await (ai as unknown as {
+        run: (model: string, params: { prompt: string; max_tokens: number }) => Promise<{ response?: string }>;
+      }).run("@cf/meta/llama-3.1-8b-instruct", {
+        prompt,
+        max_tokens: 256,
+      });
+
+      const raw = response.response ?? "";
+      // JSON 파싱 시도
+      const jsonMatch = raw.match(/\{[\s\S]*\}/);
+      if (jsonMatch) {
+        const parsed = JSON.parse(jsonMatch[0]) as {
+          title?: string;
+          description?: string;
+          confidence?: number;
+        };
+        return {
+          title: String(parsed.title ?? "").slice(0, 100),
+          description: String(parsed.description ?? "").slice(0, 300),
+          confidence: Math.min(1, Math.max(0, Number(parsed.confidence ?? 0.7))),
+        };
+      }
+    } catch {
+      // Workers AI 실패 시 graceful fallback
+    }
+
+    // Fallback: 첫 번째 문서의 파일명에서 제목 추정
+    const firstFilename = parsedTexts[0]!.filename.replace(/\.[^.]+$/, "");
+    return {
+      title: firstFilename.slice(0, 100),
+      description: "",
+      confidence: 0.1,
+    };
+  }
+
+  /**
+   * D1에서 biz_item_id 또는 file_ids 기준으로 파싱된 문서를 조회한다.
+   */
+  async fetchParsedTexts(
+    db: D1Database,
+    options: { bizItemId?: string; fileIds?: string[]; tenantId: string },
+  ): Promise<Array<{ filename: string; content_text: string }>> {
+    if (options.fileIds && options.fileIds.length > 0) {
+      const placeholders = options.fileIds.map(() => "?").join(", ");
+      const { results } = await db
+        .prepare(
+          `SELECT f.filename, pd.content_text
+           FROM parsed_documents pd
+           JOIN uploaded_files f ON f.id = pd.file_id
+           WHERE pd.file_id IN (${placeholders})
+             AND f.tenant_id = ?
+           ORDER BY pd.parsed_at DESC
+           LIMIT ${MAX_DOCS}`,
+        )
+        .bind(...options.fileIds, options.tenantId)
+        .all<{ filename: string; content_text: string }>();
+      return results;
+    }
+
+    if (options.bizItemId) {
+      const { results } = await db
+        .prepare(
+          `SELECT f.filename, pd.content_text
+           FROM parsed_documents pd
+           JOIN uploaded_files f ON f.id = pd.file_id
+           WHERE f.biz_item_id = ? AND f.tenant_id = ?
+           ORDER BY pd.parsed_at DESC
+           LIMIT ${MAX_DOCS}`,
+        )
+        .bind(options.bizItemId, options.tenantId)
+        .all<{ filename: string; content_text: string }>();
+      return results;
+    }
+
+    return [];
+  }
+}
+
+export const documentExtractService = new DocumentExtractService();

--- a/packages/api/src/core/offering/services/business-plan-generator.ts
+++ b/packages/api/src/core/offering/services/business-plan-generator.ts
@@ -27,6 +27,8 @@ export interface BpGenerationInput {
   templateType?: TemplateType;
   tone?: ToneType;
   length?: LengthType;
+  // F443: 업로드 문서 파싱 결과 컨텍스트
+  documentContext?: string[];
 }
 
 export interface BusinessPlanDraft {
@@ -167,7 +169,9 @@ export class BusinessPlanGeneratorService {
 기존 evidence를 삭제하지 않고, 보강만 수행하세요.
 사업 아이템: ${input.bizItem.title}
 시작점: ${input.startingPoint ?? "미분류"}
-
+${input.documentContext && input.documentContext.length > 0
+  ? `\n--- 첨부 자료 (참고용) ---\n${input.documentContext.join("\n\n---\n\n")}\n`
+  : ""}
 --- 사업계획서 초안 ---
 ${draft}`,
           systemPromptOverride: "당신은 B2B 사업계획서 전문 편집자입니다. KT DS 사업개발팀 문체에 맞게 구조화된 사업계획서를 다듬어주세요.",

--- a/packages/api/src/core/offering/services/business-plan-template.ts
+++ b/packages/api/src/core/offering/services/business-plan-template.ts
@@ -50,6 +50,8 @@ export interface BpDataBundle {
     trends: unknown;
   } | null;
   prdContent: string | null;
+  // F443: 업로드 문서 파싱 결과 컨텍스트
+  documentContext?: string[];
 }
 
 // ─── 매핑 함수 ───

--- a/packages/web/src/components/feature/discovery/AttachedFilesPanel.tsx
+++ b/packages/web/src/components/feature/discovery/AttachedFilesPanel.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+/**
+ * F443: 첨부 자료 패널 (Sprint 214)
+ * 아이템 상세 페이지에서 업로드된 파일 목록과 파싱 상태를 표시한다.
+ */
+import { useCallback, useEffect, useState } from "react";
+import { Loader2, Trash2, FileText, RefreshCw } from "lucide-react";
+import { fetchFiles, deleteFile, type UploadedFileMeta } from "@/lib/api-client";
+import { FileUploadZone } from "@/components/feature/FileUploadZone";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+
+const STATUS_LABELS: Record<string, { label: string; variant: "default" | "secondary" | "destructive" }> = {
+  pending: { label: "대기", variant: "secondary" },
+  uploaded: { label: "업로드 완료", variant: "secondary" },
+  parsing: { label: "파싱 중", variant: "default" },
+  parsed: { label: "파싱 완료", variant: "default" },
+  error: { label: "오류", variant: "destructive" },
+};
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}
+
+interface AttachedFilesPanelProps {
+  bizItemId: string;
+  apiBaseUrl?: string;
+}
+
+export default function AttachedFilesPanel({ bizItemId, apiBaseUrl = "" }: AttachedFilesPanelProps) {
+  const [files, setFiles] = useState<UploadedFileMeta[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [showUpload, setShowUpload] = useState(false);
+
+  const loadFiles = useCallback(async () => {
+    setLoading(true);
+    try {
+      const result = await fetchFiles(bizItemId);
+      setFiles(result);
+    } catch {
+      // fail silently
+    } finally {
+      setLoading(false);
+    }
+  }, [bizItemId]);
+
+  useEffect(() => {
+    void loadFiles();
+  }, [loadFiles]);
+
+  async function handleDelete(fileId: string) {
+    setDeletingId(fileId);
+    try {
+      await deleteFile(fileId);
+      setFiles((prev) => prev.filter((f) => f.id !== fileId));
+    } catch {
+      // fail silently
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  function handleUploadComplete(fileId: string) {
+    // 업로드 완료 후 목록 새로고침
+    void loadFiles();
+    // 파싱이 끝나면 다시 새로고침 (3초 후)
+    setTimeout(() => void loadFiles(), 3000);
+    void fileId;
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* 헤더 */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-bold">첨부 자료</h3>
+          <p className="text-xs text-muted-foreground">
+            PDF, PPTX, DOCX 파일을 업로드하면 발굴 분석에 자동으로 활용돼요
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => void loadFiles()}
+            disabled={loading}
+          >
+            <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setShowUpload((v) => !v)}
+          >
+            {showUpload ? "닫기" : "+ 파일 추가"}
+          </Button>
+        </div>
+      </div>
+
+      {/* 업로드 존 (토글) */}
+      {showUpload && (
+        <div className="rounded-lg border p-3">
+          <FileUploadZone
+            apiBaseUrl={apiBaseUrl}
+            bizItemId={bizItemId}
+            onUploadComplete={(id) => {
+              handleUploadComplete(id);
+              setShowUpload(false);
+            }}
+          />
+        </div>
+      )}
+
+      {/* 파일 목록 */}
+      {loading ? (
+        <div className="flex items-center justify-center py-8 text-muted-foreground">
+          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          <span className="text-sm">불러오는 중...</span>
+        </div>
+      ) : files.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-8 text-center">
+          <FileText className="mx-auto mb-2 h-8 w-8 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">첨부된 자료가 없어요</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            파일을 업로드하면 AI가 발굴 분석에 활용해요
+          </p>
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-3"
+            onClick={() => setShowUpload(true)}
+          >
+            + 파일 업로드
+          </Button>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {files.map((file) => {
+            const statusInfo = STATUS_LABELS[file.status] ?? { label: file.status, variant: "secondary" as const };
+            return (
+              <div
+                key={file.id}
+                className="flex items-center gap-3 rounded-lg border bg-card p-3"
+              >
+                <FileText className="h-5 w-5 shrink-0 text-muted-foreground" />
+                <div className="flex-1 min-w-0">
+                  <p className="truncate text-sm font-medium">{file.filename}</p>
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <span>{formatBytes(file.size_bytes)}</span>
+                    {file.page_count != null && (
+                      <span>· {file.page_count}페이지</span>
+                    )}
+                  </div>
+                </div>
+                <Badge variant={statusInfo.variant} className="shrink-0 text-[10px]">
+                  {statusInfo.label}
+                </Badge>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 shrink-0 text-muted-foreground hover:text-destructive"
+                  onClick={() => void handleDelete(file.id)}
+                  disabled={deletingId === file.id}
+                  aria-label={`${file.filename} 삭제`}
+                >
+                  {deletingId === file.id ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <Trash2 className="h-3.5 w-3.5" />
+                  )}
+                </Button>
+              </div>
+            );
+          })}
+          <p className="text-right text-xs text-muted-foreground">
+            총 {files.length}개 · 파싱 완료 {files.filter((f) => f.status === "parsed").length}개
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/lib/api-client.ts
+++ b/packages/web/src/lib/api-client.ts
@@ -2880,3 +2880,41 @@ export async function advancePipelineStage(
 ): Promise<{ success: boolean }> {
   return patchApi(`/pipeline/items/${bizItemId}/stage`, { stage, notes });
 }
+
+// ─── F443: 파일 업로드 + 문서 추출 ──────────────────────────────────────
+
+export interface UploadedFileMeta {
+  id: string;
+  filename: string;
+  mime_type: string;
+  status: string;
+  size_bytes: number;
+  created_at: number;
+  parsed_at?: number | null;
+  page_count?: number | null;
+}
+
+export async function fetchFiles(bizItemId?: string): Promise<UploadedFileMeta[]> {
+  const params = bizItemId ? `?biz_item_id=${encodeURIComponent(bizItemId)}` : "";
+  const data = await fetchApi<{ files: UploadedFileMeta[] }>(`/files${params}`);
+  return data.files ?? [];
+}
+
+export async function deleteFile(fileId: string): Promise<void> {
+  await deleteApi(`/files/${fileId}`);
+}
+
+export async function extractItemFromDocuments(
+  fileIds: string[],
+): Promise<{ title: string; description: string; confidence: number }> {
+  return postApi("/files/extract-item", { file_ids: fileIds });
+}
+
+export async function associateFilesToItem(
+  fileIds: string[],
+  bizItemId: string,
+): Promise<void> {
+  await Promise.all(
+    fileIds.map((id) => patchApi(`/files/${id}`, { biz_item_id: bizItemId })),
+  );
+}

--- a/packages/web/src/routes/ax-bd/discovery-detail.tsx
+++ b/packages/web/src/routes/ax-bd/discovery-detail.tsx
@@ -3,10 +3,11 @@
 /**
  * F439 — 아이템 상세 허브 (3탭: 기본정보/발굴분석/형상화)
  * F440 — 사업기획서 생성 + 열람
- * F447 — 파이프라인 상태 추적 스테퍼
- * F448 — 단계 간 자동 전환 CTA
+ * F443 — 첨부 자료 탭 추가 (Sprint 214)
  * F444 — 사업기획서 편집기 + 버전 이력
  * F445 — 기획서 템플릿 선택
+ * F447 — 파이프라인 상태 추적 스테퍼
+ * F448 — 단계 간 자동 전환 CTA
  */
 import { useCallback, useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
@@ -35,6 +36,7 @@ import PipelineTransitionCTA from "@/components/feature/discovery/PipelineTransi
 import BusinessPlanEditor from "@/components/feature/discovery/BusinessPlanEditor";
 import VersionHistoryPanel from "@/components/feature/discovery/VersionHistoryPanel";
 import TemplateSelector, { type TemplateParams } from "@/components/feature/discovery/TemplateSelector";
+import AttachedFilesPanel from "@/components/feature/discovery/AttachedFilesPanel";
 
 const TYPE_LABELS: Record<string, string> = {
   I: "아이디어형", M: "시장·타겟형", P: "고객문제형", T: "기술형", S: "서비스형",
@@ -164,12 +166,13 @@ export function Component() {
       {/* F447: 파이프라인 진행률 스테퍼 */}
       {pipelineDetail && <PipelineProgressStepper detail={pipelineDetail} />}
 
-      {/* 3탭 허브 */}
+      {/* 4탭 허브 (F443: "첨부 자료" 탭 추가) */}
       <Tabs defaultValue="info">
         <TabsList>
           <TabsTrigger value="info">기본정보</TabsTrigger>
           <TabsTrigger value="analysis">발굴분석</TabsTrigger>
           <TabsTrigger value="shaping">형상화</TabsTrigger>
+          <TabsTrigger value="files">첨부 자료</TabsTrigger>
         </TabsList>
 
         {/* ── 탭 1: 기본정보 ── */}
@@ -335,6 +338,13 @@ export function Component() {
               onCancel={() => setShowTemplateSelector(false)}
             />
           )}
+        </TabsContent>
+
+        {/* ── 탭 4: 첨부 자료 (F443) ── */}
+        <TabsContent value="files" className="mt-4">
+          <div className="rounded-lg border bg-card p-5">
+            <AttachedFilesPanel bizItemId={id!} />
+          </div>
         </TabsContent>
       </Tabs>
     </div>

--- a/packages/web/src/routes/getting-started.tsx
+++ b/packages/web/src/routes/getting-started.tsx
@@ -6,7 +6,8 @@ import { ArrowLeft, ArrowRight, CheckCircle2, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { postApi } from "@/lib/api-client";
+import { postApi, extractItemFromDocuments, associateFilesToItem } from "@/lib/api-client";
+import { FileUploadZone } from "@/components/feature/FileUploadZone";
 
 // ─── Types ───
 
@@ -24,7 +25,8 @@ interface ClassifyResult {
 
 // ─── Step Indicator ───
 
-const STEPS = ["아이디어 입력", "AI 분석", "확인 & 등록"] as const;
+// F443: 자료 업로드 스텝 추가 (Step 0)
+const STEPS = ["자료 업로드", "아이디어 입력", "AI 분석", "확인 & 등록"] as const;
 
 function StepIndicator({ current }: { current: number }) {
   return (
@@ -63,6 +65,60 @@ function StepIndicator({ current }: { current: number }) {
           )}
         </div>
       ))}
+    </div>
+  );
+}
+
+// ─── Step 1: 아이디어 입력 ───
+
+// ─── Step 0: 자료 업로드 (F443, optional) ───
+
+function Step0({
+  uploadedFileIds,
+  onUpload,
+  onExtracted,
+  onSkip,
+  extracting,
+}: {
+  uploadedFileIds: string[];
+  onUpload: (fileId: string) => void;
+  onExtracted: (title: string, description: string) => void;
+  onSkip: () => void;
+  extracting: boolean;
+}) {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="mb-1 text-lg font-semibold">자료를 업로드해 주세요 (선택)</h2>
+        <p className="text-sm text-muted-foreground">
+          PDF, PPTX, DOCX 파일을 업로드하면 AI가 아이디어 제목과 설명을 자동으로 채워드려요.
+        </p>
+      </div>
+
+      <FileUploadZone onUploadComplete={onUpload} />
+
+      {uploadedFileIds.length > 0 && (
+        <p className="text-sm text-muted-foreground">
+          ✅ {uploadedFileIds.length}개 파일 업로드 완료
+        </p>
+      )}
+
+      <div className="flex gap-3">
+        <Button
+          className="flex-1"
+          onClick={() => void onExtracted("", "")}
+          disabled={uploadedFileIds.length === 0 || extracting}
+        >
+          {extracting ? (
+            <><Loader2 className="mr-2 h-4 w-4 animate-spin" />AI 분석 중...</>
+          ) : (
+            <><ArrowRight className="mr-2 h-4 w-4" />다음 (AI 자동 입력)</>
+          )}
+        </Button>
+        <Button variant="ghost" onClick={onSkip}>
+          건너뛰기
+        </Button>
+      </div>
     </div>
   );
 }
@@ -294,6 +350,31 @@ export function Component() {
   const [createdItem, setCreatedItem] = useState<CreatedItem | null>(null);
   const [classifyResult, setClassifyResult] = useState<ClassifyResult | null>(null);
   const [classifyLoading, setClassifyLoading] = useState(false);
+  // F443: 자료 업로드 상태
+  const [uploadedFileIds, setUploadedFileIds] = useState<string[]>([]);
+  const [extracting, setExtracting] = useState(false);
+
+  const handleFileUploaded = (fileId: string) => {
+    setUploadedFileIds((prev) => [...prev, fileId]);
+  };
+
+  const handleExtract = async () => {
+    if (uploadedFileIds.length === 0) {
+      setStep(1);
+      return;
+    }
+    setExtracting(true);
+    try {
+      const result = await extractItemFromDocuments(uploadedFileIds);
+      if (result.title) setTitle(result.title);
+      if (result.description) setDescription(result.description);
+    } catch {
+      // 추출 실패 시 빈 필드로 진행
+    } finally {
+      setExtracting(false);
+      setStep(1);
+    }
+  };
 
   const handleStep1Next = async () => {
     setError(null);
@@ -305,7 +386,13 @@ export function Component() {
         source: "wizard",
       });
       setCreatedItem(item);
-      setStep(1);
+
+      // F443: 업로드된 파일을 생성된 아이템에 연결
+      if (uploadedFileIds.length > 0) {
+        associateFilesToItem(uploadedFileIds, item.id).catch(() => {/* non-fatal */});
+      }
+
+      setStep(2); // Step 2 = AI 분석 (STEPS[2])
 
       // Kick off classification in background
       setClassifyLoading(true);
@@ -344,7 +431,17 @@ export function Component() {
           </CardTitle>
         </CardHeader>
         <CardContent>
+          {/* F443: Step 0 — 자료 업로드 (optional) */}
           {step === 0 && (
+            <Step0
+              uploadedFileIds={uploadedFileIds}
+              onUpload={handleFileUploaded}
+              onExtracted={() => void handleExtract()}
+              onSkip={() => setStep(1)}
+              extracting={extracting}
+            />
+          )}
+          {step === 1 && (
             <Step1
               title={title}
               description={description}
@@ -355,22 +452,22 @@ export function Component() {
               error={error}
             />
           )}
-          {step === 1 && createdItem && (
+          {step === 2 && createdItem && (
             <Step2
               item={createdItem}
               classifyResult={classifyResult}
               classifyLoading={classifyLoading}
-              onBack={() => setStep(0)}
-              onNext={() => setStep(2)}
+              onBack={() => setStep(1)}
+              onNext={() => setStep(3)}
             />
           )}
-          {step === 2 && createdItem && (
+          {step === 3 && createdItem && (
             <Step3
               item={{
                 ...createdItem,
                 discoveryType: classifyResult?.type ?? classifyResult?.category ?? createdItem.discoveryType,
               }}
-              onBack={() => setStep(1)}
+              onBack={() => setStep(2)}
               onFinish={handleFinish}
             />
           )}


### PR DESCRIPTION
## Sprint 214 — F443 자료 기반 발굴 입력

Phase 25-A의 마지막 단계: F441(파일 업로드)+F442(파싱 엔진) 결과를 발굴 플로우에 통합한다.

### 구현 범위

**API**
- `document-extract-service.ts` (신규): Workers AI로 파싱 텍스트 → 아이템 제목/설명 자동 추출
- `POST /files/extract-item`: 파싱된 문서에서 아이템 정보 AI 추출
- `PATCH /files/:id`: 파일을 아이템에 연결 (biz_item_id 업데이트)
- `GET /files`: `parsed_at`/`page_count` JOIN 개선
- `generate-business-plan`: 첨부 문서 파싱 결과를 LLM 프롬프트 컨텍스트로 자동 주입

**Web**
- `AttachedFilesPanel.tsx` (신규): 파일 목록 + 파싱 상태 + 업로드 버튼
- `discovery-detail.tsx`: "첨부 자료" 탭 (4번째 탭 추가)
- `getting-started.tsx`: Step 0 자료 업로드 (4단계 위저드, 건너뛰기 가능)
- `api-client.ts`: `fetchFiles`, `deleteFile`, `extractItemFromDocuments`, `associateFilesToItem`

**문서**
- Plan: `docs/01-plan/features/sprint-214.plan.md`
- Design: `docs/02-design/features/sprint-214.design.md`

### 선행 조건
- Sprint 213 (F441+F442) merged ✅

---
🤖 Auto-generated from Sprint autopilot