### PR TITLE
feat: Sprint 245 — F501(Projects Board) + F502(CHANGELOG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- F501: GitHub Projects Board 초기 설정 스크립트 + `/ax:task start` 연동
+- F502: CHANGELOG.md 도입 (Keep a Changelog 형식) + session-end/gov-retro 연동
+- F499: Task Orchestrator S-β — doctor/adopt/park + Master IPC
+- F500: Sprint auto Monitor+Merge 파이프라인
+
+## [Phase 31] - 2026-04-10
+
+### Added
+- F497: Task Orchestrator MVP (S-α) — start/list + daemon + 4-track
+
+## [Phase 30] - 2026-04-09
+
+### Added
+- F493: 발굴 단계 평가결과서 v2 — 9탭 리치 리포트
+
+### Fixed
+- F494: 파이프라인 단계 전진 구조 버그
+- F492: FileUploadZone API 경로 drift
+
+### Changed
+- F495: 파이프라인 재구조화 — 발굴/형상화 2-stage
+- F496: 발굴 9기준 체크리스트 정보형 재설계
+
+## [Phase 29] - 2026-04-08
+
+### Added
+- F488: req-manage --create-issue 기본화
+- F489: gov-retro 회고 통합 소급 등록
+
+### Fixed
+- F490: E2E workflow shard 병렬화
+
+### Changed
+- F491: 테스트 공유 Org 모드

--- a/docs/04-report/features/sprint-245.report.md
+++ b/docs/04-report/features/sprint-245.report.md
@@ -1,0 +1,46 @@
+---
+code: FX-RPRT-S245
+title: "Sprint 245 Report — F501/F502 GitHub Projects Board + CHANGELOG"
+version: "1.0"
+status: Active
+category: RPRT
+created: 2026-04-11
+updated: 2026-04-11
+author: Claude Opus 4.6 (sprint-245 autopilot)
+sprint: 245
+f_items: [F501, F502]
+match_rate: 95
+---
+
+# Sprint 245 Report — GitHub Projects Board + CHANGELOG 도입
+
+## 1. 요약
+
+Sprint 245 autopilot으로 F501(GitHub Projects Board) + F502(CHANGELOG 자동화) 두 F항목을 한 배치로 구현했어요. Design §4 파일 목록 5건 모두 반영, 의도적 제외 3건(Actions workflow, Phase 1~28 소급, Org-level Project)은 Design §6 그대로 유지.
+
+## 2. 산출물
+
+### F501 — GitHub Projects Board
+- `scripts/github-project-setup.sh` (신규, 105줄) — gh project list/create + Status 필드 확인 + 기존 open Issues bulk 추가. `--dry-run` 지원, rate limit 방지 sleep 포함.
+- `scripts/task/task-start.sh` Step 6b 추가 (10줄) — Issue 생성 성공 시 "Foundry-X Kanban" 보드에 자동 item-add, 실패해도 task 시작은 계속.
+
+### F502 — CHANGELOG 자동화
+- `CHANGELOG.md` (신규) — Keep a Changelog 1.1.0 형식, `[Unreleased]` + Phase 29~31 소급.
+- `session-end` SKILL.md Phase 2 — Keep a Changelog 형식 자동 감지, feat/fix/docs 커밋만 필터링, Added/Fixed/Changed 섹션에 중복 방지 삽입. `## [Unreleased]` 미존재 시 기존 "세션 NNN" 형식 fallback.
+- `gov-retro` SKILL.md Step 8 — 태그 생성 성공 시 `[Unreleased]` → `[vX.Y.Z] - DATE` 승격하는 sed 커맨드 + auto-commit.
+
+## 3. Gap Analysis
+
+Match Rate **95%** — Design §4 5건 모두 구현, 줄 수는 design 추정치 ±20% 이내. 유일한 일탈: task-start.sh "Step 7b" → "Step 6b" 리네이밍 (실제 파일의 기존 Step 번호 기준으로 정정, 의도 보존).
+
+## 4. 검증
+
+- `bash -n` 구문 체크: scripts/github-project-setup.sh, scripts/task/task-start.sh 모두 통과.
+- 실행 검증(`bash scripts/github-project-setup.sh --dry-run`)은 gh `project` scope 필요 — 세션 종료 후 수동 실행 권장.
+- session-end/gov-retro 변경은 marketplace + cache 양쪽 동기화 완료 (플러그인 8곳 동기화 규칙 중 핵심 2곳).
+
+## 5. 후속
+
+- gh `project` scope refresh + 스크립트 최초 실행으로 board 생성
+- Actions `project-automation.yml`은 Sprint 246+ 이후 검토
+- plugin 8곳 동기화 중 marketplace+cache 이외 경로(help 스킬, 문서) 업데이트는 별도 housekeeping Sprint 권장

--- a/scripts/github-project-setup.sh
+++ b/scripts/github-project-setup.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# GitHub Projects Board 초기 설정 — F501
+# Foundry-X Kanban: Inbox → Backlog → Triaged → Sprint Ready → In Progress → Done
+#
+# Usage:
+#   bash scripts/github-project-setup.sh            # 생성 + 기존 Issues 배치
+#   bash scripts/github-project-setup.sh --dry-run  # 실행 계획만 출력
+#
+# 사전 조건:
+#   - gh CLI 인증 완료 (gh auth status)
+#   - project scope 포함: gh auth refresh -s project
+set -euo pipefail
+
+REPO="KTDS-AXBD/Foundry-X"
+OWNER="KTDS-AXBD"
+PROJECT_TITLE="Foundry-X Kanban"
+COLUMNS=("Inbox" "Backlog" "Triaged" "Sprint Ready" "In Progress" "Done")
+
+DRY_RUN=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    -h|--help)
+      sed -n '2,15p' "$0"
+      exit 0
+      ;;
+  esac
+done
+
+log() { printf '[project-setup] %s\n' "$*"; }
+run() {
+  if $DRY_RUN; then
+    printf '[dry-run] %s\n' "$*"
+  else
+    eval "$@"
+  fi
+}
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "[project-setup] gh CLI가 필요합니다." >&2
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "[project-setup] jq가 필요합니다." >&2
+  exit 1
+fi
+
+# ─── Step 1: 프로젝트 존재 확인 또는 생성 ─────────────────────────────────────
+log "Step 1: 프로젝트 확인 — $PROJECT_TITLE"
+PROJECT_NUM=$(gh project list --owner "$OWNER" --format json 2>/dev/null \
+  | jq -r --arg t "$PROJECT_TITLE" '.projects[] | select(.title==$t) | .number' \
+  | head -1 || true)
+
+if [ -z "$PROJECT_NUM" ]; then
+  log "프로젝트 없음 — 신규 생성"
+  if $DRY_RUN; then
+    log "[dry-run] gh project create --owner $OWNER --title '$PROJECT_TITLE'"
+    PROJECT_NUM="999"
+  else
+    PROJECT_JSON=$(gh project create --owner "$OWNER" --title "$PROJECT_TITLE" --format json)
+    PROJECT_NUM=$(echo "$PROJECT_JSON" | jq -r '.number')
+    log "생성됨: project #$PROJECT_NUM"
+  fi
+else
+  log "기존 프로젝트 재사용: #$PROJECT_NUM"
+fi
+
+# ─── Step 2: Status 필드 옵션(컬럼) 확인 ──────────────────────────────────────
+log "Step 2: Status 필드 옵션 조회"
+if ! $DRY_RUN; then
+  STATUS_OPTIONS=$(gh project field-list "$PROJECT_NUM" --owner "$OWNER" --format json 2>/dev/null \
+    | jq -r '.fields[] | select(.name=="Status") | .options[]?.name' || true)
+  for col in "${COLUMNS[@]}"; do
+    if echo "$STATUS_OPTIONS" | grep -qxF "$col"; then
+      log "  ✓ $col"
+    else
+      log "  ⚠️  누락: $col — GraphQL updateProjectV2Field로 수동 추가 필요"
+    fi
+  done
+else
+  log "[dry-run] Status 옵션 확인: ${COLUMNS[*]}"
+fi
+
+# ─── Step 3: 기존 open Issues 배치 ───────────────────────────────────────────
+log "Step 3: 기존 open Issues 프로젝트 추가"
+ISSUE_COUNT=0
+FAIL_COUNT=0
+
+while read -r NUM; do
+  [ -z "$NUM" ] && continue
+  URL="https://github.com/$REPO/issues/$NUM"
+  if $DRY_RUN; then
+    log "[dry-run] + #$NUM → project"
+  else
+    if gh project item-add "$PROJECT_NUM" --owner "$OWNER" --url "$URL" >/dev/null 2>&1; then
+      ISSUE_COUNT=$((ISSUE_COUNT + 1))
+    else
+      FAIL_COUNT=$((FAIL_COUNT + 1))
+    fi
+    sleep 0.3  # rate limit 방지
+  fi
+done < <(gh issue list --repo "$REPO" --state open --limit 200 --json number \
+           2>/dev/null | jq -r '.[].number' || true)
+
+log "Step 3 완료 — 추가: $ISSUE_COUNT / 실패: $FAIL_COUNT"
+
+# ─── 요약 ────────────────────────────────────────────────────────────────────
+cat <<EOF
+[project-setup] ✅ 완료
+  project:  #$PROJECT_NUM ($PROJECT_TITLE)
+  columns:  ${COLUMNS[*]}
+  added:    $ISSUE_COUNT issue(s)
+  board:    https://github.com/orgs/$OWNER/projects/$PROJECT_NUM
+EOF

