### PR TITLE
feat(task): S-β heartbeat signal + liveness probe

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -54,6 +54,17 @@
     ],
     "PostToolUse": [
       {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/task/heartbeat-hook.sh",
+            "timeout": 5000,
+            "statusMessage": "heartbeat"
+          }
+        ]
+      },
+      {
         "matcher": "Edit|Write",
         "hooks": [
           {

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ packages/web/playwright-report/
 # Windows Zone.Identifier metadata (WSL file copy artifact)
 *:Zone.Identifier
 .sprint-watch-config
+.task-context
+.task-prompt

--- a/scripts/task/heartbeat-hook.sh
+++ b/scripts/task/heartbeat-hook.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# PostToolUse hook: update .task-context LAST_HEARTBEAT timestamp.
+# Runs after every tool use in a task WT — keeps heartbeat fresh so
+# Master's `task list` liveness probe can detect alive/stale/dead.
+#
+# Fast path: ~5ms (single sed in-place). No network, no jq.
+
+TASK_CTX=".task-context"
+
+# Only run inside a task WT (has .task-context)
+[ -f "$TASK_CTX" ] || exit 0
+
+# Update LAST_HEARTBEAT with current UTC timestamp
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+sed -i "s/^LAST_HEARTBEAT=.*/LAST_HEARTBEAT=$TS/" "$TASK_CTX"
+
+exit 0

--- a/scripts/task/lib.sh
+++ b/scripts/task/lib.sh
@@ -53,6 +53,20 @@ allocate_id() {
 # ─── repo/git helpers ────────────────────────────────────────────────────────
 _repo_root() { git rev-parse --show-toplevel 2>/dev/null; }
 
+# Original project name (works in both main repo and worktrees).
+# In a worktree, --show-toplevel returns the WT path, not the main repo.
+# --git-common-dir returns <main-repo>/.git, so we strip /.git suffix.
+_project_name() {
+  local common_dir; common_dir=$(git rev-parse --git-common-dir 2>/dev/null)
+  if [ -n "$common_dir" ]; then
+    # common_dir = /path/to/main-repo/.git or /path/to/main-repo/.git/worktrees/...
+    local main_git="${common_dir%%/worktrees/*}"
+    basename "$(dirname "$main_git")"
+  else
+    basename "$(_repo_root)"
+  fi
+}
+
 assert_master_clean() {
   if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
     echo "[fx-task] master에 미커밋 변경 — 먼저 정리 필요" >&2
@@ -98,6 +112,92 @@ cache_upsert_task() {
         updated_at: $ts
       } | .tasks[$id].started_at = (.tasks[$id].started_at // $ts)' \
     "$FX_CACHE" > "$tmp" && mv "$tmp" "$FX_CACHE"
+}
+
+# ─── heartbeat ───────────────────────────────────────────────────────────────
+# Update LAST_HEARTBEAT in a .task-context file (atomic sed in-place).
+update_heartbeat() {
+  local ctx="${1:-.task-context}"
+  [ -f "$ctx" ] || return 1
+  local ts; ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  sed -i "s/^LAST_HEARTBEAT=.*/LAST_HEARTBEAT=$ts/" "$ctx"
+}
+
+# Read a key from .task-context (key=value format).
+read_task_ctx() {
+  local ctx="$1" key="$2"
+  grep "^${key}=" "$ctx" 2>/dev/null | head -1 | cut -d= -f2-
+}
+
+# Liveness probe for a single task.
+# Returns: "ok" | "stale" | "dead"
+#   ok    — PID alive + heartbeat within 5 min
+#   stale — heartbeat older than 10 min (Claude Code crash 의심)
+#   dead  — PID not running
+check_liveness() {
+  local ctx="$1"
+  [ -f "$ctx" ] || { echo "dead"; return; }
+
+  local pid; pid=$(read_task_ctx "$ctx" "PID")
+  local hb; hb=$(read_task_ctx "$ctx" "LAST_HEARTBEAT")
+
+  # Heartbeat freshness is the primary liveness indicator.
+  # PID check is secondary — hook subprocesses have transient PIDs,
+  # so a stale heartbeat is more reliable than PID existence.
+  if [ -n "$hb" ]; then
+    local hb_epoch now_epoch age_sec
+    hb_epoch=$(date -d "$hb" +%s 2>/dev/null || echo 0)
+    now_epoch=$(date +%s)
+    age_sec=$(( now_epoch - hb_epoch ))
+    if [ "$age_sec" -gt 600 ]; then
+      # 10+ min stale — likely crashed
+      echo "dead"
+      return
+    elif [ "$age_sec" -gt 300 ]; then
+      # 5~10 min — suspicious
+      echo "stale"
+      return
+    fi
+    echo "ok"
+    return
+  fi
+
+  # No heartbeat timestamp at all — check PID as fallback
+  if [ -n "$pid" ] && ! kill -0 "$pid" 2>/dev/null; then
+    echo "dead"
+    return
+  fi
+
+  echo "ok"
+}
+
+# ─── signal files (Master IPC) ──────────────────────────────────────────────
+FX_SIGNAL_DIR="/tmp/task-signals"
+
+# Write a completion signal file for Master to detect.
+# Usage: write_signal <task_id> <status> [extra_key=value ...]
+write_signal() {
+  local task_id="$1" status="$2"
+  shift 2
+  local project; project=$(_project_name 2>/dev/null || echo "unknown")
+  mkdir -p "$FX_SIGNAL_DIR"
+  local sig_file="${FX_SIGNAL_DIR}/${project}-${task_id}.signal"
+  cat > "$sig_file" <<EOF
+TASK_ID=$task_id
+STATUS=$status
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+PROJECT=$project
+EOF
+  # Append any extra key=value pairs
+  for kv in "$@"; do
+    echo "$kv" >> "$sig_file"
+  done
+}
+
+# Read all pending signals for this project. Returns signal file paths.
+read_signals() {
+  local project; project=$(_project_name 2>/dev/null || echo "unknown")
+  ls "${FX_SIGNAL_DIR}/${project}-"*.signal 2>/dev/null || true
 }
 
 # ─── slug ────────────────────────────────────────────────────────────────────

--- a/scripts/task/task-list.sh
+++ b/scripts/task/task-list.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# scripts/task/task-list.sh — /ax:task list (S-α MVP, no liveness probe)
+# scripts/task/task-list.sh — /ax:task list (S-β: liveness probe)
 #
 # Usage: task-list.sh [--json]
 #
-# Reads ~/.foundry-x/tasks-cache.json and renders a table.
-# S-α scope: cache-only output. Liveness probe + GH label sync = S-β.
+# Reads ~/.foundry-x/tasks-cache.json and renders a table with HB column.
+# Liveness probe: checks PID + LAST_HEARTBEAT from .task-context in each WT.
 
 set -euo pipefail
 
@@ -35,17 +35,48 @@ emoji_for() {
   esac
 }
 
-printf "%-6s %-4s %-4s %-32s %-12s %s\n" "ID" "TRK" "ST" "BRANCH" "AGE" "PANE"
-printf "%-6s %-4s %-4s %-32s %-12s %s\n" "------" "----" "----" "--------------------------------" "------------" "--------"
+hb_display() {
+  case "$1" in
+    ok)    echo "ok" ;;
+    stale) echo "⚠ stale" ;;
+    dead)  echo "✗ dead" ;;
+    *)     echo "—" ;;
+  esac
+}
+
+printf "%-6s %-4s %-4s %-32s %-8s %-10s %s\n" "ID" "TRK" "ST" "BRANCH" "AGE" "HB" "PANE"
+printf "%-6s %-4s %-4s %-32s %-8s %-10s %s\n" "------" "----" "----" "--------------------------------" "--------" "----------" "--------"
 
 now_epoch=$(date +%s)
 
-jq -r '.tasks | to_entries[] | [.key, .value.track, .value.status, .value.branch, .value.started_at, .value.pane] | @tsv' "$FX_CACHE" \
-| while IFS=$'\t' read -r id track status branch started pane; do
+jq -r '.tasks | to_entries[] | [.key, .value.track, .value.status, .value.branch, .value.started_at, .value.pane, .value.wt] | @tsv' "$FX_CACHE" \
+| while IFS=$'\t' read -r id track status branch started pane wt; do
   start_epoch=$(date -d "$started" +%s 2>/dev/null || echo "$now_epoch")
   age_sec=$(( now_epoch - start_epoch ))
   age=$(printf "%02d:%02d" $((age_sec/3600)) $(((age_sec%3600)/60)))
   emoji=$(emoji_for "$status")
   br_short="${branch:0:32}"
-  printf "%-6s %-4s %-4s %-32s %-12s %s\n" "$id" "$track" "$emoji" "$br_short" "$age" "${pane:-—}"
+
+  # Liveness probe — check .task-context in WT path
+  hb="—"
+  if [ -n "$wt" ] && [ -d "$wt" ]; then
+    local_ctx="${wt}/.task-context"
+    hb_raw=$(check_liveness "$local_ctx")
+    hb=$(hb_display "$hb_raw")
+  fi
+
+  printf "%-6s %-4s %-4s %-32s %-8s %-10s %s\n" "$id" "$track" "$emoji" "$br_short" "$age" "$hb" "${pane:-—}"
 done
+
+# Check for pending signals
+sig_count=$(read_signals | wc -l)
+if [ "$sig_count" -gt 0 ]; then
+  echo ""
+  echo "[fx-task] 📡 $sig_count signal(s) pending:"
+  for sig in $(read_signals); do
+    sig_id=$(grep "^TASK_ID=" "$sig" 2>/dev/null | cut -d= -f2-)
+    sig_status=$(grep "^STATUS=" "$sig" 2>/dev/null | cut -d= -f2-)
+    sig_ts=$(grep "^TIMESTAMP=" "$sig" 2>/dev/null | cut -d= -f2-)
+    echo "  - ${sig_id}: ${sig_status} (${sig_ts})"
+  done
+fi


### PR DESCRIPTION
## Summary
- PostToolUse hook으로 `.task-context` LAST_HEARTBEAT를 매 도구 사용 시 갱신 (~5ms)
- `task list`에 HB 컬럼 추가 — ok / ⚠ stale (5~10min) / ✗ dead (10min+)
- Master IPC signal 파일 (`/tmp/task-signals/{project}-{ID}.signal`) 구조 구현

## Changes
| File | Change |
|------|--------|
| `scripts/task/lib.sh` | `_project_name()`, `update_heartbeat()`, `read_task_ctx()`, `check_liveness()`, `write_signal()`, `read_signals()` |
| `scripts/task/heartbeat-hook.sh` | New — PostToolUse hook (all tools, 5s timeout) |
| `scripts/task/task-list.sh` | HB column + pending signal queue display |
| `.claude/settings.json` | Heartbeat hook registration |

## Test plan
- [x] `check_liveness()` returns ok/stale/dead correctly (manual test)
- [x] `write_signal()` creates structured signal file with correct project name in WT
- [x] `task list` displays HB column — verified X1=ok after heartbeat, C2=dead (no heartbeat)
- [ ] Verify heartbeat hook fires on PostToolUse in active WT session

🤖 Generated with [Claude Code](https://claude.com/claude-code)