### PR TITLE
fix(task-orchestrator): Closes #N in PR body + sprint-merge-monitor local branch cleanup

### DIFF
--- a/scripts/sprint-merge-monitor.sh
+++ b/scripts/sprint-merge-monitor.sh
@@ -152,6 +152,20 @@ handle_merge() {
       || git worktree remove "$wt_path" --force >>"$LOG_FILE" 2>&1 || true
   fi
 
+  # 5b) local branch cleanup — `gh pr merge --delete-branch` only removes
+  # the REMOTE ref, so whatever branch was tracked by this sprint signal
+  # lingers locally until the next orphan-scan sweep. Delete it here too,
+  # covering any name pattern (sprint/*, task/*, fix/*, feat/*, …). Must
+  # run after `worktree remove` since git refuses to delete a branch that
+  # is currently checked out in a worktree.
+  #
+  # Daemon CWD is assumed to be inside the main repo (nohup background
+  # started from master pane). Best-effort (`|| true`): a stale ref or
+  # already-deleted branch must not break the daemon loop.
+  if [ -n "$branch" ]; then
+    git branch -D "$branch" >>"$LOG_FILE" 2>&1 || true
+  fi
+
   # 6) Board 동기화 (F504) — 연관 Issue를 Done 컬럼으로 이동
   local script_dir
   script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/task/task-complete.sh
+++ b/scripts/task/task-complete.sh
@@ -46,6 +46,15 @@ TASK_ID=$(grep '^TASK_ID=' "$TASK_CTX" | cut -d= -f2)
 BRANCH=$(grep '^BRANCH=' "$TASK_CTX" | cut -d= -f2)
 TASK_TYPE=$(grep '^TASK_TYPE=' "$TASK_CTX" | cut -d= -f2)
 TITLE=$(grep '^TITLE=' "$TASK_CTX" | cut -d= -f2)
+ISSUE_URL=$(grep '^ISSUE_URL=' "$TASK_CTX" | cut -d= -f2- || true)
+
+# Extract numeric issue ID from ISSUE_URL (e.g. ".../issues/488" → "488")
+# so the PR body can declare `Closes #488`. GitHub resolves this to an
+# auto-close link only when the PR is merged into the default branch.
+ISSUE_NUM=""
+if [ -n "${ISSUE_URL:-}" ]; then
+  ISSUE_NUM=$(echo "$ISSUE_URL" | grep -oE '/issues/[0-9]+' | grep -oE '[0-9]+$' || true)
+fi
 
 [ -n "$TASK_ID" ] || { echo "[fx-task-complete] TASK_ID 비어있음" >&2; exit 1; }
 [ -n "$BRANCH" ] || { echo "[fx-task-complete] BRANCH 비어있음" >&2; exit 1; }
@@ -135,17 +144,25 @@ if [ "$COMMIT_COUNT" -gt 0 ]; then
       echo "[fx-task-complete] 기존 PR: ${PR_URL}"
     else
       DIFF_STAT=$(git diff --stat master..HEAD 2>/dev/null | tail -1 || echo "")
+      # Build PR body: include `Closes #<n>` so GitHub auto-closes the task
+      # issue on merge. Omit the line entirely when ISSUE_NUM is empty
+      # (degraded start where gh issue create failed) to avoid a literal
+      # "Closes #" text in the PR body.
+      CLOSES_LINE=""
+      [ -n "$ISSUE_NUM" ] && CLOSES_LINE="$(printf '\n\nCloses #%s' "$ISSUE_NUM")"
+      PR_BODY=$(printf 'Task Orchestrator — auto-created by task-complete.\n\n- ID: %s\n- Track: %s\n- Commits: %s\n- Changes: %s%s\n' \
+        "$TASK_ID" "$TASK_TYPE" "$COMMIT_COUNT" "$DIFF_STAT" "$CLOSES_LINE")
       PR_URL=$(gh pr create \
         --repo "KTDS-AXBD/Foundry-X" \
         --base master \
         --head "$BRANCH" \
         --title "[${TASK_ID}] ${TITLE}" \
-        --body "$(printf 'Task Orchestrator — auto-created by task-complete.\n\n- ID: %s\n- Track: %s\n- Commits: %s\n- Changes: %s\n' "$TASK_ID" "$TASK_TYPE" "$COMMIT_COUNT" "$DIFF_STAT")" \
+        --body "$PR_BODY" \
         2>/dev/null) || {
         echo "[fx-task-complete] PR 생성 실패 (degraded)" >&2
         PR_URL=""
       }
-      [ -n "$PR_URL" ] && echo "[fx-task-complete] PR 생성: ${PR_URL}"
+      [ -n "$PR_URL" ] && echo "[fx-task-complete] PR 생성: ${PR_URL}${ISSUE_NUM:+ (Closes #${ISSUE_NUM})}"
     fi
   fi
 else

--- a/scripts/task/task-start.sh
+++ b/scripts/task/task-start.sh
@@ -435,6 +435,17 @@ if command -v gh >/dev/null 2>&1; then
   fi
 fi
 
+# Persist ISSUE_URL into the WT's .task-context so task-complete.sh can
+# emit `Closes #N` in the generated PR body (which is how GitHub closes
+# the task issue automatically at merge time). Previously only the cache
+# held this link, so manual completion in a WT lost the reference and
+# issues were left OPEN after merge (S258 residual: #470/471/475/476/
+# 481/483/485/488 all required manual close). Append (not rewrite) so
+# we don't disturb existing keys.
+if [ -n "$ISSUE_URL" ] && [ -f "$WT_PATH/.task-context" ]; then
+  echo "ISSUE_URL=$ISSUE_URL" >> "$WT_PATH/.task-context"
+fi
+
 # ─── Step 6b: GitHub Projects Board 추가 (F501) ──────────────────────────────
 # Issue 생성 성공 시 Foundry-X Kanban 보드에 자동 추가.
 # 실패해도 task 시작은 계속 — board 연동은 부가 기능.


### PR DESCRIPTION
## Summary

Two related post-merge hygiene fixes surfaced during the S259 C18~C25 orphan sweep.

### 1. `task-complete.sh` PR body → `Closes #N`

The task orchestrator created GitHub issues at `task-start.sh` time, but `task-complete.sh` never included `Closes #N` in the generated PR body, so GitHub never auto-closed the issue at merge time. Root cause of **7 orphan OPEN issues** (#470/471/475/476/481/483/485/488) that needed manual close during this session.

Fix pipeline:
- `task-start.sh`: after `gh issue create`, append `ISSUE_URL=...` to the WT's `.task-context` (WT-local authority, preserves existing keys via `>>`)
- `task-complete.sh`: read `ISSUE_URL` from `.task-context`, extract numeric ID via `/issues/[0-9]+` regex, build PR body with a `Closes #N` line only when `ISSUE_NUM` is non-empty (degraded-start path stays clean — no literal `Closes #` text)

### 2. `sprint-merge-monitor.sh` → local branch cleanup

`gh pr merge --delete-branch` only removes the REMOTE ref. Local branches of any pattern (`sprint/*`, `task/*`, `fix/*`, `feat/*`) were lingering until the next orphan-scan sweep. S258 hit this: `fix/spec-c16-c17-closed-empty` (PR #479) and `fix/task-orchestrator-silent-drops-s257b` (PR #474) both needed manual `git branch -D`.

Fix: new step 5b `git branch -D "$branch"` after the existing `git worktree remove`, with best-effort `|| true` so a stale ref cannot abort the daemon loop. Runs after WT removal because git refuses to delete a branch that is currently checked out.

## Test plan
- [x] Syntax: 3 files `bash -n` OK
- [x] Issue regex smoke: `/issues/488 → 488`, `/pull/489 → ""` (rejects PR URLs — important because C25 cache was observed holding a PR URL in `issue_url` field post-merge), `"" → ""`, `https://example.com → ""`
- [x] Body construction: `n=488` → `\n\nCloses #488` appended, `n=""` → no Closes line
- [x] Regression: `scripts/task/test-reuse-id.sh` still 6/6 PASS
- [ ] Dogfood: next C-track task (C26+) will exercise `task-start → task-complete → daemon auto-merge → issue auto-close` end-to-end — verify on next run

## Related
- S258 MEMORY `task-start.sh ID forward 로직`
- S259 C24 `--reuse-id` flag (PR #487)
- S259 C25 `board-sync-spec gh scope preflight` (PR #489, dogfooded --reuse-id, surfaced this orphan pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)