### PR TITLE
fix: CoworkSetupGuide 스킬 수 22→23 drift fix

### DIFF
--- a/packages/web/src/components/feature/CoworkSetupGuide.tsx
+++ b/packages/web/src/components/feature/CoworkSetupGuide.tsx
@@ -48,7 +48,7 @@ const ENV_META: Record<
     icon: Terminal,
     label: "Claude Code (터미널)",
     badge: "권장",
-    desc: "터미널에서 claude 명령으로 실행. ax plugin(22개 워크플로우 스킬) + CLAUDE_AXBD(76개 BD 분석 스킬) 모두 사용 가능.",
+    desc: "터미널에서 claude 명령으로 실행. ax plugin(23개 워크플로우 스킬) + CLAUDE_AXBD(76개 BD 분석 스킬) 모두 사용 가능.",
   },
   "claude-desktop": {
     icon: Monitor,
@@ -86,7 +86,7 @@ const STEPS: Record<Environment, SetupStep[]> = {
       number: 1,
       title: "ax 워크플로우 Plugin 설치",
       description:
-        "세션 관리, Sprint, 거버넌스, 요구사항 관리 등 22개 개발 워크플로우 스킬을 설치해요.",
+        "세션 관리, Sprint, 거버넌스, 요구사항 관리 등 23개 개발 워크플로우 스킬을 설치해요.",
       why: "Plugin으로 설치하면 어떤 프로젝트 폴더에서든 ax:session-start, ax:sprint 등을 사용할 수 있어요.",
       commands: [
         "claude plugin install ax@ax-marketplace",
@@ -364,7 +364,7 @@ function ResourcesSection() {
   const resources = [
     {
       title: "ax plugin (개발 워크플로우)",
-      desc: "22개 워크플로우 스킬 — 세션/Sprint/거버넌스/요구사항",
+      desc: "23개 워크플로우 스킬 — 세션/Sprint/거버넌스/요구사항",
       href: "https://github.com/KTDS-AXBD/ax-plugin",
       internal: false,
     },


### PR DESCRIPTION
## 요약

ax-marketplace에 `sprint-watch` 스킬이 추가되어 실제 스킬 수가 **23개**가 되었으나, `CoworkSetupGuide.tsx` 3곳에 `22`가 하드코딩되어 웹 UI와 실제 플러그인이 불일치하는 drift가 발생.

## 변경 내역

`packages/web/src/components/feature/CoworkSetupGuide.tsx` — 3줄

| 위치 | 변경 |
|------|------|
| L51 | claude-code 환경 desc "22개 워크플로우 스킬" → "23개" |
| L89 | Plugin 설치 스텝 description "22개 개발 워크플로우" → "23개" |
| L367 | ResourcesSection desc "22개 워크플로우 스킬" → "23개" |

## SPEC 미등록 사유

- 3줄 단순 문자열 drift 수정 (새 기능 아님)
- master의 `SPEC.md`에 Phase 6c auto-sync 잔여 변경이 있어 F-item 등록 시 multipane-commit safety 위배 위험
- 추후 하드코딩 드리프트 재발 방지는 `ax-plugin` 대시보드 기반 동적 수치 제공으로 처리 예정

## 검증

- [x] git diff --stat: 1 file changed, 3 insertions(+), 3 deletions(-)
- [x] 다른 dirty 파일 오염 없음 (WT 분리)
- [ ] CI typecheck + lint pass 대기

🤖 Generated with [Claude Code](https://claude.com/claude-code)