### PR TITLE
[C33] eslint no-explicit-any cleanup

### DIFF
--- a/packages/cli/src/harness/lint-rules/require-zod-schema.ts
+++ b/packages/cli/src/harness/lint-rules/require-zod-schema.ts
@@ -29,6 +29,7 @@ export const requireZodSchema: Rule.RuleModule = {
           node.callee.object.property.name === "req"
         ) {
           // 부모가 이미 schema.parse() 래핑인지 확인
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ESLint AST node.parent is runtime-only, not in Rule.Node type
           const parent = (node as any).parent;
           if (
             parent?.type === "CallExpression" &&

--- a/packages/cli/src/ui/render.tsx
+++ b/packages/cli/src/ui/render.tsx
@@ -49,6 +49,7 @@ export async function renderOutput<T extends ViewType>(
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- view registry uses heterogeneous FC types
 function getViewComponent(view: ViewType): React.FC<any> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- view registry uses heterogeneous FC types
   const views: Record<ViewType, React.FC<any>> = {
     status: StatusView,
     init: InitView,


### PR DESCRIPTION
Task Orchestrator — auto-created by task-complete.

- ID: C33
- Track: C
- Commits: 2
- Changes:  2 files changed, 2 insertions(+)

Closes #509