### PR TITLE
fix(api): pre-existing test debt unblocking F509 deploy

### DIFF
--- a/packages/api/src/__tests__/mcp-adapter.test.ts
+++ b/packages/api/src/__tests__/mcp-adapter.test.ts
@@ -3,7 +3,7 @@ import { TASK_TYPE_TO_MCP_TOOL } from "../core/agent/services/mcp-adapter.js";
 import type { McpMessage, McpResponse } from "../core/agent/services/mcp-adapter.js";
 
 describe("MCP Adapter", () => {
-  it("TASK_TYPE_TO_MCP_TOOL maps all 7 task types", () => {
+  it("TASK_TYPE_TO_MCP_TOOL maps all 14 task types", () => {
     expect(TASK_TYPE_TO_MCP_TOOL["code-review"]).toBe("foundry_code_review");
     expect(TASK_TYPE_TO_MCP_TOOL["code-generation"]).toBe("foundry_code_gen");
     expect(TASK_TYPE_TO_MCP_TOOL["spec-analysis"]).toBe("foundry_spec_analyze");
@@ -14,7 +14,13 @@ describe("MCP Adapter", () => {
     expect(TASK_TYPE_TO_MCP_TOOL["ontology-lookup"]).toBe("foundry_ontology_lookup");
     expect(TASK_TYPE_TO_MCP_TOOL["security-review"]).toBe("foundry_security_review");
     expect(TASK_TYPE_TO_MCP_TOOL["qa-testing"]).toBe("foundry_qa_testing");
-    expect(Object.keys(TASK_TYPE_TO_MCP_TOOL)).toHaveLength(13);
+    // Phase 15+: BD/Discovery 확장
+    expect(TASK_TYPE_TO_MCP_TOOL["infra-analysis"]).toBe("foundry_infra_analysis");
+    expect(TASK_TYPE_TO_MCP_TOOL["bmc-generation"]).toBe("foundry_bmc_generation");
+    expect(TASK_TYPE_TO_MCP_TOOL["bmc-insight"]).toBe("foundry_bmc_insight");
+    expect(TASK_TYPE_TO_MCP_TOOL["market-summary"]).toBe("foundry_market_summary");
+    expect(TASK_TYPE_TO_MCP_TOOL["discovery-analysis"]).toBe("foundry_discovery_analysis");
+    expect(Object.keys(TASK_TYPE_TO_MCP_TOOL)).toHaveLength(14);
   });
 
   it("MCP message types have correct structure", () => {

--- a/packages/api/src/core/discovery/services/stage-runner-service.ts
+++ b/packages/api/src/core/discovery/services/stage-runner-service.ts
@@ -199,6 +199,11 @@ export class StageRunnerService {
       // 결과는 반환하되 DB 저장 실패는 로그만 — 사용자가 편집/재시도 가능
     }
 
+    // stage 상태를 completed로 복귀 (in_progress lock 해제)
+    // — 재실행 시나리오 지원: 피드백 기반 재분석이 가능해야 함
+    // — in_progress stuck 방지: race condition 가드가 영구 잠금이 되지 않도록
+    await stageSvc.updateStage(bizItemId, orgId, stage as never, "completed");
+
     // viability question
     const viabilityQuestion = isV82Stage ? VIABILITY_QUESTIONS[stage as Stage] : null;
     const commitGateQuestions = stage === "2-5" ? [...COMMIT_GATE_QUESTIONS] : null;


### PR DESCRIPTION
## 배경

Sprint 261에서 F509(fx-work-observability Walking Skeleton)를 머지했으나 `/work-management` 라우트가 프로덕션 fx.minu.best에 배포되지 않아 404. 원인 조사 결과:

1. Sprint 261 본 커밋(\`e942b87d\`)의 deploy workflow run이 SPEC DONE 메타 커밋에 의해 **concurrency group으로 cancelled**
2. 다음 trigger를 위해 manual workflow_dispatch를 돌렸더니 **pre-existing 테스트 2건**이 fail하면서 deploy-web job 전 단계에서 중단

두 테스트 실패는 F509/Sprint 261과 직접적 연관이 없으며, 앞서 merge된 다른 커밋들이 남긴 기술 부채임.

## 변경

### 1. `packages/api/src/__tests__/mcp-adapter.test.ts`
- \`TASK_TYPE_TO_MCP_TOOL\`이 14 key로 확장됐으나 테스트 \`toHaveLength(13)\` 고정
- length를 14로 올리고 누락된 5개 key(\`infra-analysis\`, \`bmc-generation\`, \`bmc-insight\`, \`market-summary\`, \`discovery-analysis\`) expect도 추가
- 테스트 타이틀 \"maps all 7 task types\" → \"maps all 14 task types\" 정정

### 2. \`packages/api/src/core/discovery/services/stage-runner-service.ts\`
- \`runStage\`가 시작 시 \`in_progress\`로 race condition 가드를 걸지만 성공 경로 끝에 상태 복귀 로직이 없어 **영구 잠금** 발생
- 실제 시나리오 영향: 사용자가 피드백과 함께 재분석을 요청해도 \`STAGE_ALREADY_RUNNING\` 에러로 차단됨
- 수정: runStage 반환 직전 \`updateStage(..., \"completed\")\` 추가로 lock 해제
- 가드 자체는 유지(동시 요청 방어는 여전히 필요)

## 검증

로컬 테스트:
\`\`\`
Test Files  2 passed (2)
     Tests  16 passed (16)
\`\`\`

## 관련

- Sprint 261 F509 PR #503 (\`e942b87d\`)
- 이 fix가 머지되면 deploy-api/deploy-web 정상 실행 → fx.minu.best/work-management 404 해소

🤖 Generated with [Claude Code](https://claude.com/claude-code)