--- a/scripts/task/task-start.sh
+++ b/scripts/task/task-start.sh
@@ -305,6 +305,18 @@ if command -v gh >/dev/null 2>&1; then
   fi
 fi
 
+# ─── Step 6b: GitHub Projects Board 추가 (F501) ──────────────────────────────
+# Issue 생성 성공 시 Foundry-X Kanban 보드에 자동 추가.
+# 실패해도 task 시작은 계속 — board 연동은 부가 기능.
+if [ -n "$ISSUE_URL" ] && command -v gh >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+  PROJECT_NUM=$(GH_TOKEN="${GH_TOKEN:-$GH_TOKEN_TMP}" gh project list --owner KTDS-AXBD --format json 2>/dev/null \
+    | jq -r '.projects[]? | select(.title=="Foundry-X Kanban") | .number' | head -1 || true)
+  if [ -n "$PROJECT_NUM" ]; then
+    GH_TOKEN="${GH_TOKEN:-$GH_TOKEN_TMP}" gh project item-add "$PROJECT_NUM" \
+      --owner KTDS-AXBD --url "$ISSUE_URL" >/dev/null 2>&1 || true
+  fi
+fi
+
 # ─── Step 7: cache + log ─────────────────────────────────────────────────────
 cache_upsert_task "$TASK_ID" "in_progress" "$TRACK" "$PANE_ID" "$WT_PATH" "$BRANCH" "$ISSUE_URL"
 log_event "$TASK_ID" "started" "$(jq -nc \


### PR DESCRIPTION
## Sprint 245 — F501 + F502

### F-items
- **F501**: GitHub Projects Board 초기 설정 + `/ax:task start` 연동
- **F502**: CHANGELOG.md (Keep a Changelog) + session-end/gov-retro 연동

### Commits
806f91ca feat: Sprint 245 — F501(Projects Board) + F502(CHANGELOG)

### Match Rate
95% — Design §4 5건 모두 반영, §6 의도적 제외 3건 유지

### Report
docs/04-report/features/sprint-245.report.md

---
🤖 Auto-generated from Sprint 245 autopilot