### PR TITLE
chore: S257 task orchestrator follow-up 4건

### DIFF
--- a/scripts/task/lib.sh
+++ b/scripts/task/lib.sh
@@ -11,10 +11,14 @@ FX_LOCK_DIR="$FX_HOME/locks"
 FX_LOG="$FX_HOME/task-log.ndjson"
 FX_CACHE="$FX_HOME/tasks-cache.json"
 FX_WIP_LOG="$FX_HOME/wip-overrides.log"
+FX_SIGNAL_DIR="/tmp/task-signals"
 
 WIP_CAP="${FX_WIP_CAP:-3}"
 
-mkdir -p "$FX_LOCK_DIR" "$FX_HOME/scripts"
+# Ensure all FX runtime dirs exist — task-start.sh references FX_SIGNAL_DIR
+# before the first write_signal call (Step 5b inject script), so creating it
+# here guarantees all callers can write without a prior mkdir.
+mkdir -p "$FX_LOCK_DIR" "$FX_HOME/scripts" "$FX_SIGNAL_DIR"
 [ -f "$FX_CACHE" ] || echo '{"version":1,"tasks":{}}' > "$FX_CACHE"
 [ -f "$FX_LOG" ] || : > "$FX_LOG"
 
@@ -195,7 +199,7 @@ check_liveness() {
 }
 
 # ─── signal files (Master IPC) ──────────────────────────────────────────────
-FX_SIGNAL_DIR="/tmp/task-signals"
+# FX_SIGNAL_DIR is declared and created at top of this file (SSOT).
 
 # Write a completion signal file for Master to detect.
 # Usage: write_signal <task_id> <status> [extra_key=value ...]

--- a/scripts/task/task-complete.sh
+++ b/scripts/task/task-complete.sh
@@ -74,9 +74,23 @@ COMMIT_COUNT=$(git rev-list master..HEAD --count 2>/dev/null || echo "0")
 
 if [ "$COMMIT_COUNT" -gt 0 ]; then
   echo "[fx-task-complete] ${COMMIT_COUNT} commits — push to ${BRANCH}"
-  git push origin "$BRANCH" -u 2>/dev/null || {
-    echo "[fx-task-complete] push 실패" >&2
-  }
+  # Fail-fast: if push fails with commits present, do NOT write a DONE signal.
+  # Otherwise the daemon sees PR_URL=none + COMMIT_COUNT>0, leaves MERGED=false,
+  # then still removes the worktree and deletes the branch (task-daemon.sh
+  # phase_signals lines 89–92) — permanently dropping the local commits.
+  # S257 investigation (#4): this was the silent-drop root cause.
+  if ! git push origin "$BRANCH" -u; then
+    echo "[fx-task-complete] ❌ push 실패 — signal 작성을 중단합니다." >&2
+    echo "[fx-task-complete] 복구: 원인 확인 후 수동 'git push origin ${BRANCH}' → 다시 task-complete 실행." >&2
+    exit 20
+  fi
+  # Belt-and-suspenders: verify remote contains local HEAD before proceeding.
+  LOCAL_HEAD=$(git rev-parse HEAD)
+  REMOTE_HEAD=$(git rev-parse "origin/${BRANCH}" 2>/dev/null || echo "")
+  if [ -z "$REMOTE_HEAD" ] || [ "$LOCAL_HEAD" != "$REMOTE_HEAD" ]; then
+    echo "[fx-task-complete] ❌ 원격 검증 실패 — local=${LOCAL_HEAD:0:8} remote=${REMOTE_HEAD:0:8}. signal 작성을 중단합니다." >&2
+    exit 21
+  fi
 
   if [ "$NO_PR" = false ] && command -v gh >/dev/null 2>&1; then
     # PR이 이미 있는지 확인

