### PR TITLE
feat: Sprint 223 — F459+F460 포트폴리오 연결 구조 검색 + 대시보드

### DIFF
--- a/packages/api/src/__tests__/portfolio-route.test.ts
+++ b/packages/api/src/__tests__/portfolio-route.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Sprint 223: F459 Portfolio Route 통합 테스트
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { app } from "../app.js";
+import { createTestEnv, createAuthHeaders } from "./helpers/test-app.js";
+
+vi.mock("../core/agent/services/agent-runner.js", () => ({
+  createAgentRunner: () => ({ type: "mock", execute: vi.fn(), isAvailable: () => Promise.resolve(true), supportsTaskType: () => true }),
+  createRoutedRunner: () => Promise.resolve({ type: "mock", execute: vi.fn(), isAvailable: () => Promise.resolve(true), supportsTaskType: () => true }),
+}));
+
+let env: ReturnType<typeof createTestEnv>;
+
+function req(path: string, headers?: Record<string, string>) {
+  return app.request(`http://localhost/api${path}`, { method: "GET", headers: { "Content-Type": "application/json", ...headers } }, env);
+}
+
+function seed(sql: string) {
+  (env.DB as any).prepare(sql).run();
+}
+
+const TABLES_SQL = `
+  CREATE TABLE IF NOT EXISTS biz_items (
+    id TEXT PRIMARY KEY, org_id TEXT NOT NULL, title TEXT NOT NULL, description TEXT,
+    source TEXT NOT NULL DEFAULT 'field', status TEXT NOT NULL DEFAULT 'draft',
+    created_by TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE TABLE IF NOT EXISTS biz_item_classifications (
+    id TEXT PRIMARY KEY, biz_item_id TEXT NOT NULL UNIQUE, item_type TEXT NOT NULL,
+    confidence REAL NOT NULL DEFAULT 0.0, turn_1_answer TEXT, turn_2_answer TEXT,
+    turn_3_answer TEXT, analysis_weights TEXT NOT NULL DEFAULT '{}',
+    classified_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE TABLE IF NOT EXISTS biz_evaluations (
+    id TEXT PRIMARY KEY, biz_item_id TEXT NOT NULL, verdict TEXT NOT NULL,
+    avg_score REAL NOT NULL DEFAULT 0.0, total_concerns INTEGER NOT NULL DEFAULT 0,
+    evaluated_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE TABLE IF NOT EXISTS biz_evaluation_scores (
+    id TEXT PRIMARY KEY, evaluation_id TEXT NOT NULL, persona_id TEXT NOT NULL,
+    business_viability REAL NOT NULL DEFAULT 0, strategic_fit REAL NOT NULL DEFAULT 0,
+    customer_value REAL NOT NULL DEFAULT 0, tech_market REAL NOT NULL DEFAULT 0,
+    execution REAL NOT NULL DEFAULT 0, financial_feasibility REAL NOT NULL DEFAULT 0,
+    competitive_diff REAL NOT NULL DEFAULT 0, scalability REAL NOT NULL DEFAULT 0,
+    summary TEXT, concerns TEXT
+  );
+  CREATE TABLE IF NOT EXISTS biz_item_starting_points (
+    id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+    biz_item_id TEXT NOT NULL UNIQUE,
+    starting_point TEXT NOT NULL CHECK (starting_point IN ('idea','market','problem','tech','service')),
+    confidence REAL NOT NULL DEFAULT 0.0, reasoning TEXT,
+    needs_confirmation INTEGER NOT NULL DEFAULT 0,
+    confirmed_at TEXT
+  );
+  CREATE TABLE IF NOT EXISTS biz_discovery_criteria (
+    id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+    biz_item_id TEXT NOT NULL,
+    criterion_id INTEGER NOT NULL CHECK (criterion_id BETWEEN 1 AND 9),
+    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending','in_progress','completed','needs_revision')),
+    evidence TEXT, completed_at TEXT,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(biz_item_id, criterion_id)
+  );
+  CREATE TABLE IF NOT EXISTS business_plan_drafts (
+    id TEXT PRIMARY KEY, biz_item_id TEXT NOT NULL, version INTEGER NOT NULL DEFAULT 1,
+    content TEXT NOT NULL, sections_snapshot TEXT, model_used TEXT,
+    tokens_used INTEGER DEFAULT 0, generated_at TEXT NOT NULL,
+    UNIQUE(biz_item_id, version)
+  );
+  CREATE TABLE IF NOT EXISTS offerings (
+    id TEXT PRIMARY KEY, org_id TEXT NOT NULL, biz_item_id TEXT NOT NULL,
+    title TEXT NOT NULL, purpose TEXT NOT NULL CHECK(purpose IN ('report','proposal','review')),
+    format TEXT NOT NULL CHECK(format IN ('html','pptx')),
+    status TEXT NOT NULL DEFAULT 'draft',
+    current_version INTEGER NOT NULL DEFAULT 1,
+    created_by TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE TABLE IF NOT EXISTS offering_sections (
+    id TEXT PRIMARY KEY, offering_id TEXT NOT NULL, section_key TEXT NOT NULL,
+    title TEXT NOT NULL, content TEXT, sort_order INTEGER NOT NULL,
+    is_required INTEGER NOT NULL DEFAULT 1, is_included INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(offering_id, section_key)
+  );
+  CREATE TABLE IF NOT EXISTS offering_versions (
+    id TEXT PRIMARY KEY, offering_id TEXT NOT NULL, version INTEGER NOT NULL,
+    snapshot TEXT, change_summary TEXT, created_by TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(offering_id, version)
+  );
+  CREATE TABLE IF NOT EXISTS offering_prototypes (
+    id TEXT PRIMARY KEY, offering_id TEXT NOT NULL, prototype_id TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(offering_id, prototype_id)
+  );
+  CREATE TABLE IF NOT EXISTS prototypes (
+    id TEXT PRIMARY KEY, biz_item_id TEXT NOT NULL, version INTEGER NOT NULL DEFAULT 1,
+    format TEXT NOT NULL DEFAULT 'html', content TEXT NOT NULL,
+    template_used TEXT, model_used TEXT, tokens_used INTEGER DEFAULT 0,
+    generated_at TEXT NOT NULL, UNIQUE(biz_item_id, version)
+  );
+  CREATE TABLE IF NOT EXISTS pipeline_stages (
+    id TEXT PRIMARY KEY, biz_item_id TEXT NOT NULL, org_id TEXT NOT NULL,
+    stage TEXT NOT NULL DEFAULT 'REGISTERED',
+    entered_at TEXT NOT NULL DEFAULT (datetime('now')),
+    exited_at TEXT, entered_by TEXT NOT NULL, notes TEXT
+  );
+  CREATE TABLE IF NOT EXISTS org_members (
+    org_id TEXT NOT NULL, user_id TEXT NOT NULL, role TEXT NOT NULL DEFAULT 'member',
+    PRIMARY KEY (org_id, user_id)
+  );
+  CREATE TABLE IF NOT EXISTS users (
+    id TEXT PRIMARY KEY, email TEXT NOT NULL UNIQUE, name TEXT,
+    role TEXT NOT NULL DEFAULT 'member',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE TABLE IF NOT EXISTS organizations (
+    id TEXT PRIMARY KEY, name TEXT NOT NULL, slug TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+`;
+
+describe("GET /biz-items/:id/portfolio", () => {
+  beforeEach(() => {
+    env = createTestEnv();
+    (env.DB as any).exec(TABLES_SQL);
+    (env.DB as any).exec(`INSERT OR IGNORE INTO users (id, email, name, role) VALUES ('test-user', 'test@example.com', 'Test', 'admin')`);
+    (env.DB as any).exec(`INSERT OR IGNORE INTO organizations (id, name, slug) VALUES ('org_test', 'Test Org', 'test-org')`);
+    (env.DB as any).exec(`INSERT OR IGNORE INTO org_members (org_id, user_id, role) VALUES ('org_test', 'test-user', 'owner')`);
+    seed(`INSERT INTO biz_items (id, org_id, title, source, status, created_by)
+          VALUES ('item-1', 'org_test', 'AI 품질예측', 'field', 'draft', 'test-user')`);
+  });
+
+  it("인증 없이 접근 — 401", async () => {
+    const res = await req("/biz-items/item-1/portfolio");
+    expect(res.status).toBe(401);
+  });
+
+  it("존재하지 않는 아이템 — 404", async () => {
+    const headers = await createAuthHeaders();
+    const res = await req("/biz-items/no-item/portfolio", headers);
+    expect(res.status).toBe(404);
+  });
+
+  it("하위 데이터 없는 아이템 — 빈 배열 + 200", async () => {
+    const headers = await createAuthHeaders();
+    const res = await req("/biz-items/item-1/portfolio", headers);
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as { data: Record<string, unknown> };
+    const data = body.data;
+    expect(data.item).toBeDefined();
+    expect(data.classification).toBeNull();
+    expect(Array.isArray(data.evaluations)).toBe(true);
+    expect((data.evaluations as unknown[]).length).toBe(0);
+    expect(Array.isArray(data.criteria)).toBe(true);
+    expect(Array.isArray(data.businessPlans)).toBe(true);
+    expect(Array.isArray(data.offerings)).toBe(true);
+    expect(Array.isArray(data.prototypes)).toBe(true);
+    expect(data.progress).toBeDefined();
+  });
+
+  it("전체 연결 데이터 — 10개 필드 모두 반환", async () => {
+    seed(`INSERT INTO biz_item_classifications (id, biz_item_id, item_type, confidence)
+          VALUES ('cls-1', 'item-1', '기술형', 0.92)`);
+    seed(`INSERT INTO biz_evaluations (id, biz_item_id, verdict, avg_score, total_concerns)
+          VALUES ('eval-1', 'item-1', 'APPROVED', 4.2, 1)`);
+    seed(`INSERT INTO biz_evaluation_scores (id, evaluation_id, persona_id, business_viability, strategic_fit, customer_value)
+          VALUES ('score-1', 'eval-1', 'pm', 4.5, 4.0, 4.1)`);
+    seed(`INSERT INTO biz_item_starting_points (id, biz_item_id, starting_point, confidence)
+          VALUES ('sp-1', 'item-1', 'tech', 0.85)`);
+    seed(`INSERT INTO biz_discovery_criteria (biz_item_id, criterion_id, status)
+          VALUES ('item-1', 1, 'completed')`);
+    seed(`INSERT INTO business_plan_drafts (id, biz_item_id, version, content, generated_at)
+          VALUES ('bp-1', 'item-1', 1, '{}', '2026-01-02')`);
+    seed(`INSERT INTO offerings (id, org_id, biz_item_id, title, purpose, format, created_by)
+          VALUES ('off-1', 'org_test', 'item-1', '제안서', 'proposal', 'html', 'user-1')`);
+    seed(`INSERT INTO prototypes (id, biz_item_id, version, content, generated_at)
+          VALUES ('proto-1', 'item-1', 1, '<html/>', '2026-01-03')`);
+    seed(`INSERT INTO offering_prototypes (id, offering_id, prototype_id)
+          VALUES ('op-1', 'off-1', 'proto-1')`);
+    seed(`INSERT INTO pipeline_stages (id, biz_item_id, org_id, stage, entered_by)
+          VALUES ('ps-1', 'item-1', 'org_test', 'DISCOVERY', 'user-1')`);
+
+    const headers = await createAuthHeaders();
+    const res = await req("/biz-items/item-1/portfolio", headers);
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as { data: Record<string, unknown[]> & { classification: Record<string, unknown>; item: Record<string, unknown>; progress: Record<string, unknown> } };
+    const data = body.data;
+
+    expect(data.classification).not.toBeNull();
+    expect((data.evaluations as unknown[]).length).toBe(1);
+    expect((data.criteria as unknown[]).length).toBe(1);
+    expect((data.businessPlans as unknown[]).length).toBe(1);
+    expect((data.offerings as Array<{ linkedPrototypeIds: string[] }>)[0]!.linkedPrototypeIds).toContain("proto-1");
+    expect((data.prototypes as unknown[]).length).toBe(1);
+    expect((data.pipelineStages as Array<{ stage: string }>)[0]!.stage).toBe("DISCOVERY");
+    expect(typeof data.progress.overallPercent).toBe("number");
+  });
+});

