### PR TITLE
fix: F492 FileUploadZone BASE_URL 통일 — Pages 오리진 405 해소

### DIFF
--- a/docs/01-plan/features/sprint-241.plan.md
+++ b/docs/01-plan/features/sprint-241.plan.md
@@ -1,0 +1,55 @@
+---
+code: FX-PLAN-241
+title: "Sprint 241 — F492 FileUploadZone API 경로 drift 수정"
+version: "1.0"
+status: Active
+category: PLAN
+created: 2026-04-09
+updated: 2026-04-09
+author: Claude Sonnet 4.6
+---
+
+# Sprint 241 Plan — F492 FileUploadZone API 경로 drift 수정
+
+## 1. 목표
+
+`FileUploadZone` 컴포넌트가 `apiBaseUrl=""` 기본값으로 상대경로를 구성하여 Pages 오리진(`fx.minu.best`)에서 405 에러가 발생하는 버그를 수정한다.
+
+- **REQ**: FX-REQ-484 (P1 Bug)
+- **GitHub Issue**: #414
+- **영향 범위**: 파일 업로드 파이프라인 전체 (F441~F443) 무력화 상태
+
+## 2. 근본 원인
+
+```
+FileUploadZone.tsx:54
+  fetch(`${apiBaseUrl}/api/files/presign`, ...)
+  → apiBaseUrl = ""  →  "/api/files/presign"  (상대경로)
+  → Pages 오리진에서 POST 미지원 → 405
+```
+
+`api-client.ts`의 `BASE_URL = import.meta.env.VITE_API_URL || "/api"` 표준을 우회하는 자체 fetch 구현이 문제의 핵심.
+
+## 3. 수정 전략
+
+| 변경 파일 | 변경 내용 |
+|-----------|-----------|
+| `FileUploadZone.tsx` | `apiBaseUrl` prop 제거, `BASE_URL` import로 대체, `/api/files/xxx` → `/files/xxx` |
+| `AttachedFilesPanel.tsx` | `apiBaseUrl` prop 인터페이스 + 전달 제거 |
+
+## 4. 검증 계획
+
+1. 타입체크 (`turbo typecheck`)
+2. 단위 테스트 (`turbo test`)
+3. E2E 시나리오 4종 추가:
+   - PDF 업로드 성공
+   - PPTX 업로드 성공
+   - DOCX 업로드 성공
+   - PNG 업로드 거부 (지원 안 되는 형식)
+
+## 5. 완료 기준
+
+- `FileUploadZone`에서 `apiBaseUrl` prop 완전 제거
+- `BASE_URL` 직접 import 적용
+- E2E 4종 추가 (회귀 방지)
+- typecheck + test 통과

