### PR TITLE
docs(landing): Sprint 240→261 / Phase 29→33 drift 동기화

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Foundry-X가 이를 읽고 분석하고 동기화를 강제해요.
 <!-- README_SYNC_START: daily-check가 SPEC.md 실측값 기준으로 자동 동기화 -->
 | 항목 | 수치 |
 |------|------|
-| Phase | 29 ✅ (Sprint 240) |
-| Sprints | 240 완료 |
-| API Routes | ~9 (Phase 20-21 MSA 이후 core/modules 분리) |
-| API Services | ~40 (adapters 13 포함) |
-| API Schemas | ~13 |
-| Tests | ~3,262 + E2E 263 |
-| D1 Migrations | 133 (latest: 0122) |
+| Phase | 33 ✅ (Sprint 261) |
+| Sprints | 261 완료 |
+| API Routes | ~10 (Phase 20-21 MSA 이후 core/modules 분리) |
+| API Services | ~41 (adapters 13 포함) |
+| API Schemas | ~14 |
+| Tests | ~3,452 + E2E 268 |
+| D1 Migrations | 136 (latest: 0125) |
 <!-- README_SYNC_END -->
 
 ## 주요 기능

--- a/packages/web/content/landing/hero.md
+++ b/packages/web/content/landing/hero.md
@@ -3,8 +3,8 @@ title: Foundry-X
 section: hero
 sort_order: 0
 tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼"
-phase: "Phase 29 ✅"
-phaseTitle: "요구사항 거버넌스 자동화"
+phase: "Phase 33 ✅"
+phaseTitle: "Work Management Observability"
 stats:
   - value: "6"
     label: "BD 파이프라인"
@@ -12,7 +12,7 @@ stats:
     label: "AI 에이전트"
   - value: "22"
     label: "자동화 스킬"
-  - value: "240"
+  - value: "261"
     label: "Sprints"
 ---
 

--- a/packages/web/src/components/landing/footer.tsx
+++ b/packages/web/src/components/landing/footer.tsx
@@ -69,7 +69,7 @@ export function Footer() {
             &copy; {new Date().getFullYear()} KTDS AX BD. All rights reserved.
           </p>
           <p className="font-mono text-xs text-muted-foreground/60">
-            Sprint 240 &middot; Phase 29
+            Sprint 261 &middot; Phase 33
           </p>
         </div>
       </div>

--- a/packages/web/src/routes/landing.tsx
+++ b/packages/web/src/routes/landing.tsx
@@ -69,9 +69,9 @@ function getSectionOrder(section: string): number {
    ═══════════════════════════════════════════════ */
 
 const SITE_META_FALLBACK = {
-  sprint: "Sprint 240",
-  phase: "Phase 29 ✅",
-  phaseTitle: "요구사항 거버넌스 자동화",
+  sprint: "Sprint 261",
+  phase: "Phase 33 ✅",
+  phaseTitle: "Work Management Observability",
   tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼",
 } as const;
 
@@ -79,7 +79,7 @@ const STATS_FALLBACK = [
   { value: "6", label: "BD 파이프라인" },
   { value: "10+", label: "AI 에이전트" },
   { value: "22", label: "자동화 스킬" },
-  { value: "240", label: "Sprints" },
+  { value: "261", label: "Sprints" },
 ];
 
 // Build-time content from TinaCMS-managed Markdown


### PR DESCRIPTION
## Summary
- 4개 랜딩 콘텐츠 파일이 Sprint 240/Phase 29 (Apr 10 상태)에 고착되어 있던 drift 일괄 수정
- `/ax:daily-check full`이 SPEC.md §2 마지막 실측 기준으로 자동 감지/보정
- Phase 30~33(Sprint 241~261) 기간 session-end 동기화 누락분 회복

## Changes
- **README.md** sync block 7필드: Phase 33, Sprint 261, routes ~10, services ~41, schemas ~14, tests ~3,452 + E2E 268, D1 136 (0125)
- **hero.md** frontmatter: `phase`, `phaseTitle` ("Work Management Observability"), `Sprints 261`
- **landing.tsx** `SITE_META_FALLBACK` 3필드 + `STATS_FALLBACK` Sprints 261
- **footer.tsx** bottom line `Sprint 261 · Phase 33`

## Test plan
- [x] `turbo typecheck --filter=@foundry-x/web` PASS (10.9s)
- [x] 로컬 4 files changed, 15+/15-
- [ ] deploy.yml (paths filter `packages/web/**` 매칭되어 deploy-web job 실행 예상)
- [ ] fx.minu.best 랜딩 hero/footer 시각 확인 (배포 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)