--- a/packages/api/src/__tests__/portfolio-service.test.ts
+++ b/packages/api/src/__tests__/portfolio-service.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Sprint 223: F459 PortfolioService 단위 테스트
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { createMockD1 } from "./helpers/mock-d1.js";
+import { PortfolioService, NotFoundError } from "../core/discovery/services/portfolio-service.js";
+
+const TABLES_SQL = `
+  CREATE TABLE IF NOT EXISTS biz_items (
+    id TEXT PRIMARY KEY, org_id TEXT NOT NULL, title TEXT NOT NULL, description TEXT,
+    source TEXT NOT NULL DEFAULT 'field', status TEXT NOT NULL DEFAULT 'draft',
+    created_by TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE TABLE IF NOT EXISTS biz_item_classifications (
+    id TEXT PRIMARY KEY, biz_item_id TEXT NOT NULL UNIQUE, item_type TEXT NOT NULL,
+    confidence REAL NOT NULL DEFAULT 0.0, turn_1_answer TEXT, turn_2_answer TEXT,
+    turn_3_answer TEXT, analysis_weights TEXT NOT NULL DEFAULT '{}',
+    classified_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE TABLE IF NOT EXISTS biz_evaluations (
+    id TEXT PRIMARY KEY, biz_item_id TEXT NOT NULL, verdict TEXT NOT NULL,
+    avg_score REAL NOT NULL DEFAULT 0.0, total_concerns INTEGER NOT NULL DEFAULT 0,
+    evaluated_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE TABLE IF NOT EXISTS biz_evaluation_scores (
+    id TEXT PRIMARY KEY, evaluation_id TEXT NOT NULL, persona_id TEXT NOT NULL,
+    business_viability REAL NOT NULL DEFAULT 0, strategic_fit REAL NOT NULL DEFAULT 0,
+    customer_value REAL NOT NULL DEFAULT 0, tech_market REAL NOT NULL DEFAULT 0,
+    execution REAL NOT NULL DEFAULT 0, financial_feasibility REAL NOT NULL DEFAULT 0,
+    competitive_diff REAL NOT NULL DEFAULT 0, scalability REAL NOT NULL DEFAULT 0,
+    summary TEXT, concerns TEXT
+  );
+  CREATE TABLE IF NOT EXISTS biz_item_starting_points (
+    id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+    biz_item_id TEXT NOT NULL UNIQUE,
+    starting_point TEXT NOT NULL CHECK (starting_point IN ('idea','market','problem','tech','service')),
+    confidence REAL NOT NULL DEFAULT 0.0, reasoning TEXT,
+    needs_confirmation INTEGER NOT NULL DEFAULT 0,
+    confirmed_at TEXT
+  );
+  CREATE TABLE IF NOT EXISTS biz_discovery_criteria (
+    id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+    biz_item_id TEXT NOT NULL,
+    criterion_id INTEGER NOT NULL CHECK (criterion_id BETWEEN 1 AND 9),
+    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending','in_progress','completed','needs_revision')),
+    evidence TEXT, completed_at TEXT,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(biz_item_id, criterion_id)
+  );
+  CREATE TABLE IF NOT EXISTS business_plan_drafts (
+    id TEXT PRIMARY KEY, biz_item_id TEXT NOT NULL, version INTEGER NOT NULL DEFAULT 1,
+    content TEXT NOT NULL, sections_snapshot TEXT, model_used TEXT,
+    tokens_used INTEGER DEFAULT 0, generated_at TEXT NOT NULL,
+    UNIQUE(biz_item_id, version)
+  );
+  CREATE TABLE IF NOT EXISTS offerings (
+    id TEXT PRIMARY KEY, org_id TEXT NOT NULL, biz_item_id TEXT NOT NULL,
+    title TEXT NOT NULL, purpose TEXT NOT NULL CHECK(purpose IN ('report','proposal','review')),
+    format TEXT NOT NULL CHECK(format IN ('html','pptx')),
+    status TEXT NOT NULL DEFAULT 'draft',
+    current_version INTEGER NOT NULL DEFAULT 1,
+    created_by TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE TABLE IF NOT EXISTS offering_sections (
+    id TEXT PRIMARY KEY, offering_id TEXT NOT NULL, section_key TEXT NOT NULL,
+    title TEXT NOT NULL, content TEXT, sort_order INTEGER NOT NULL,
+    is_required INTEGER NOT NULL DEFAULT 1, is_included INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(offering_id, section_key)
+  );
+  CREATE TABLE IF NOT EXISTS offering_versions (
+    id TEXT PRIMARY KEY, offering_id TEXT NOT NULL, version INTEGER NOT NULL,
+    snapshot TEXT, change_summary TEXT, created_by TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(offering_id, version)
+  );
+  CREATE TABLE IF NOT EXISTS offering_prototypes (
+    id TEXT PRIMARY KEY, offering_id TEXT NOT NULL, prototype_id TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(offering_id, prototype_id)
+  );
+  CREATE TABLE IF NOT EXISTS prototypes (
+    id TEXT PRIMARY KEY, biz_item_id TEXT NOT NULL, version INTEGER NOT NULL DEFAULT 1,
+    format TEXT NOT NULL DEFAULT 'html', content TEXT NOT NULL,
+    template_used TEXT, model_used TEXT, tokens_used INTEGER DEFAULT 0,
+    generated_at TEXT NOT NULL, UNIQUE(biz_item_id, version)
+  );
+  CREATE TABLE IF NOT EXISTS pipeline_stages (
+    id TEXT PRIMARY KEY, biz_item_id TEXT NOT NULL, org_id TEXT NOT NULL,
+    stage TEXT NOT NULL DEFAULT 'REGISTERED',
+    entered_at TEXT NOT NULL DEFAULT (datetime('now')),
+    exited_at TEXT, entered_by TEXT NOT NULL, notes TEXT
+  );
+`;
+
+describe("PortfolioService", () => {
+  let db: ReturnType<typeof createMockD1>;
+  let service: PortfolioService;
+
+  beforeEach(() => {
+    db = createMockD1();
+    (db as any).exec(TABLES_SQL);
+    service = new PortfolioService(db as unknown as D1Database);
+  });
+
+  function seed(sql: string) {
+    (db as any).exec(sql);
+  }
+
+  function seedItem(id = "item-1", orgId = "org-1") {
+    seed(`INSERT INTO biz_items (id, org_id, title, description, source, status, created_by)
+          VALUES ('${id}', '${orgId}', 'AI 품질예측', '품질 예측 시스템', 'field', 'draft', 'user-1')`);
+  }
+
+  it("존재하지 않는 아이템 — NotFoundError", async () => {
+    await expect(service.getPortfolioTree("no-item", "org-1")).rejects.toThrow(NotFoundError);
+  });
+
+  it("다른 org 아이템 접근 — NotFoundError (권한 차단)", async () => {
+    seedItem("item-1", "org-A");
+    await expect(service.getPortfolioTree("item-1", "org-B")).rejects.toThrow(NotFoundError);
+  });
+
+  it("하위 데이터 없는 아이템 — 빈 배열/null 반환, 에러 없음", async () => {
+    seedItem();
+    const result = await service.getPortfolioTree("item-1", "org-1");
+
+    expect(result.item.id).toBe("item-1");
+    expect(result.classification).toBeNull();
+    expect(result.evaluations).toEqual([]);
+    expect(result.startingPoint).toBeNull();
+    expect(result.criteria).toEqual([]);
+    expect(result.businessPlans).toEqual([]);
+    expect(result.offerings).toEqual([]);
+    expect(result.prototypes).toEqual([]);
+    expect(result.pipelineStages).toEqual([]);
+    expect(result.progress.overallPercent).toBeGreaterThanOrEqual(0);
+  });
+
+  it("전체 연결 데이터가 있는 아이템 — 모든 필드 반환", async () => {
+    seedItem();
+
+    seed(`INSERT INTO biz_item_classifications (id, biz_item_id, item_type, confidence)
+          VALUES ('cls-1', 'item-1', '기술형', 0.92)`);
+    seed(`INSERT INTO biz_evaluations (id, biz_item_id, verdict, avg_score, total_concerns)
+          VALUES ('eval-1', 'item-1', 'APPROVED', 4.2, 1)`);
+    seed(`INSERT INTO biz_evaluation_scores (id, evaluation_id, persona_id, business_viability, strategic_fit, customer_value)
+          VALUES ('score-1', 'eval-1', 'pm', 4.5, 4.0, 4.1)`);
+    seed(`INSERT INTO biz_item_starting_points (id, biz_item_id, starting_point, confidence)
+          VALUES ('sp-1', 'item-1', 'tech', 0.85)`);
+    seed(`INSERT INTO biz_discovery_criteria (biz_item_id, criterion_id, status, completed_at)
+          VALUES ('item-1', 1, 'completed', '2026-01-01')`);
+    seed(`INSERT INTO business_plan_drafts (id, biz_item_id, version, content, generated_at)
+          VALUES ('bp-1', 'item-1', 1, '{}', '2026-01-02')`);
+    seed(`INSERT INTO offerings (id, org_id, biz_item_id, title, purpose, format, created_by)
+          VALUES ('off-1', 'org-1', 'item-1', '제안서', 'proposal', 'html', 'user-1')`);
+    seed(`INSERT INTO prototypes (id, biz_item_id, version, content, generated_at)
+          VALUES ('proto-1', 'item-1', 1, '<html/>', '2026-01-03')`);
+    seed(`INSERT INTO offering_prototypes (id, offering_id, prototype_id)
+          VALUES ('op-1', 'off-1', 'proto-1')`);
+    seed(`INSERT INTO pipeline_stages (id, biz_item_id, org_id, stage, entered_by)
+          VALUES ('ps-1', 'item-1', 'org-1', 'DISCOVERY', 'user-1')`);
+
+    const result = await service.getPortfolioTree("item-1", "org-1");
+
+    expect(result.classification?.itemType).toBe("기술형");
+    expect(result.evaluations).toHaveLength(1);
+    expect(result.evaluations[0]!.scores).toHaveLength(1);
+    expect(result.startingPoint?.startingPoint).toBe("tech");
+    expect(result.criteria).toHaveLength(1);
+    expect(result.criteria[0]!.status).toBe("completed");
+    expect(result.businessPlans).toHaveLength(1);
+    expect(result.offerings).toHaveLength(1);
+    expect(result.offerings[0]!.linkedPrototypeIds).toContain("proto-1");
+    expect(result.prototypes).toHaveLength(1);
+    expect(result.pipelineStages).toHaveLength(1);
+    expect(result.pipelineStages[0]!.stage).toBe("DISCOVERY");
+  });
+
+  it("progress 계산 — criteria 5/9 완료 + plan 있음 + offering 없음", () => {
+    const stages = [{ stage: "FORMALIZATION" }];
+    const criteria = [
+      ...Array(5).fill({ status: "completed" }),
+      ...Array(4).fill({ status: "pending" }),
+    ];
+    const plans = [{}];
+    const offerings: unknown[] = [];
+    const prototypes: unknown[] = [];
+
+    const progress = service.calculateProgress(stages, criteria, plans, offerings, prototypes);
+
+    // 단계진입: 3/6 * 30 = 15 + 기준: 5/9 * 25 ≈ 13.88 + 기획서: 15 = ~43.88 → 44
+    expect(progress.currentStage).toBe("FORMALIZATION");
+    expect(progress.completedStages).toEqual(["REGISTERED", "DISCOVERY", "FORMALIZATION"]);
+    expect(progress.criteriaCompleted).toBe(5);
+    expect(progress.hasBusinessPlan).toBe(true);
+    expect(progress.hasOffering).toBe(false);
+    expect(progress.overallPercent).toBe(44);
+  });
+
+  it("progress — 빈 stages는 REGISTERED로 처리", () => {
+    const progress = service.calculateProgress([], [], [], [], []);
+    expect(progress.currentStage).toBe("REGISTERED");
+    expect(progress.completedStages).toEqual(["REGISTERED"]);
+    expect(progress.overallPercent).toBeGreaterThan(0);
+  });
+});