--- a/docs/02-design/features/sprint-241.design.md
+++ b/docs/02-design/features/sprint-241.design.md
@@ -1,0 +1,118 @@
+---
+code: FX-DSGN-241
+title: "Sprint 241 — F492 FileUploadZone API 경로 drift 수정 Design"
+version: "1.0"
+status: Active
+category: DSGN
+created: 2026-04-09
+updated: 2026-04-09
+author: Claude Sonnet 4.6
+---
+
+# Sprint 241 Design — F492 FileUploadZone API 경로 drift 수정
+
+## §1. 변경 목록
+
+### FileUploadZone.tsx
+
+**Before**:
+```tsx
+import { useState, useRef, useCallback, ... } from "react";
+
+interface FileUploadZoneProps {
+  apiBaseUrl?: string;   // ← 제거
+  bizItemId?: string;
+  onUploadComplete?: (fileId: string) => void;
+}
+
+export function FileUploadZone({ apiBaseUrl = "", ... }: FileUploadZoneProps) {
+  const presignRes = await fetch(`${apiBaseUrl}/api/files/presign`, ...);
+  const confirmRes = await fetch(`${apiBaseUrl}/api/files/confirm`, ...);
+  const parseRes = await fetch(`${apiBaseUrl}/api/files/${file_id}/parse`, ...);
+}
+```
+
+**After**:
+```tsx
+import { useState, useRef, useCallback, ... } from "react";
+import { BASE_URL } from "@/lib/api-client";   // ← 추가
+
+interface FileUploadZoneProps {
+  // apiBaseUrl 제거
+  bizItemId?: string;
+  onUploadComplete?: (fileId: string) => void;
+}
+
+export function FileUploadZone({ bizItemId, onUploadComplete }: FileUploadZoneProps) {
+  const presignRes = await fetch(`${BASE_URL}/files/presign`, ...);   // /api 중복 제거
+  const confirmRes = await fetch(`${BASE_URL}/files/confirm`, ...);
+  const parseRes = await fetch(`${BASE_URL}/files/${file_id}/parse`, ...);
+}
+```
+
+### AttachedFilesPanel.tsx
+
+**Before**:
+```tsx
+interface AttachedFilesPanelProps {
+  bizItemId: string;
+  apiBaseUrl?: string;  // ← 제거
+}
+
+export default function AttachedFilesPanel({ bizItemId, apiBaseUrl = "" }: AttachedFilesPanelProps) {
+  ...
+  <FileUploadZone
+    apiBaseUrl={apiBaseUrl}   // ← 제거
+    bizItemId={bizItemId}
+    ...
+  />
+}
+```
+
+**After**:
+```tsx
+interface AttachedFilesPanelProps {
+  bizItemId: string;
+  // apiBaseUrl 제거
+}
+
+export default function AttachedFilesPanel({ bizItemId }: AttachedFilesPanelProps) {
+  ...
+  <FileUploadZone
+    // apiBaseUrl 없음
+    bizItemId={bizItemId}
+    ...
+  />
+}
+```
+
+## §2. E2E 테스트 추가
+
+파일: `packages/web/e2e/file-upload.spec.ts` (신규)
+
+```typescript
+// 4종 시나리오
+test("PDF 파일 업로드 성공", ...)
+test("PPTX 파일 업로드 성공", ...)
+test("DOCX 파일 업로드 성공", ...)
+test("PNG 파일 업로드 거부 — 지원 안 되는 형식 오류 표시", ...)
+```
+
+## §3. Worker 파일 매핑
+
+단일 구현 (Worker 없음 — 변경 파일 2개, 간단한 prop 제거):
+
+| 파일 | 작업 |
+|------|------|
+| `packages/web/src/components/feature/FileUploadZone.tsx` | `apiBaseUrl` prop 제거, `BASE_URL` import |
+| `packages/web/src/components/feature/discovery/AttachedFilesPanel.tsx` | `apiBaseUrl` prop 제거 |
+| `packages/web/e2e/file-upload.spec.ts` | E2E 4종 신규 작성 |
+
+## §4. 검증 체크리스트
+
+- [ ] `FileUploadZone`에서 `apiBaseUrl` prop 흔적 없음
+- [ ] `BASE_URL` import 추가, fetch 경로에서 `/api` 중복 없음
+- [ ] `AttachedFilesPanel`에서 `apiBaseUrl` 전달 없음
+- [ ] E2E file-upload.spec.ts 4개 test 존재
+- [ ] `turbo typecheck` 통과
+- [ ] `turbo test` 통과

