### PR TITLE
[C26] sprint-merge-monitor dead git -C cleanup

### DIFF
--- a/scripts/sprint-merge-monitor.sh
+++ b/scripts/sprint-merge-monitor.sh
@@ -148,8 +148,7 @@ handle_merge() {
 
   # 5) worktree cleanup
   if [ -n "$wt_path" ] && [ -d "$wt_path" ]; then
-    git -C "$wt_path/../.." worktree remove "$wt_path" --force >>"$LOG_FILE" 2>&1 \
-      || git worktree remove "$wt_path" --force >>"$LOG_FILE" 2>&1 || true
+    git worktree remove "$wt_path" --force >>"$LOG_FILE" 2>&1 || true
   fi
 
   # 5b) local branch cleanup — `gh pr merge --delete-branch` only removes


### PR DESCRIPTION
Task Orchestrator — auto-created by task-complete.

- ID: C26
- Track: C
- Commits: 2
- Changes:  1 file changed, 1 insertion(+), 2 deletions(-)

Closes #491