--- a/packages/api/src/core/discovery/routes/biz-items.ts
+++ b/packages/api/src/core/discovery/routes/biz-items.ts
@@ -47,6 +47,8 @@ import { BpPrdGenerator } from "../../offering/services/bp-prd-generator.js";
 import { PrdInterviewService } from "../../offering/services/prd-interview-service.js";
 import { GeneratePrdFromBpSchema } from "../../offering/schemas/bp-prd.js";
 import { StartInterviewSchema, AnswerInterviewSchema } from "../../offering/schemas/prd-interview.js";
+// Sprint 223 imports (F459)
+import { PortfolioService, NotFoundError } from "../services/portfolio-service.js";
 
 export const bizItemsRoute = new Hono<{ Bindings: Env; Variables: TenantVariables }>();
 
@@ -1257,5 +1259,23 @@ bizItemsRoute.patch("/biz-items/:bizItemId/prds/:prdId", async (c) => {
       if (err.message === "READ_ONLY") return c.json({ error: "READ_ONLY", message: "1차 PRD는 읽기 전용이에요" }, 403);
     }
     throw err;
+  }
+});
+
+// ─── GET /biz-items/:id/portfolio — 포트폴리오 연결 구조 검색 (F459, Sprint 223) ───
+
+bizItemsRoute.get("/biz-items/:id/portfolio", async (c) => {
+  const orgId = c.get("orgId");
+  const bizItemId = c.req.param("id");
+
+  const service = new PortfolioService(c.env.DB);
+  try {
+    const portfolio = await service.getPortfolioTree(bizItemId, orgId);
+    return c.json({ data: portfolio });
+  } catch (err) {
+    if (err instanceof NotFoundError) {
+      return c.json({ error: err.message }, 404);
+    }
+    return c.json({ error: "포트폴리오 조회 중 오류가 발생했어요" }, 500);
   }
 });

