### PR TITLE
fix(api): discovery stage analysis timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ packages/web/playwright-report/
 # Windows Zone.Identifier metadata (WSL file copy artifact)
 *:Zone.Identifier
 .sprint-watch-config
+.task-context
+.task-prompt

--- a/packages/api/src/__tests__/model-router.test.ts
+++ b/packages/api/src/__tests__/model-router.test.ts
@@ -181,7 +181,7 @@ describe("DEFAULT_MODEL_MAP", () => {
       expect(typeof DEFAULT_MODEL_MAP[tt]).toBe("string");
     }
 
-    expect(Object.keys(DEFAULT_MODEL_MAP)).toHaveLength(13);
+    expect(Object.keys(DEFAULT_MODEL_MAP)).toHaveLength(14);
   });
 });
 

--- a/packages/api/src/core/agent/services/execution-types.ts
+++ b/packages/api/src/core/agent/services/execution-types.ts
@@ -17,7 +17,8 @@ export type AgentTaskType =
   | "ontology-lookup"
   | "bmc-generation"
   | "bmc-insight"
-  | "market-summary";
+  | "market-summary"
+  | "discovery-analysis";
 
 export interface AgentConstraintRule {
   id: string;

--- a/packages/api/src/core/agent/services/model-router.ts
+++ b/packages/api/src/core/agent/services/model-router.ts
@@ -30,6 +30,7 @@ export const DEFAULT_MODEL_MAP: Record<AgentTaskType, string> = {
   "bmc-generation": "anthropic/claude-sonnet-4-6",
   "bmc-insight": "anthropic/claude-sonnet-4-6",
   "market-summary": "anthropic/claude-sonnet-4-6",
+  "discovery-analysis": "anthropic/claude-haiku-4-5",
 };
 
 interface D1RoutingRow {

--- a/packages/api/src/core/agent/services/openrouter-runner.ts
+++ b/packages/api/src/core/agent/services/openrouter-runner.ts
@@ -8,7 +8,7 @@ import { TASK_SYSTEM_PROMPTS, buildUserPrompt, getSystemPrompt } from "./prompt-
 export const DEFAULT_BASE_URL = "https://openrouter.ai/api/v1";
 export const DEFAULT_MODEL = "anthropic/claude-sonnet-4";
 export const DEFAULT_MAX_TOKENS = 4096;
-export const REQUEST_TIMEOUT_MS = 30_000;
+export const REQUEST_TIMEOUT_MS = 60_000;
 
 interface OpenRouterResponse {
   id: string;

--- a/packages/api/src/core/agent/services/prompt-utils.ts
+++ b/packages/api/src/core/agent/services/prompt-utils.ts
@@ -63,6 +63,15 @@ Return a JSON array with title, description, and suggestedContent.` + UIHINT_INS
   "market-summary": `You are a market analysis agent for the Foundry-X project.
 Given keywords, provide market summary, trends, opportunities, and risks.
 Return a JSON object with summary, trends, opportunities, and risks arrays.` + UIHINT_INSTRUCTION,
+
+  "discovery-analysis": `당신은 AX BD팀의 사업 발굴 분석 에이전트입니다.
+모든 응답은 반드시 다음 JSON 스키마로 출력하세요:
+{
+  "summary": "1~2문장 핵심 요약 (한국어)",
+  "details": "마크다운 형식 상세 분석 (한국어)",
+  "confidence": 0~100 사이 정수
+}
+다른 필드를 추가하지 마세요. 반드시 위 3개 필드만 포함된 유효한 JSON을 반환하세요.`,
 };
 
 /** F60: Default layout per task type — client fallback when uiHint is absent */
@@ -80,6 +89,7 @@ export const DEFAULT_LAYOUT_MAP: Record<AgentTaskType, string> = {
   "bmc-generation": "card",
   "bmc-insight": "card",
   "market-summary": "card",
+  "discovery-analysis": "card",
 };
 
 /** F146: Get system prompt — custom override or task-type default */

--- a/packages/api/src/core/discovery/routes/discovery-stage-runner.ts
+++ b/packages/api/src/core/discovery/routes/discovery-stage-runner.ts
@@ -7,7 +7,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import type { Env } from "../../../env.js";
 import type { TenantVariables } from "../../../middleware/tenant.js";
-import { createAgentRunner } from "../../agent/services/agent-runner.js";
+import { createAgentRunner, createRoutedRunner } from "../../agent/services/agent-runner.js";
 import { StageRunnerService } from "../services/stage-runner-service.js";
 import type { DiscoveryType } from "../services/analysis-path-v82.js";
 
@@ -108,7 +108,7 @@ discoveryStageRunnerRoute.post("/biz-items/:id/discovery-stage/:stage/run", asyn
   const parsed = StageRunSchema.safeParse(body);
   const feedback = parsed.success ? parsed.data.feedback : undefined;
 
-  const runner = createAgentRunner(c.env);
+  const runner = await createRoutedRunner(c.env, "discovery-analysis", c.env.DB);
   const service = new StageRunnerService(c.env.DB, runner);
 
   try {

--- a/packages/api/src/core/discovery/services/stage-runner-service.ts
+++ b/packages/api/src/core/discovery/services/stage-runner-service.ts
@@ -117,7 +117,7 @@ export class StageRunnerService {
     const request: AgentExecutionRequest = {
       taskId: `stage-${stage}-${bizItemId}`,
       agentId: "discovery-stage-runner",
-      taskType: "spec-analysis",
+      taskType: "discovery-analysis",
       context: {
         repoUrl: "",
         branch: "",


### PR DESCRIPTION
## Summary
- Discovery 분석 실행이 OpenRouter 30s timeout으로 항상 실패하던 **P0 버그 수정**
- `discovery-analysis` 전용 taskType 신설 → Haiku 모델 매핑 (Opus/Sonnet 대비 5~10x 빠른 응답)
- OpenRouter 타임아웃 30s → 60s 확대
- run 엔드포인트에서 `createRoutedRunner` 적용으로 D1 규칙 기반 런타임 모델 변경 가능

## Root Cause
`stage-runner-service.ts`가 `taskType: "spec-analysis"`를 사용 → `model-router.ts`에서 `claude-opus-4` 매핑.
라우트는 `createAgentRunner(c.env)`로 runner를 생성해 D1 라우팅을 우회.
OpenRouter 경유 Opus 호출은 30초 안에 응답할 수 없어 항상 timeout 실패.

## Test plan
- [x] model-router.test.ts — DEFAULT_MODEL_MAP 길이 14 반영 (46 tests pass)
- [x] stage-runner-service.test.ts — taskType 변경 반영 (14 tests pass)
- [x] openrouter-runner.test.ts — 기존 동작 유지 (16 tests pass)
- [ ] 배포 후 실제 아이템에서 분석 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)