--- a/scripts/task/task-daemon.sh
+++ b/scripts/task/task-daemon.sh
@@ -85,14 +85,24 @@ phase_signals() {
       (cd "$REPO_ROOT" && git pull origin master --ff-only 2>/dev/null) || true
     fi
 
-    # WT 제거
-    if [ -n "$WT_PATH" ] && [ -d "$WT_PATH" ]; then
-      (cd "$REPO_ROOT" && git worktree remove "$WT_PATH" --force 2>/dev/null) || true
+    # Safety guard (S257 #4): only destroy WT+branch when either
+    #   (a) merge succeeded, OR (b) truly zero commits + no PR (empty task).
+    # If commits exist but nothing was merged, the WT/branch are the only
+    # place those commits live — removing them = silent data loss.
+    local PRESERVED=false
+    if [ "$MERGED" = true ] || { [ "${PR_URL:-none}" = "none" ] && [ "${COMMIT_COUNT:-0}" = "0" ]; }; then
+      # WT 제거
+      if [ -n "$WT_PATH" ] && [ -d "$WT_PATH" ]; then
+        (cd "$REPO_ROOT" && git worktree remove "$WT_PATH" --force 2>/dev/null) || true
+      fi
+      [ -n "$BRANCH" ] && (cd "$REPO_ROOT" && git branch -D "$BRANCH" 2>/dev/null) || true
+    else
+      log "🛡️  ${TASK_ID}: MERGED=false + commits=${COMMIT_COUNT:-0} — WT/branch 보존 (silent drop 방지)"
+      PRESERVED=true
     fi
-    [ -n "$BRANCH" ] && (cd "$REPO_ROOT" && git branch -D "$BRANCH" 2>/dev/null) || true
 
-    # pane 종료
-    if [ -n "$PANE_ID" ] && [ "$PANE_ID" != "unknown" ]; then
+    # pane 종료 (preserved task는 pane도 살려둬서 수동 복구 가능)
+    if [ "$PRESERVED" = false ] && [ -n "$PANE_ID" ] && [ "$PANE_ID" != "unknown" ]; then
       tmux kill-pane -t "$PANE_ID" 2>/dev/null || true
     fi
 
@@ -107,7 +117,11 @@ phase_signals() {
 
     # cache + cleanup
     local FINAL_STATUS="merged"
-    [ "$MERGED" = false ] && FINAL_STATUS="done_pending_merge"
+    if [ "$PRESERVED" = true ]; then
+      FINAL_STATUS="needs_manual_review"
+    elif [ "$MERGED" = false ]; then
+      FINAL_STATUS="done_pending_merge"
+    fi
     cache_upsert_task "$TASK_ID" "$FINAL_STATUS" "" "" "" "$BRANCH" "${PR_URL:-}"
     log_event "$TASK_ID" "daemon_processed" "$(jq -nc --arg s "$FINAL_STATUS" '{status:$s}')"
     rm -f "$sig_file"

--- a/scripts/task/task-start.sh
+++ b/scripts/task/task-start.sh
@@ -216,6 +216,13 @@ fi
 
 # ─── Step 5b: auto-inject Claude session + prompt (background) ──────────────
 if [ -n "$PANE_ID" ]; then
+  # Autonomous completion principle — appended to every task prompt to
+  # prevent the "worker-blocked-on-user" interview loop. Workers must drive
+  # tasks to completion without asking Master for confirmation on routine
+  # decisions; only block on genuine ambiguity (conflicting requirements,
+  # missing access). See MEMORY feedback: S256 interview-loop incident.
+  AUTONOMY_RULE="자율 완료 원칙: 결정이 필요한 지점에서 사용자 확인을 기다리지 말고 합리적 기본값으로 진행하세요. 막히면 commit+stash 후 task-complete로 넘기세요. 진짜 막힌 경우(권한 부재/요구 충돌)만 예외. 작업 완료 후 반드시 bash scripts/task/task-complete.sh 를 실행해서 커밋/PR/signal 처리해줘."
+
   # Generate default prompt if not provided
   if [ -z "$PROMPT" ]; then
     case "$TRACK" in
@@ -224,12 +231,12 @@ if [ -n "$PANE_ID" ]; then
       C) TRACK_DESC="점검/Chore 작업" ;;
       X) TRACK_DESC="실험/Spike 탐색" ;;
     esac
-    PROMPT="이 worktree는 task ${TASK_ID} — ${TITLE}. .task-context 파일을 읽고 ${TRACK_DESC}을 진행해줘. 작업 완료 후 반드시 bash scripts/task/task-complete.sh 를 실행해서 커밋/PR/signal 처리해줘."
+    PROMPT="이 worktree는 task ${TASK_ID} — ${TITLE}. .task-context 파일을 읽고 ${TRACK_DESC}을 진행해줘. ${AUTONOMY_RULE}"
   fi
 
-  # Append completion instruction to custom prompts
+  # Append autonomy + completion instruction to custom prompts
   if ! echo "$PROMPT" | grep -q "task-complete.sh"; then
-    PROMPT="${PROMPT} 작업 완료 후 반드시 bash scripts/task/task-complete.sh 를 실행해서 커밋/PR/signal 처리해줘."
+    PROMPT="${PROMPT} ${AUTONOMY_RULE}"
   fi
 
   # Write prompt to WT for Claude to pick up


### PR DESCRIPTION
## Summary

S256에서 식별된 task orchestrator 구조 follow-up 4건을 일괄 처리했어요.

- **#1** `lib.sh`: FX_SIGNAL_DIR을 top-level SSOT로 이동 + mkdir 포함 → task-start.sh Step 5b inject script silent fail 해소
- **#2** `task-start.sh`: PROMPT 템플릿에 AUTONOMY_RULE 하드코딩 → worker-blocked-on-user 인터뷰 loop 방지
- **#3** `task-complete.sh`: push 실패 시 fail-fast (exit 20/21) → 로컬 커밋 silent drop 근본 차단
- **#4** `task-daemon.sh` phase_signals: MERGED=false + commits>0 일 때 WT/branch/pane 보존 방어 계층 추가

## Silent drop 경로 (#3 + #4)

이전 경로:
```
task-complete.sh:77  git push ... 2>/dev/null || { echo 실패 >&2; }  # continue
→ PR 생성 실패 (remote branch 없음)
→ write_signal STATUS=DONE, PR_URL=none, COMMIT_COUNT>0
→ task-daemon.sh phase_signals MERGED=false
→ git worktree remove + git branch -D  ❌ 로컬 커밋 영구 손실
```

이후: task-complete.sh가 exit 20/21로 중단 → signal 미작성. 만약 signal이 어떤 경로로든 들어와도 daemon이 PRESERVED=true로 WT/branch 보존.

## Test plan

- [x] `bash -n` 4개 파일 통과
- [x] `task-daemon.sh --status` 정상 (PID 391302)
- [ ] 실사용 시 새 task에서 AUTONOMY_RULE 주입 확인
- [ ] 실사용 시 push 실패 시나리오에서 exit 20 관측

🤖 Generated with [Claude Code](https://claude.com/claude-code)