--- a/packages/api/src/core/discovery/schemas/portfolio.ts
+++ b/packages/api/src/core/discovery/schemas/portfolio.ts
@@ -1,0 +1,114 @@
+/**
+ * Sprint 223: F459 포트폴리오 연결 구조 검색 스키마
+ */
+import { z } from "zod";
+
+export const PortfolioClassificationSchema = z
+  .object({
+    itemType: z.string(),
+    confidence: z.number(),
+    classifiedAt: z.string(),
+  })
+  .nullable();
+
+export const PortfolioEvaluationScoreSchema = z.object({
+  personaId: z.string(),
+  businessViability: z.number(),
+  strategicFit: z.number(),
+  customerValue: z.number(),
+  summary: z.string().nullable(),
+});
+
+export const PortfolioEvaluationSchema = z.object({
+  id: z.string(),
+  verdict: z.string(),
+  avgScore: z.number(),
+  totalConcerns: z.number(),
+  evaluatedAt: z.string(),
+  scores: z.array(PortfolioEvaluationScoreSchema),
+});
+
+export const PortfolioStartingPointSchema = z
+  .object({
+    startingPoint: z.enum(["idea", "market", "problem", "tech", "service"]),
+    confidence: z.number(),
+    reasoning: z.string().nullable(),
+  })
+  .nullable();
+
+export const PortfolioCriterionSchema = z.object({
+  criterionId: z.number(),
+  status: z.enum(["pending", "in_progress", "completed", "needs_revision"]),
+  evidence: z.string().nullable(),
+  completedAt: z.string().nullable(),
+});
+
+export const PortfolioBusinessPlanSchema = z.object({
+  id: z.string(),
+  version: z.number(),
+  modelUsed: z.string().nullable(),
+  generatedAt: z.string(),
+});
+
+export const PortfolioOfferingSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  purpose: z.enum(["report", "proposal", "review"]),
+  format: z.enum(["html", "pptx"]),
+  status: z.string(),
+  currentVersion: z.number(),
+  sectionsCount: z.number(),
+  versionsCount: z.number(),
+  linkedPrototypeIds: z.array(z.string()),
+});
+
+export const PortfolioPrototypeSchema = z.object({
+  id: z.string(),
+  version: z.number(),
+  format: z.string(),
+  templateUsed: z.string().nullable(),
+  generatedAt: z.string(),
+});
+
+export const PortfolioPipelineStageSchema = z.object({
+  stage: z.string(),
+  enteredAt: z.string(),
+  exitedAt: z.string().nullable(),
+  notes: z.string().nullable(),
+});
+
+export const PortfolioProgressSchema = z.object({
+  currentStage: z.string(),
+  completedStages: z.array(z.string()),
+  criteriaCompleted: z.number(),
+  criteriaTotal: z.number(),
+  hasBusinessPlan: z.boolean(),
+  hasOffering: z.boolean(),
+  hasPrototype: z.boolean(),
+  overallPercent: z.number(),
+});
+
+export const PortfolioTreeSchema = z.object({
+  item: z.object({
+    id: z.string(),
+    title: z.string(),
+    description: z.string().nullable(),
+    source: z.string(),
+    status: z.string(),
+    createdAt: z.string(),
+  }),
+  classification: PortfolioClassificationSchema,
+  evaluations: z.array(PortfolioEvaluationSchema),
+  startingPoint: PortfolioStartingPointSchema,
+  criteria: z.array(PortfolioCriterionSchema),
+  businessPlans: z.array(PortfolioBusinessPlanSchema),
+  offerings: z.array(PortfolioOfferingSchema),
+  prototypes: z.array(PortfolioPrototypeSchema),
+  pipelineStages: z.array(PortfolioPipelineStageSchema),
+  progress: PortfolioProgressSchema,
+});
+
+export type PortfolioTree = z.infer<typeof PortfolioTreeSchema>;
+export type PortfolioProgress = z.infer<typeof PortfolioProgressSchema>;
+export type PortfolioOffering = z.infer<typeof PortfolioOfferingSchema>;
+export type PortfolioEvaluation = z.infer<typeof PortfolioEvaluationSchema>;