--- a/docs/04-report/sprint-241.report.md
+++ b/docs/04-report/sprint-241.report.md
@@ -1,0 +1,46 @@
+---
+code: FX-RPRT-241
+title: "Sprint 241 완료 보고서 — F492 FileUploadZone API 경로 drift 수정"
+version: "1.0"
+status: Active
+category: RPRT
+created: 2026-04-09
+updated: 2026-04-09
+author: Claude Sonnet 4.6
+---
+
+# Sprint 241 완료 보고서
+
+## 요약
+
+| 항목 | 내용 |
+|------|------|
+| Sprint | 241 |
+| F-item | F492 |
+| REQ | FX-REQ-484 (P1 Bug) |
+| Match Rate | **100%** |
+| typecheck | 11/11 ✅ |
+| test | 3436 passed ✅ |
+
+## 문제 및 해결
+
+**근본 원인**: `FileUploadZone.tsx`가 `apiBaseUrl=""` 기본값으로 `/api/files/presign` 상대경로를 구성하여, Pages(`fx.minu.best`) 오리진에서 `POST` 미지원 → 405 반환. `api-client.ts`의 `BASE_URL` 표준을 우회하는 자체 fetch 구현.
+
+**수정**:
+1. `FileUploadZone.tsx`: `apiBaseUrl` prop 제거, `BASE_URL` import 추가, fetch 경로 `/api/files/*` → `/files/*` (BASE_URL에 `/api` 포함)
+2. `AttachedFilesPanel.tsx`: `apiBaseUrl` prop 인터페이스 + 전달 제거
+
+## 변경 파일
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `packages/web/src/components/feature/FileUploadZone.tsx` | `apiBaseUrl` prop 제거, `BASE_URL` import, 3개 fetch 경로 수정 |
+| `packages/web/src/components/feature/discovery/AttachedFilesPanel.tsx` | `apiBaseUrl` prop 인터페이스 + 전달 제거 |
+| `packages/web/e2e/file-upload.spec.ts` | F492 회귀 방지 E2E 4종 신규 추가 (PDF/PPTX/DOCX 성공 + PNG 거부) |
+| `docs/01-plan/features/sprint-241.plan.md` | Plan 문서 |
+| `docs/02-design/features/sprint-241.design.md` | Design 문서 |
+
+## 교훈
+
+- **drift 패턴 재발**: `api-client` 표준을 우회하는 자체 fetch 구현 (#243 offering legacy fetcher와 동일 축)
+- **예방**: 신규 컴포넌트에서 `fetch()`를 직접 호출할 때 `BASE_URL` import 필수 — `apiBaseUrl` prop 패턴은 금지

--- a/packages/web/e2e/file-upload.spec.ts
+++ b/packages/web/e2e/file-upload.spec.ts
@@ -1,0 +1,221 @@
+/**
+ * E2E: F492 — FileUploadZone API 경로 회귀 방지
+ * BASE_URL 통일 수정 후 PDF/PPTX/DOCX 업로드 성공 + PNG 거부 검증
+ *
+ * @service: foundry-x
+ * @sprint: 241
+ * @tagged-by: F492
+ */
+import { test, expect } from "./fixtures/auth";
+
+const MOCK_BIZ_ITEM = {
+  id: "biz-f492",
+  title: "F492 업로드 테스트 아이템",
+  description: "FileUploadZone API 경로 drift 수정 회귀 테스트",
+  discoveryType: "I",
+  status: "analyzed",
+  source: "wizard",
+  orgId: "test-org-e2e",
+  authorId: "test-user-id",
+  classification: null,
+  createdBy: "test-user-id",
+  createdAt: "2026-04-09T00:00:00Z",
+  updatedAt: "2026-04-09T00:00:00Z",
+};
+
+const MOCK_PRESIGN = {
+  presigned_url: "https://r2.mock.dev/upload/f492-test",
+  file_id: "file-f492-1",
+};
+
+async function setupBaseMocks(page: import("@playwright/test").Page) {
+  await page.evaluate(() => {
+    localStorage.setItem("fx-discovery-tour-completed", "true");
+    localStorage.setItem("fx-tour-completed", "true");
+  });
+
+  await page.route("**/api/biz-items/biz-f492", (route) => {
+    if (route.request().method() === "GET") return route.fulfill({ json: MOCK_BIZ_ITEM });
+    return route.continue();
+  });
+  await page.route("**/api/biz-items", (route) =>
+    route.fulfill({ json: { items: [MOCK_BIZ_ITEM], total: 1, page: 1, limit: 20 } }),
+  );
+  await page.route("**/api/biz-items/biz-f492/shaping-artifacts", (route) =>
+    route.fulfill({ json: { businessPlan: null, offering: null, prd: null, prototype: null } }),
+  );
+  await page.route("**/api/biz-items/biz-f492/discovery-criteria", (route) =>
+    route.fulfill({ json: { total: 9, completed: 3, gateStatus: "warning", criteria: [] } }),
+  );
+  await page.route("**/api/biz-items/biz-f492/next-guide", (route) =>
+    route.fulfill({ json: { step: "2-3", description: "mock" } }),
+  );
+  await page.route("**/api/biz-items/biz-f492/discovery-progress", (route) =>
+    route.fulfill({ json: { stages: [], currentStage: null, completedCount: 0, totalCount: 0 } }),
+  );
+  await page.route("**/api/bdp/biz-f492", (route) =>
+    route.fulfill({ json: { error: "not found" }, status: 404 }),
+  );
+  await page.route("**/api/pipeline/items/biz-f492", (route) =>
+    route.fulfill({ json: { id: "pipe-f492", title: "F492 업로드 테스트 아이템", currentStage: "DISCOVERY", stageEnteredAt: "2026-04-09T00:00:00Z", stageHistory: [] } }),
+  );
+  await page.route("**/api/help-agent/**", (route) =>
+    route.fulfill({ json: { content: "mock" } }),
+  );
+  await page.route(/\/api\/files(\?|$)/, (route) =>
+    route.fulfill({ json: { files: [] } }),
+  );
+}
+
+async function setupUploadMocks(page: import("@playwright/test").Page) {
+  await page.route("**/api/files/presign", (route) => {
+    if (route.request().method() === "POST") return route.fulfill({ json: MOCK_PRESIGN });
+    return route.continue();
+  });
+  await page.route("https://r2.mock.dev/**", (route) =>
+    route.fulfill({ status: 200, body: "" }),
+  );
+  await page.route("**/api/files/confirm", (route) =>
+    route.fulfill({ json: { success: true } }),
+  );
+  await page.route("**/api/files/file-f492-1/parse", (route) =>
+    route.fulfill({ json: { success: true } }),
+  );
+}
+
+async function openUploadZone(page: import("@playwright/test").Page) {
+  await page.goto("/discovery/items/biz-f492");
+  await expect(page.getByText("F492 업로드 테스트 아이템").first()).toBeVisible({ timeout: 10000 });
+  await page.getByRole("tab", { name: "첨부 자료" }).click();
+  await page.getByRole("button", { name: /파일 업로드/ }).click();
+  await expect(page.getByTestId("file-upload-zone")).toBeVisible({ timeout: 3000 });
+}
+
+test.describe("F492 — FileUploadZone BASE_URL 통일 회귀 방지", () => {
+  test("PDF 파일 업로드 → presign API 호출 성공", async ({ authenticatedPage: page }) => {
+    await setupBaseMocks(page);
+    await setupUploadMocks(page);
+
+    let presignBody: Record<string, unknown> | null = null;
+    await page.route("**/api/files/presign", async (route) => {
+      if (route.request().method() === "POST") {
+        presignBody = await route.request().postDataJSON() as Record<string, unknown>;
+        return route.fulfill({ json: MOCK_PRESIGN });
+      }
+      return route.continue();
+    });
+
+    await openUploadZone(page);
+
+    await page.locator('input[type="file"]').setInputFiles({
+      name: "사업계획서.pdf",
+      mimeType: "application/pdf",
+      buffer: Buffer.from("fake pdf content"),
+    });
+
+    await page.waitForResponse(
+      (res) => res.url().includes("/api/files/presign") && res.ok(),
+      { timeout: 10000 },
+    );
+
+    expect(presignBody).not.toBeNull();
+    expect((presignBody as Record<string, unknown>)["mime_type"]).toBe("application/pdf");
+
+    await expect(page.getByText(/업로드 중|텍스트 추출|업로드 완료/)).toBeVisible({ timeout: 10000 });
+  });
+
+  test("PPTX 파일 업로드 → presign API 호출 성공", async ({ authenticatedPage: page }) => {
+    await setupBaseMocks(page);
+    await setupUploadMocks(page);
+
+    let presignBody: Record<string, unknown> | null = null;
+    await page.route("**/api/files/presign", async (route) => {
+      if (route.request().method() === "POST") {
+        presignBody = await route.request().postDataJSON() as Record<string, unknown>;
+        return route.fulfill({ json: MOCK_PRESIGN });
+      }
+      return route.continue();
+    });
+
+    await openUploadZone(page);
+
+    await page.locator('input[type="file"]').setInputFiles({
+      name: "발표자료.pptx",
+      mimeType: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      buffer: Buffer.from("fake pptx content"),
+    });
+
+    await page.waitForResponse(
+      (res) => res.url().includes("/api/files/presign") && res.ok(),
+      { timeout: 10000 },
+    );
+
+    expect(presignBody).not.toBeNull();
+    expect((presignBody as Record<string, unknown>)["mime_type"]).toBe(
+      "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    );
+
+    await expect(page.getByText(/업로드 중|텍스트 추출|업로드 완료/)).toBeVisible({ timeout: 10000 });
+  });
+
+  test("DOCX 파일 업로드 → presign API 호출 성공", async ({ authenticatedPage: page }) => {
+    await setupBaseMocks(page);
+    await setupUploadMocks(page);
+
+    let presignBody: Record<string, unknown> | null = null;
+    await page.route("**/api/files/presign", async (route) => {
+      if (route.request().method() === "POST") {
+        presignBody = await route.request().postDataJSON() as Record<string, unknown>;
+        return route.fulfill({ json: MOCK_PRESIGN });
+      }
+      return route.continue();
+    });
+
+    await openUploadZone(page);
+
+    await page.locator('input[type="file"]').setInputFiles({
+      name: "보고서.docx",
+      mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      buffer: Buffer.from("fake docx content"),
+    });
+
+    await page.waitForResponse(
+      (res) => res.url().includes("/api/files/presign") && res.ok(),
+      { timeout: 10000 },
+    );
+
+    expect(presignBody).not.toBeNull();
+    expect((presignBody as Record<string, unknown>)["mime_type"]).toBe(
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    );
+
+    await expect(page.getByText(/업로드 중|텍스트 추출|업로드 완료/)).toBeVisible({ timeout: 10000 });
+  });
+
+  test("PNG 파일 업로드 시도 → 지원 안 되는 형식 에러 표시 (presign API 미호출)", async ({ authenticatedPage: page }) => {
+    await setupBaseMocks(page);
+
+    let presignCalled = false;
+    await page.route("**/api/files/presign", (route) => {
+      presignCalled = true;
+      return route.continue();
+    });
+
+    await openUploadZone(page);
+
+    await page.locator('input[type="file"]').setInputFiles({
+      name: "screenshot.png",
+      mimeType: "image/png",
+      buffer: Buffer.from("fake png content"),
+    });
+
+    // 에러 메시지 표시
+    await expect(page.getByText("PDF, PPTX, DOCX 파일만 업로드할 수 있어요")).toBeVisible({ timeout: 5000 });
+
+    // presign API 미호출 확인 (클라이언트 사이드 유효성 검사)
+    expect(presignCalled).toBe(false);
+
+    // "다시 시도" 버튼
+    await expect(page.getByRole("button", { name: "다시 시도" })).toBeVisible();
+  });
+});

--- a/packages/web/src/components/feature/FileUploadZone.tsx
+++ b/packages/web/src/components/feature/FileUploadZone.tsx
@@ -3,6 +3,7 @@
  * R2 Presigned URL을 통한 drag-and-drop 파일 업로드
  */
 import { useState, useRef, useCallback, type DragEvent, type ChangeEvent } from "react";
+import { BASE_URL } from "@/lib/api-client";
 
 const ACCEPTED_MIMES: Record<string, string> = {
   "application/pdf": ".pdf",
@@ -14,12 +15,11 @@ const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
 type UploadStatus = "idle" | "uploading" | "parsing" | "done" | "error";
 
 interface FileUploadZoneProps {
-  apiBaseUrl?: string;
   bizItemId?: string;
   onUploadComplete?: (fileId: string) => void;
 }
 
-export function FileUploadZone({ apiBaseUrl = "", bizItemId, onUploadComplete }: FileUploadZoneProps) {
+export function FileUploadZone({ bizItemId, onUploadComplete }: FileUploadZoneProps) {
   const [status, setStatus] = useState<UploadStatus>("idle");
   const [progress, setProgress] = useState(0);
   const [filename, setFilename] = useState("");
@@ -51,7 +51,7 @@ export function FileUploadZone({ apiBaseUrl = "", bizItemId, onUploadComplete }:
 
     try {
       // Step 1: Presigned URL 발급
-      const presignRes = await fetch(`${apiBaseUrl}/api/files/presign`, {
+      const presignRes = await fetch(`${BASE_URL}/files/presign`, {
         method: "POST",
         headers: { "Content-Type": "application/json", ...getAuthHeaders() },
         body: JSON.stringify({
@@ -86,7 +86,7 @@ export function FileUploadZone({ apiBaseUrl = "", bizItemId, onUploadComplete }:
       setProgress(90);
 
       // Step 3: 업로드 확인
-      const confirmRes = await fetch(`${apiBaseUrl}/api/files/confirm`, {
+      const confirmRes = await fetch(`${BASE_URL}/files/confirm`, {
         method: "POST",
         headers: { "Content-Type": "application/json", ...getAuthHeaders() },
         body: JSON.stringify({ file_id }),
@@ -96,7 +96,7 @@ export function FileUploadZone({ apiBaseUrl = "", bizItemId, onUploadComplete }:
 
       // Step 4: 파싱 트리거
       setStatus("parsing");
-      const parseRes = await fetch(`${apiBaseUrl}/api/files/${file_id}/parse`, {
+      const parseRes = await fetch(`${BASE_URL}/files/${file_id}/parse`, {
         method: "POST",
         headers: { "Content-Type": "application/json", ...getAuthHeaders() },
       });
@@ -113,7 +113,7 @@ export function FileUploadZone({ apiBaseUrl = "", bizItemId, onUploadComplete }:
       setStatus("error");
       setErrorMsg(err instanceof Error ? err.message : "업로드에 실패했어요");
     }
-  }, [apiBaseUrl, bizItemId, onUploadComplete]);
+  }, [bizItemId, onUploadComplete]);
 
   const handleDrop = (e: DragEvent<HTMLDivElement>) => {
     e.preventDefault();

--- a/packages/web/src/components/feature/discovery/AttachedFilesPanel.tsx
+++ b/packages/web/src/components/feature/discovery/AttachedFilesPanel.tsx
@@ -27,10 +27,9 @@ function formatBytes(bytes: number): string {
 
 interface AttachedFilesPanelProps {
   bizItemId: string;
-  apiBaseUrl?: string;
 }
 
-export default function AttachedFilesPanel({ bizItemId, apiBaseUrl = "" }: AttachedFilesPanelProps) {
+export default function AttachedFilesPanel({ bizItemId }: AttachedFilesPanelProps) {
   const [files, setFiles] = useState<UploadedFileMeta[]>([]);
   const [loading, setLoading] = useState(true);
   const [deletingId, setDeletingId] = useState<string | null>(null);
@@ -105,7 +104,6 @@ export default function AttachedFilesPanel({ bizItemId, apiBaseUrl = "" }: Attac
       {showUpload && (
         <div className="rounded-lg border p-3">
           <FileUploadZone
-            apiBaseUrl={apiBaseUrl}
             bizItemId={bizItemId}
             onUploadComplete={(id) => {
               handleUploadComplete(id);


### PR DESCRIPTION
## Summary
- `FileUploadZone.tsx`에서 `apiBaseUrl=""` 기본값으로 상대경로 구성 → Pages 오리진 405 버그 수정
- `BASE_URL` (`@/lib/api-client`) 직접 import로 대체
- `AttachedFilesPanel.tsx` `apiBaseUrl` prop 완전 제거
- E2E 회귀 방지 4종 추가 (PDF/PPTX/DOCX 업로드 성공 + PNG 거부)

## Root Cause
\`FileUploadZone\`이 \`apiBaseUrl=""\` 기본값으로 \`/api/files/presign\` 상대경로를 구성 → Pages(\`fx.minu.best\`) 오리진에서 POST 미지원 → 405 Method Not Allowed

## Changed Files
- \`packages/web/src/components/feature/FileUploadZone.tsx\` — prop 제거, BASE_URL import
- \`packages/web/src/components/feature/discovery/AttachedFilesPanel.tsx\` — prop 제거
- \`packages/web/e2e/file-upload.spec.ts\` — F492 E2E 4종 신규

## Test Plan
- [x] typecheck: 11/11 passed
- [x] unit test: 3436 passed
- [x] E2E 4종 추가 (CI에서 실행 예정)

Closes #414 (FX-REQ-484, P1 Bug, Sprint 241)

🤖 Generated with [Claude Code](https://claude.com/claude-code)