--- a/packages/api/src/core/discovery/services/portfolio-service.ts
+++ b/packages/api/src/core/discovery/services/portfolio-service.ts
@@ -1,0 +1,380 @@
+/**
+ * Sprint 223: F459 포트폴리오 연결 구조 검색 서비스
+ *
+ * D1 환경에서 복잡한 JOIN 대신 개별 쿼리 8개를 Promise.all로 병렬 실행하여 트리를 조립해요.
+ */
+
+import type { PortfolioTree, PortfolioProgress, PortfolioOffering } from "../schemas/portfolio.js";
+
+export class NotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NotFoundError";
+  }
+}
+
+interface RawBizItem {
+  id: string;
+  title: string;
+  description: string | null;
+  source: string;
+  status: string;
+  created_at: string;
+}
+
+interface RawClassification {
+  item_type: string;
+  confidence: number;
+  classified_at: string;
+}
+
+interface RawEvaluation {
+  id: string;
+  verdict: string;
+  avg_score: number;
+  total_concerns: number;
+  evaluated_at: string;
+}
+
+interface RawEvaluationScore {
+  evaluation_id: string;
+  persona_id: string;
+  business_viability: number;
+  strategic_fit: number;
+  customer_value: number;
+  summary: string | null;
+}
+
+interface RawStartingPoint {
+  starting_point: string;
+  confidence: number;
+  reasoning: string | null;
+}
+
+interface RawCriterion {
+  criterion_id: number;
+  status: string;
+  evidence: string | null;
+  completed_at: string | null;
+}
+
+interface RawBusinessPlan {
+  id: string;
+  version: number;
+  model_used: string | null;
+  generated_at: string;
+}
+
+interface RawOffering {
+  id: string;
+  title: string;
+  purpose: string;
+  format: string;
+  status: string;
+  current_version: number;
+  sections_count: number;
+  versions_count: number;
+}
+
+interface RawPrototype {
+  id: string;
+  version: number;
+  format: string;
+  template_used: string | null;
+  generated_at: string;
+}
+
+interface RawPipelineStage {
+  stage: string;
+  entered_at: string;
+  exited_at: string | null;
+  notes: string | null;
+}
+
+interface RawOfferingPrototype {
+  offering_id: string;
+  prototype_id: string;
+}
+
+const STAGE_ORDER = ["REGISTERED", "DISCOVERY", "FORMALIZATION", "REVIEW", "DECISION", "OFFERING"];
+
+export class PortfolioService {
+  constructor(private db: D1Database) {}
+
+  async getPortfolioTree(bizItemId: string, orgId: string): Promise<PortfolioTree> {
+    const item = await this.getBizItem(bizItemId, orgId);
+    if (!item) throw new NotFoundError("사업 아이템을 찾을 수 없어요");
+
+    // 8개 쿼리 병렬 실행
+    const [
+      classification,
+      evaluations,
+      startingPoint,
+      criteria,
+      businessPlans,
+      offerings,
+      prototypes,
+      pipelineStages,
+    ] = await Promise.all([
+      this.getClassification(bizItemId),
+      this.getEvaluationsWithScores(bizItemId),
+      this.getStartingPoint(bizItemId),
+      this.getCriteria(bizItemId),
+      this.getBusinessPlans(bizItemId),
+      this.getOfferingsWithCounts(bizItemId),
+      this.getPrototypes(bizItemId),
+      this.getPipelineStages(bizItemId),
+    ]);
+
+    // offering ↔ prototype 연결
+    const offeringIds = offerings.map((o) => o.id);
+    const offeringsWithPrototypes = offeringIds.length > 0
+      ? await this.attachPrototypesToOfferings(offerings, offeringIds)
+      : offerings;
+
+    const progress = this.calculateProgress(pipelineStages, criteria, businessPlans, offerings, prototypes);
+
+    return {
+      item: {
+        id: item.id,
+        title: item.title,
+        description: item.description,
+        source: item.source,
+        status: item.status,
+        createdAt: item.created_at,
+      },
+      classification,
+      evaluations,
+      startingPoint,
+      criteria,
+      businessPlans,
+      offerings: offeringsWithPrototypes,
+      prototypes,
+      pipelineStages,
+      progress,
+    };
+  }
+
+  private async getBizItem(bizItemId: string, orgId: string): Promise<RawBizItem | null> {
+    return this.db
+      .prepare("SELECT id, title, description, source, status, created_at FROM biz_items WHERE id = ? AND org_id = ?")
+      .bind(bizItemId, orgId)
+      .first<RawBizItem>();
+  }
+
+  private async getClassification(bizItemId: string) {
+    const row = await this.db
+      .prepare("SELECT item_type, confidence, classified_at FROM biz_item_classifications WHERE biz_item_id = ?")
+      .bind(bizItemId)
+      .first<RawClassification>();
+
+    if (!row) return null;
+    return {
+      itemType: row.item_type,
+      confidence: row.confidence,
+      classifiedAt: row.classified_at,
+    };
+  }
+
+  private async getEvaluationsWithScores(bizItemId: string) {
+    const { results: evals } = await this.db
+      .prepare("SELECT id, verdict, avg_score, total_concerns, evaluated_at FROM biz_evaluations WHERE biz_item_id = ? ORDER BY evaluated_at DESC")
+      .bind(bizItemId)
+      .all<RawEvaluation>();
+
+    if (evals.length === 0) return [];
+
+    const evalIds = evals.map((e) => e.id);
+    const placeholders = evalIds.map(() => "?").join(",");
+    const { results: scores } = await this.db
+      .prepare(`SELECT evaluation_id, persona_id, business_viability, strategic_fit, customer_value, summary FROM biz_evaluation_scores WHERE evaluation_id IN (${placeholders})`)
+      .bind(...evalIds)
+      .all<RawEvaluationScore>();
+
+    const scoresByEval = new Map<string, RawEvaluationScore[]>();
+    for (const s of scores) {
+      const arr = scoresByEval.get(s.evaluation_id) ?? [];
+      arr.push(s);
+      scoresByEval.set(s.evaluation_id, arr);
+    }
+
+    return evals.map((e) => ({
+      id: e.id,
+      verdict: e.verdict,
+      avgScore: e.avg_score,
+      totalConcerns: e.total_concerns,
+      evaluatedAt: e.evaluated_at,
+      scores: (scoresByEval.get(e.id) ?? []).map((s) => ({
+        personaId: s.persona_id,
+        businessViability: s.business_viability,
+        strategicFit: s.strategic_fit,
+        customerValue: s.customer_value,
+        summary: s.summary,
+      })),
+    }));
+  }
+
+  private async getStartingPoint(bizItemId: string) {
+    const row = await this.db
+      .prepare("SELECT starting_point, confidence, reasoning FROM biz_item_starting_points WHERE biz_item_id = ?")
+      .bind(bizItemId)
+      .first<RawStartingPoint>();
+
+    if (!row) return null;
+    return {
+      startingPoint: row.starting_point as "idea" | "market" | "problem" | "tech" | "service",
+      confidence: row.confidence,
+      reasoning: row.reasoning,
+    };
+  }
+
+  private async getCriteria(bizItemId: string) {
+    const { results } = await this.db
+      .prepare("SELECT criterion_id, status, evidence, completed_at FROM biz_discovery_criteria WHERE biz_item_id = ? ORDER BY criterion_id")
+      .bind(bizItemId)
+      .all<RawCriterion>();
+
+    return results.map((r) => ({
+      criterionId: r.criterion_id,
+      status: r.status as "pending" | "in_progress" | "completed" | "needs_revision",
+      evidence: r.evidence,
+      completedAt: r.completed_at,
+    }));
+  }
+
+  private async getBusinessPlans(bizItemId: string) {
+    const { results } = await this.db
+      .prepare("SELECT id, version, model_used, generated_at FROM business_plan_drafts WHERE biz_item_id = ? ORDER BY version DESC")
+      .bind(bizItemId)
+      .all<RawBusinessPlan>();
+
+    return results.map((r) => ({
+      id: r.id,
+      version: r.version,
+      modelUsed: r.model_used,
+      generatedAt: r.generated_at,
+    }));
+  }
+
+  private async getOfferingsWithCounts(bizItemId: string): Promise<PortfolioOffering[]> {
+    const { results: offs } = await this.db
+      .prepare("SELECT id, title, purpose, format, status, current_version FROM offerings WHERE biz_item_id = ?")
+      .bind(bizItemId)
+      .all<RawOffering>();
+
+    if (offs.length === 0) return [];
+
+    // 각 offering의 섹션/버전 카운트 조회
+    const enriched = await Promise.all(
+      offs.map(async (o) => {
+        const [sectionsResult, versionsResult] = await Promise.all([
+          this.db
+            .prepare("SELECT COUNT(*) as cnt FROM offering_sections WHERE offering_id = ?")
+            .bind(o.id)
+            .first<{ cnt: number }>(),
+          this.db
+            .prepare("SELECT COUNT(*) as cnt FROM offering_versions WHERE offering_id = ?")
+            .bind(o.id)
+            .first<{ cnt: number }>(),
+        ]);
+
+        return {
+          id: o.id,
+          title: o.title,
+          purpose: o.purpose as "report" | "proposal" | "review",
+          format: o.format as "html" | "pptx",
+          status: o.status,
+          currentVersion: o.current_version,
+          sectionsCount: sectionsResult?.cnt ?? 0,
+          versionsCount: versionsResult?.cnt ?? 0,
+          linkedPrototypeIds: [] as string[],
+        };
+      }),
+    );
+
+    return enriched;
+  }
+
+  private async getPrototypes(bizItemId: string) {
+    const { results } = await this.db
+      .prepare("SELECT id, version, format, template_used, generated_at FROM prototypes WHERE biz_item_id = ? ORDER BY version DESC")
+      .bind(bizItemId)
+      .all<RawPrototype>();
+
+    return results.map((r) => ({
+      id: r.id,
+      version: r.version,
+      format: r.format,
+      templateUsed: r.template_used,
+      generatedAt: r.generated_at,
+    }));
+  }
+
+  private async getPipelineStages(bizItemId: string) {
+    const { results } = await this.db
+      .prepare("SELECT stage, entered_at, exited_at, notes FROM pipeline_stages WHERE biz_item_id = ? ORDER BY entered_at ASC")
+      .bind(bizItemId)
+      .all<RawPipelineStage>();
+
+    return results.map((r) => ({
+      stage: r.stage,
+      enteredAt: r.entered_at,
+      exitedAt: r.exited_at,
+      notes: r.notes,
+    }));
+  }
+
+  private async attachPrototypesToOfferings(
+    offerings: PortfolioOffering[],
+    offeringIds: string[],
+  ): Promise<PortfolioOffering[]> {
+    const placeholders = offeringIds.map(() => "?").join(",");
+    const { results } = await this.db
+      .prepare(`SELECT offering_id, prototype_id FROM offering_prototypes WHERE offering_id IN (${placeholders})`)
+      .bind(...offeringIds)
+      .all<RawOfferingPrototype>();
+
+    const linkMap = new Map<string, string[]>();
+    for (const r of results) {
+      const arr = linkMap.get(r.offering_id) ?? [];
+      arr.push(r.prototype_id);
+      linkMap.set(r.offering_id, arr);
+    }
+
+    return offerings.map((o) => ({
+      ...o,
+      linkedPrototypeIds: linkMap.get(o.id) ?? [],
+    }));
+  }
+
+  calculateProgress(
+    stages: Array<{ stage: string }>,
+    criteria: Array<{ status: string }>,
+    plans: unknown[],
+    offerings: unknown[],
+    prototypes: unknown[],
+  ): PortfolioProgress {
+    const currentStage = stages.length > 0 ? stages[stages.length - 1]!.stage : "REGISTERED";
+    const stageIdx = STAGE_ORDER.indexOf(currentStage);
+    const completedStages = STAGE_ORDER.slice(0, stageIdx + 1);
+    const criteriaCompleted = criteria.filter((c) => c.status === "completed").length;
+
+    // 가중치 기반 진행률: 단계진입 30% + 기준완료 25% + 기획서 15% + Offering 15% + Prototype 15%
+    const stagePercent = (completedStages.length / STAGE_ORDER.length) * 30;
+    const criteriaPercent = (criteriaCompleted / 9) * 25;
+    const planPercent = plans.length > 0 ? 15 : 0;
+    const offeringPercent = offerings.length > 0 ? 15 : 0;
+    const prototypePercent = prototypes.length > 0 ? 15 : 0;
+
+    return {
+      currentStage,
+      completedStages,
+      criteriaCompleted,
+      criteriaTotal: 9,
+      hasBusinessPlan: plans.length > 0,
+      hasOffering: offerings.length > 0,
+      hasPrototype: prototypes.length > 0,
+      overallPercent: Math.round(stagePercent + criteriaPercent + planPercent + offeringPercent + prototypePercent),
+    };
+  }
+}

--- a/packages/web/src/__tests__/portfolio-view.test.tsx
+++ b/packages/web/src/__tests__/portfolio-view.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * Sprint 223: F460 포트폴리오 컴포넌트 테스트
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { PipelineProgressBar } from "../components/feature/discovery/PipelineProgressBar";
+import { PortfolioView } from "../components/feature/discovery/PortfolioView";
+import type { PortfolioTree } from "../lib/api-client";
+
+// Mock api-client
+vi.mock("@/lib/api-client", () => ({
+  fetchApi: vi.fn(),
+  fetchPortfolio: vi.fn(),
+  BASE_URL: "/api",
+}));
+
+import { fetchApi, fetchPortfolio } from "@/lib/api-client";
+
+const mockFetchApi = vi.mocked(fetchApi);
+const mockFetchPortfolio = vi.mocked(fetchPortfolio);
+
+function makePortfolioTree(overrides: Partial<PortfolioTree> = {}): PortfolioTree {
+  return {
+    item: { id: "item-1", title: "AI 품질예측", description: null, source: "field", status: "draft", createdAt: "2026-01-01" },
+    classification: { itemType: "기술형", confidence: 0.92, classifiedAt: "2026-01-01" },
+    evaluations: [],
+    startingPoint: null,
+    criteria: [],
+    businessPlans: [{ id: "bp-1", version: 1, modelUsed: null, generatedAt: "2026-01-02" }],
+    offerings: [{ id: "off-1", title: "제안서", purpose: "proposal", format: "html", status: "draft", currentVersion: 1, sectionsCount: 3, versionsCount: 1, linkedPrototypeIds: ["proto-1"] }],
+    prototypes: [{ id: "proto-1", version: 1, format: "html", templateUsed: null, generatedAt: "2026-01-03" }],
+    pipelineStages: [{ stage: "DISCOVERY", enteredAt: "2026-01-01", exitedAt: null, notes: null }],
+    progress: {
+      currentStage: "DISCOVERY",
+      completedStages: ["REGISTERED", "DISCOVERY"],
+      criteriaCompleted: 0,
+      criteriaTotal: 9,
+      hasBusinessPlan: true,
+      hasOffering: true,
+      hasPrototype: true,
+      overallPercent: 45,
+    },
+    ...overrides,
+  };
+}
+
+describe("PipelineProgressBar", () => {
+  it("FORMALIZATION 단계 — 3개 filled, 3개 empty", () => {
+    const { container } = render(
+      <PipelineProgressBar
+        currentStage="FORMALIZATION"
+        completedStages={["REGISTERED", "DISCOVERY", "FORMALIZATION"]}
+        overallPercent={50}
+      />,
+    );
+
+    // 완료(green-500) 스텝 3개, 미래(bg-muted) 스텝 3개
+    const steps = container.querySelectorAll("[class*='rounded-full']");
+    const greenSteps = Array.from(steps).filter((el) => el.className.includes("green-500"));
+    const mutedSteps = Array.from(steps).filter((el) => el.className.includes("bg-muted"));
+
+    expect(greenSteps.length).toBe(3);
+    expect(mutedSteps.length).toBe(3);
+  });
+
+  it("진행률 % 텍스트 표시", () => {
+    const { getByText } = render(
+      <PipelineProgressBar
+        currentStage="REGISTERED"
+        completedStages={["REGISTERED"]}
+        overallPercent={17}
+      />,
+    );
+    expect(getByText("17%")).toBeDefined();
+  });
+
+  it("6단계 라벨 렌더링 (compact=false)", () => {
+    const { getByText } = render(
+      <PipelineProgressBar
+        currentStage="REGISTERED"
+        completedStages={["REGISTERED"]}
+        overallPercent={5}
+      />,
+    );
+    // 6개 라벨 중 하나라도 존재해야 함
+    expect(getByText("등록")).toBeDefined();
+    expect(getByText("발굴")).toBeDefined();
+  });
+});
+
+describe("PortfolioView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("아이템 0건 — 빈 상태 메시지 표시", async () => {
+    mockFetchApi.mockResolvedValue([]);
+
+    const { findByText } = render(
+      <MemoryRouter>
+        <PortfolioView />
+      </MemoryRouter>,
+    );
+    expect(await findByText("등록된 사업 아이템이 없어요")).toBeDefined();
+  });
+
+  it("아이템 목록 렌더링 + 진행률 바 표시", async () => {
+    mockFetchApi.mockResolvedValue([
+      { bizItemId: "item-1", title: "AI 품질예측", currentStage: 2 },
+    ]);
+
+    const { findByText } = render(
+      <MemoryRouter>
+        <PortfolioView />
+      </MemoryRouter>,
+    );
+    expect(await findByText("AI 품질예측")).toBeDefined();
+  });
+
+  it("아이템 선택 시 fetchPortfolio 호출", async () => {
+    mockFetchApi.mockResolvedValue([
+      { bizItemId: "item-1", title: "AI 품질예측", currentStage: 2 },
+    ]);
+    mockFetchPortfolio.mockResolvedValue(makePortfolioTree());
+
+    const { findByText, getByText } = render(
+      <MemoryRouter>
+        <PortfolioView />
+      </MemoryRouter>,
+    );
+
+    await findByText("AI 품질예측");
+    getByText("AI 품질예측").click();
+
+    // fetchPortfolio가 해당 아이템 ID로 호출되어야 함
+    await vi.waitFor(() => {
+      expect(mockFetchPortfolio).toHaveBeenCalledWith("item-1");
+    });
+  });
+});

--- a/packages/web/src/components/feature/discovery/PipelineProgressBar.tsx
+++ b/packages/web/src/components/feature/discovery/PipelineProgressBar.tsx
@@ -1,0 +1,76 @@
+/**
+ * Sprint 223: F460 — 아이템별 파이프라인 6단계 진행률 바
+ */
+
+interface PipelineProgressBarProps {
+  currentStage: string;
+  completedStages: string[];
+  overallPercent: number;
+  compact?: boolean;
+}
+
+const PIPELINE_STAGES = [
+  { key: "REGISTERED", label: "등록" },
+  { key: "DISCOVERY", label: "발굴" },
+  { key: "FORMALIZATION", label: "형상화" },
+  { key: "REVIEW", label: "검토" },
+  { key: "DECISION", label: "결정" },
+  { key: "OFFERING", label: "오퍼링" },
+];
+
+export function PipelineProgressBar({
+  currentStage,
+  completedStages,
+  overallPercent,
+  compact = false,
+}: PipelineProgressBarProps) {
+  return (
+    <div className={compact ? "space-y-1" : "space-y-2"}>
+      <div className="flex items-center gap-1">
+        {PIPELINE_STAGES.map((s, i) => {
+          const isCompleted = completedStages.includes(s.key);
+          const isCurrent = s.key === currentStage;
+          const isFuture = !isCompleted && !isCurrent;
+
+          return (
+            <div key={s.key} className="flex items-center">
+              {/* 스텝 아이콘 */}
+              <div className="flex flex-col items-center gap-0.5">
+                <div
+                  title={s.label}
+                  className={[
+                    "h-3 w-3 rounded-full transition-all",
+                    isCompleted ? "bg-green-500" : "",
+                    isCurrent ? "animate-pulse bg-blue-500" : "",
+                    isFuture ? "bg-muted" : "",
+                  ].join(" ")}
+                />
+                {!compact && (
+                  <span className={["text-[9px] leading-none", isFuture ? "text-muted-foreground" : "text-foreground"].join(" ")}>
+                    {s.label}
+                  </span>
+                )}
+              </div>
+              {/* 연결선 */}
+              {i < PIPELINE_STAGES.length - 1 && (
+                <div
+                  className={[
+                    "mx-0.5 h-px w-4",
+                    completedStages.includes(PIPELINE_STAGES[i + 1]!.key) || isCurrent
+                      ? "bg-green-400"
+                      : "bg-muted",
+                  ].join(" ")}
+                />
+              )}
+            </div>
+          );
+        })}
+
+        {/* 진행률 % */}
+        <span className="ml-2 text-xs font-medium tabular-nums text-muted-foreground">
+          {overallPercent}%
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/feature/discovery/PortfolioGraph.tsx
+++ b/packages/web/src/components/feature/discovery/PortfolioGraph.tsx
@@ -1,0 +1,117 @@
+/**
+ * Sprint 223: F460 — 포트폴리오 문서 연결 그래프 (Mermaid flowchart)
+ */
+import { useEffect, useRef } from "react";
+import type { PortfolioTree } from "@/lib/api-client";
+
+interface PortfolioGraphProps {
+  portfolio: PortfolioTree;
+}
+
+function buildMermaidGraph(portfolio: PortfolioTree): string {
+  const { item, classification, evaluations, startingPoint, criteria, businessPlans, offerings, prototypes } = portfolio;
+
+  const escapeLabel = (s: string) => s.replace(/["\[\]]/g, "").slice(0, 30);
+  const lines: string[] = ["graph TD"];
+
+  lines.push(`  root["🏢 ${escapeLabel(item.title)}"]`);
+
+  if (classification) {
+    lines.push(`  cls["📂 분류: ${escapeLabel(classification.itemType)}"]`);
+    lines.push("  root --> cls");
+  }
+
+  if (evaluations.length > 0) {
+    const avgScore = (evaluations.reduce((s, e) => s + e.avgScore, 0) / evaluations.length).toFixed(1);
+    lines.push(`  eval["⭐ 평가 ${evaluations.length}건 ★${avgScore}"]`);
+    lines.push("  root --> eval");
+  }
+
+  if (startingPoint) {
+    lines.push(`  sp["🚀 시작점: ${escapeLabel(startingPoint.startingPoint)}"]`);
+    lines.push("  root --> sp");
+  }
+
+  const completedCriteria = criteria.filter((c) => c.status === "completed").length;
+  if (criteria.length > 0) {
+    lines.push(`  crit["✅ 발굴기준 ${completedCriteria}/${criteria.length}"]`);
+    lines.push("  root --> crit");
+  }
+
+  if (businessPlans.length > 0) {
+    const latest = businessPlans[0]!;
+    lines.push(`  bp["📄 기획서 v${latest.version}"]`);
+    lines.push("  root --> bp");
+  }
+
+  for (const offering of offerings) {
+    const offId = `off_${offering.id.slice(0, 8)}`;
+    lines.push(`  ${offId}["📑 ${escapeLabel(offering.title)}"]`);
+    lines.push(`  root --> ${offId}`);
+
+    for (const protoId of offering.linkedPrototypeIds) {
+      const proto = prototypes.find((p) => p.id === protoId);
+      if (proto) {
+        const pId = `proto_${proto.id.slice(0, 8)}`;
+        lines.push(`  ${pId}["🖥️ Prototype v${proto.version}"]`);
+        lines.push(`  ${offId} --> ${pId}`);
+      }
+    }
+  }
+
+  // offering과 연결되지 않은 standalone prototypes
+  const linkedProtoIds = new Set(offerings.flatMap((o) => o.linkedPrototypeIds));
+  for (const proto of prototypes) {
+    if (!linkedProtoIds.has(proto.id)) {
+      const pId = `proto_${proto.id.slice(0, 8)}`;
+      lines.push(`  ${pId}["🖥️ Prototype v${proto.version}"]`);
+      lines.push(`  root --> ${pId}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export function PortfolioGraph({ portfolio }: PortfolioGraphProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const graph = buildMermaidGraph(portfolio);
+
+    // Mermaid를 동적으로 로드 (CDN)
+    const render = async () => {
+      try {
+        // @ts-expect-error mermaid는 CDN 기반 전역 로드
+        const mermaid = (window as Record<string, unknown>).mermaid as { initialize: (c: unknown) => void; render: (id: string, graph: string) => Promise<{ svg: string }> } | undefined;
+        if (!mermaid) {
+          // mermaid가 없으면 fallback: 텍스트 표시
+          if (containerRef.current) {
+            containerRef.current.innerHTML = `<pre class="text-xs text-muted-foreground whitespace-pre-wrap">${graph}</pre>`;
+          }
+          return;
+        }
+        mermaid.initialize({ startOnLoad: false, theme: "neutral" });
+        const { svg } = await mermaid.render(`portfolio-graph-${portfolio.item.id}`, graph);
+        if (containerRef.current) {
+          containerRef.current.innerHTML = svg;
+        }
+      } catch {
+        // 렌더링 실패 시 fallback
+        if (containerRef.current) {
+          containerRef.current.innerHTML = `<pre class="text-xs text-muted-foreground whitespace-pre-wrap">${graph}</pre>`;
+        }
+      }
+    };
+
+    void render();
+  }, [portfolio]);
+
+  return (
+    <div className="rounded-lg border bg-card p-4">
+      <h3 className="mb-3 text-sm font-semibold text-muted-foreground">연결 구조</h3>
+      <div ref={containerRef} data-portfolio-graph className="min-h-24 overflow-auto" />
+    </div>
+  );
+}

--- a/packages/web/src/components/feature/discovery/PortfolioView.tsx
+++ b/packages/web/src/components/feature/discovery/PortfolioView.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+/**
+ * Sprint 223: F460 — 포트폴리오 뷰 메인 컴포넌트
+ * 사업 아이템 목록 + 파이프라인 진행률 + 선택 시 연결 그래프
+ */
+import { useState, useEffect, useMemo } from "react";
+import { fetchApi, fetchPortfolio } from "@/lib/api-client";
+import type { BizItemSummary, PortfolioTree } from "@/lib/api-client";
+import { PipelineProgressBar } from "./PipelineProgressBar";
+import { PortfolioGraph } from "./PortfolioGraph";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { ChevronRight, Layers, FileText, Package } from "lucide-react";
+import LoadingSkeleton from "./LoadingSkeleton";
+
+const STAGE_FILTER_OPTIONS = [
+  { value: "all", label: "전체" },
+  { value: "REGISTERED", label: "등록" },
+  { value: "DISCOVERY", label: "발굴" },
+  { value: "FORMALIZATION", label: "형상화" },
+  { value: "REVIEW", label: "검토" },
+  { value: "DECISION", label: "결정" },
+  { value: "OFFERING", label: "오퍼링" },
+];
+
+// /biz-items/summary endpoint returns {bizItemId, title, currentStage (number)}
+// We need raw biz_items with stage string — use /biz-items for basic list
+// and overlay progress from portfolio endpoint on demand
+
+interface PortfolioSummaryItem {
+  id: string;
+  title: string;
+  status: string;
+  currentStage: number;  // 1-based stage number from summary
+  stageKey: string;      // REGISTERED | DISCOVERY | ...
+}
+
+const STAGE_KEYS = ["REGISTERED", "DISCOVERY", "FORMALIZATION", "REVIEW", "DECISION", "OFFERING"];
+
+function stageNumToKey(num: number): string {
+  return STAGE_KEYS[num - 1] ?? "REGISTERED";
+}
+
+interface PortfolioViewProps {
+  orgId?: string;
+}
+
+export function PortfolioView(_: PortfolioViewProps) {
+  const [items, setItems] = useState<PortfolioSummaryItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [portfolio, setPortfolio] = useState<PortfolioTree | null>(null);
+  const [portfolioLoading, setPortfolioLoading] = useState(false);
+  const [filter, setFilter] = useState("all");
+
+  // 아이템 목록 로드
+  useEffect(() => {
+    setLoading(true);
+    fetchApi<Array<{ bizItemId: string; title: string; currentStage: number }>>("/biz-items/summary")
+      .then((data) => {
+        setItems(
+          data.map((d) => ({
+            id: d.bizItemId,
+            title: d.title,
+            status: "draft",
+            currentStage: d.currentStage,
+            stageKey: stageNumToKey(d.currentStage),
+          })),
+        );
+      })
+      .catch(() => setItems([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  // 아이템 선택 시 포트폴리오 조회
+  useEffect(() => {
+    if (!selectedId) {
+      setPortfolio(null);
+      return;
+    }
+    setPortfolioLoading(true);
+    fetchPortfolio(selectedId)
+      .then(setPortfolio)
+      .catch(() => setPortfolio(null))
+      .finally(() => setPortfolioLoading(false));
+  }, [selectedId]);
+
+  const filteredItems = useMemo(() => {
+    if (filter === "all") return items;
+    return items.filter((item) => item.stageKey === filter);
+  }, [items, filter]);
+
+  if (loading) return <LoadingSkeleton />;
+
+  return (
+    <div className="space-y-4">
+      {/* 필터 바 */}
+      <div className="flex flex-wrap gap-2">
+        {STAGE_FILTER_OPTIONS.map((opt) => (
+          <Button
+            key={opt.value}
+            variant={filter === opt.value ? "default" : "outline"}
+            size="sm"
+            onClick={() => setFilter(opt.value)}
+          >
+            {opt.label}
+            {opt.value !== "all" && (
+              <Badge variant="secondary" className="ml-1 text-[10px]">
+                {items.filter((i) => i.stageKey === opt.value).length}
+              </Badge>
+            )}
+          </Button>
+        ))}
+      </div>
+
+      {filteredItems.length === 0 && (
+        <div className="py-12 text-center text-muted-foreground">
+          <Layers className="mx-auto mb-3 h-8 w-8 opacity-40" />
+          <p className="text-sm">등록된 사업 아이템이 없어요</p>
+        </div>
+      )}
+
+      <div className="grid gap-3">
+        {filteredItems.map((item) => (
+          <Card
+            key={item.id}
+            data-portfolio-item={item.id}
+            className={[
+              "cursor-pointer transition-all",
+              selectedId === item.id ? "ring-2 ring-primary" : "hover:shadow-sm",
+            ].join(" ")}
+            onClick={() => setSelectedId(selectedId === item.id ? null : item.id)}
+          >
+            <CardHeader className="pb-2 pt-4">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium">{item.title}</span>
+                <ChevronRight
+                  className={["h-4 w-4 text-muted-foreground transition-transform", selectedId === item.id ? "rotate-90" : ""].join(" ")}
+                />
+              </div>
+            </CardHeader>
+            <CardContent className="pb-4 pt-0">
+              <PipelineProgressBar
+                currentStage={item.stageKey}
+                completedStages={STAGE_KEYS.slice(0, item.currentStage)}
+                overallPercent={Math.round((item.currentStage / 6) * 100)}
+              />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* 선택된 아이템 상세 포트폴리오 */}
+      {selectedId && (
+        <div className="mt-4 space-y-3">
+          {portfolioLoading && <LoadingSkeleton />}
+          {portfolio && !portfolioLoading && (
+            <>
+              {/* 문서 카운트 요약 */}
+              <div className="flex flex-wrap gap-3">
+                <SummaryChip icon={<FileText className="h-3.5 w-3.5" />} label="기획서" count={portfolio.businessPlans.length} />
+                <SummaryChip icon={<Layers className="h-3.5 w-3.5" />} label="Offering" count={portfolio.offerings.length} />
+                <SummaryChip icon={<Package className="h-3.5 w-3.5" />} label="Prototype" count={portfolio.prototypes.length} />
+                <SummaryChip icon={<span className="text-[10px]">✅</span>} label={`발굴기준 ${portfolio.progress.criteriaCompleted}/${portfolio.progress.criteriaTotal}`} />
+              </div>
+              {/* 연결 그래프 */}
+              <PortfolioGraph portfolio={portfolio} />
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SummaryChip({ icon, label, count }: { icon: React.ReactNode; label: string; count?: number }) {
+  return (
+    <div className="flex items-center gap-1.5 rounded-full border bg-background px-3 py-1 text-xs text-muted-foreground">
+      {icon}
+      <span>{label}</span>
+      {count !== undefined && (
+        <Badge variant="secondary" className="ml-1 text-[10px]">{count}</Badge>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/lib/api-client.ts
+++ b/packages/web/src/lib/api-client.ts
@@ -3047,3 +3047,40 @@ export async function diffPrds(
 ): Promise<{ v1: { id: string; version: number }; v2: { id: string; version: number }; hunks: DiffHunk[] }> {
   return fetchApi(`/biz-items/${bizItemId}/prds/diff?v1=${encodeURIComponent(v1Id)}&v2=${encodeURIComponent(v2Id)}`);
 }
+
+// ─── Sprint 223: F459 포트폴리오 연결 구조 (F459) ───
+
+export interface PortfolioProgress {
+  currentStage: string;
+  completedStages: string[];
+  criteriaCompleted: number;
+  criteriaTotal: number;
+  hasBusinessPlan: boolean;
+  hasOffering: boolean;
+  hasPrototype: boolean;
+  overallPercent: number;
+}
+
+export interface PortfolioTree {
+  item: { id: string; title: string; description: string | null; source: string; status: string; createdAt: string };
+  classification: { itemType: string; confidence: number; classifiedAt: string } | null;
+  evaluations: Array<{
+    id: string; verdict: string; avgScore: number; totalConcerns: number; evaluatedAt: string;
+    scores: Array<{ personaId: string; businessViability: number; strategicFit: number; customerValue: number; summary: string | null }>;
+  }>;
+  startingPoint: { startingPoint: string; confidence: number; reasoning: string | null } | null;
+  criteria: Array<{ criterionId: number; status: string; evidence: string | null; completedAt: string | null }>;
+  businessPlans: Array<{ id: string; version: number; modelUsed: string | null; generatedAt: string }>;
+  offerings: Array<{
+    id: string; title: string; purpose: string; format: string; status: string;
+    currentVersion: number; sectionsCount: number; versionsCount: number; linkedPrototypeIds: string[];
+  }>;
+  prototypes: Array<{ id: string; version: number; format: string; templateUsed: string | null; generatedAt: string }>;
+  pipelineStages: Array<{ stage: string; enteredAt: string; exitedAt: string | null; notes: string | null }>;
+  progress: PortfolioProgress;
+}
+
+export async function fetchPortfolio(bizItemId: string): Promise<PortfolioTree> {
+  const res = await fetchApi<{ data: PortfolioTree }>(`/biz-items/${bizItemId}/portfolio`);
+  return res.data;
+}

--- a/packages/web/src/routes/ax-bd/discovery.tsx
+++ b/packages/web/src/routes/ax-bd/discovery.tsx
@@ -4,11 +4,13 @@
  * Sprint 94: F263 + F265 — Discovery 페이지 위저드 중심 재구성
  * Sprint 100: F269 — 프로세스 가이드 탭 통합
  * F449 — ErrorBoundary 래핑
+ * Sprint 223: F460 — 포트폴리오 탭 추가
  */
 import { useSearchParams } from "react-router-dom";
 import DiscoveryWizard from "@/components/feature/discovery/DiscoveryWizard";
 import DiscoveryTour from "@/components/feature/discovery/DiscoveryTour";
 import ProcessGuide from "@/components/feature/ax-bd/ProcessGuide";
+import { PortfolioView } from "@/components/feature/discovery/PortfolioView";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import ErrorBoundary from "@/components/feature/discovery/ErrorBoundary";
 
@@ -27,6 +29,7 @@ export function Component() {
           <TabsList>
             <TabsTrigger value="wizard">Discovery 위저드</TabsTrigger>
             <TabsTrigger value="guide">프로세스 가이드</TabsTrigger>
+            <TabsTrigger value="portfolio">포트폴리오</TabsTrigger>
           </TabsList>
 
           <TabsContent value="wizard" className="space-y-8">
@@ -36,6 +39,10 @@ export function Component() {
 
           <TabsContent value="guide">
             <ProcessGuide />
+          </TabsContent>
+
+          <TabsContent value="portfolio">
+            <PortfolioView />
           </TabsContent>
         </Tabs>
       </div>

--- a/packages/web/src/routes/dashboard.tsx
+++ b/packages/web/src/routes/dashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import { Link } from "react-router-dom";
 import { fetchApi } from "@/lib/api-client";
 import type {
@@ -85,6 +85,16 @@ const stageColors = [
   "bg-rose-500",
 ];
 
+// BD 파이프라인 단계 키(stage 번호 1-6) → DB 스테이지명 매핑
+const STAGE_NUM_TO_DB_KEY: Record<number, string> = {
+  1: "REGISTERED",
+  2: "DISCOVERY",
+  3: "FORMALIZATION",
+  4: "REVIEW",
+  5: "DECISION",
+  6: "OFFERING",
+};
+
 function ProcessPipeline({ stats }: { stats: PipelineStats | null }) {
   return (
     <div className="rounded-lg border bg-card p-5">
@@ -93,7 +103,8 @@ function ProcessPipeline({ stats }: { stats: PipelineStats | null }) {
       </h2>
       <div className="flex items-center gap-1">
         {STAGES.map((stage, i) => {
-          const count = stats?.byStage?.[stage.label] ?? 0;
+          const dbKey = STAGE_NUM_TO_DB_KEY[stage.stage] ?? stage.label;
+          const count = stats?.byStage?.[dbKey] ?? stats?.byStage?.[stage.label] ?? 0;
           return (
             <div key={stage.stage} className="flex items-center">
               <Link
@@ -166,12 +177,35 @@ function QuickActions() {
 /*  Dashboard Page                                                     */
 /* ------------------------------------------------------------------ */
 
+// Sprint 223: F460 — /biz-items/summary로 파이프라인 카운트 실제 데이터 연동
+const BD_STAGE_KEYS = ["REGISTERED", "DISCOVERY", "FORMALIZATION", "REVIEW", "DECISION", "OFFERING"];
+
 export function Component() {
   const health = useApi<HealthScore>("/health");
   const reqs = useApi<RequirementItem[]>("/requirements");
   const integrity = useApi<HarnessIntegrity>("/integrity");
   const freshness = useApi<FreshnessReport>("/freshness");
   const pipelineStats = useApi<PipelineStats>("/pipeline/stats");
+  const bizItemSummary = useApi<Array<{ bizItemId: string; title: string; currentStage: number }>>("/biz-items/summary");
+
+  // biz-items/summary → byStage (stageNum 기반 집계)
+  const bdByStage = useMemo(() => {
+    if (!bizItemSummary.data) return {};
+    const counts: Record<string, number> = {};
+    for (const item of bizItemSummary.data) {
+      const key = BD_STAGE_KEYS[item.currentStage - 1] ?? "REGISTERED";
+      counts[key] = (counts[key] ?? 0) + 1;
+    }
+    return counts;
+  }, [bizItemSummary.data]);
+
+  // pipeline/stats byStage 키가 DB 스테이지명(DISCOVERY 등)이지만,
+  // dashboard STAGES.label은 한국어(수집, 발굴...) — 실제 수치는 bizItemSummary로 보완
+  const mergedStats: PipelineStats | null = pipelineStats.data
+    ? { ...pipelineStats.data, byStage: bdByStage }
+    : bizItemSummary.data
+      ? { totalItems: bizItemSummary.data.length, byStage: bdByStage, avgDaysInStage: {} }
+      : null;
 
   const reqCounts = reqs.data
     ? {
@@ -186,7 +220,7 @@ export function Component() {
       <h1 className="mb-6 text-2xl font-bold">홈</h1>
 
       {/* 프로세스 파이프라인 (상단 메인) */}
-      <ProcessPipeline stats={pipelineStats.data} />
+      <ProcessPipeline stats={mergedStats} />
 
       {/* 퀵 액션 + Sprint Status */}
       <div className="mt-4 grid gap-4 md:grid-cols-2">


### PR DESCRIPTION
## Sprint 223: 포트폴리오 연결 구조 검색 + 대시보드

### F459: GET /biz-items/:id/portfolio (포트폴리오 연결 구조 검색)
- **PortfolioService**: 8개 테이블 개별 쿼리 `Promise.all` 병렬 실행 → 트리 조립 (D1 JOIN 불안정성 회피)
- **Zod 스키마**: PortfolioTree (classification / evaluations / startingPoint / criteria / businessPlans / offerings / prototypes / pipelineStages / progress)
- **진행률 계산**: 가중치 기반 (단계진입 30% + 기준완료 25% + 기획서 15% + Offering 15% + Prototype 15%)
- **에러 처리**: NotFoundError (404) + org_id 권한 차단

### F460: 포트폴리오 대시보드 UI
- **PipelineProgressBar**: 6단계 스텝 아이콘 (완료=green, 현재=pulse/blue, 미래=muted)
- **PortfolioGraph**: Mermaid flowchart 기반 문서 연결 시각화 (CDN 기반, fallback 제공)
- **PortfolioView**: 아이템 카드 목록 + 단계별 필터 + 선택 시 문서 카운트 요약 + 연결 그래프
- **discovery.tsx**: `포트폴리오` 탭 추가 (Discovery 위저드 / 프로세스 가이드 / 포트폴리오)
- **dashboard.tsx**: `/biz-items/summary`로 파이프라인 카운트 실제 데이터 연동 (0 하드코딩 해소)

### 테스트
- API: `portfolio-service.test.ts` 6건 + `portfolio-route.test.ts` 4건 = 10건 ✅
- Web: `portfolio-view.test.tsx` 6건 ✅

### 변경 파일 (12개)
| 구분 | 파일 |
|------|------|
| 신규 | `schemas/portfolio.ts`, `services/portfolio-service.ts` |
| 수정 | `routes/biz-items.ts` (라우트 추가) |
| 신규 | `PipelineProgressBar.tsx`, `PortfolioGraph.tsx`, `PortfolioView.tsx` |
| 수정 | `lib/api-client.ts`, `routes/ax-bd/discovery.tsx`, `routes/dashboard.tsx` |
| 신규 | `portfolio-service.test.ts`, `portfolio-route.test.ts`, `portfolio-view.test.tsx` |

🤖 Auto-generated from Sprint 223 autopilot