### PR TITLE
[F510-M4] 웹 API + Kanban Sessions 탭 — 멀티 에이전트 세션 상태 노출

### DIFF
--- a/packages/api/src/__tests__/work-sessions.test.ts
+++ b/packages/api/src/__tests__/work-sessions.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Work Sessions API tests (F510 M4)
+ * WorkService.getSessions + syncSessions
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import Database from "better-sqlite3";
+import { WorkService } from "../services/work.service.js";
+import type { Env } from "../env.js";
+
+// ── Minimal D1 mock with agent_sessions schema ─────────────────────────────
+
+class D1PreparedStatement {
+  private bindings: unknown[] = [];
+  constructor(private db: Database.Database, private query: string) {}
+
+  bind(...values: unknown[]) {
+    this.bindings = values;
+    return this;
+  }
+
+  async first<T = Record<string, unknown>>(col?: string): Promise<T | null> {
+    const row = this.db.prepare(this.query).get(...this.bindings) as Record<string, unknown> | undefined;
+    if (!row) return null;
+    if (col) return (row[col] as T) ?? null;
+    return row as T;
+  }
+
+  async run() {
+    const info = this.db.prepare(this.query).run(...this.bindings);
+    return {
+      results: [] as unknown[],
+      success: true,
+      meta: { duration: 0, last_row_id: info.lastInsertRowid, changes: info.changes, served_by: "mock", internal_stats: null },
+    };
+  }
+
+  async all<T = Record<string, unknown>>() {
+    const rows = this.db.prepare(this.query).all(...this.bindings);
+    return { results: rows as T[], success: true, meta: { duration: 0, served_by: "mock", internal_stats: null } };
+  }
+}
+
+class MockSessionsD1 {
+  private db: Database.Database;
+
+  constructor() {
+    this.db = new Database(":memory:");
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS agent_sessions (
+        id            TEXT PRIMARY KEY,
+        name          TEXT NOT NULL,
+        status        TEXT NOT NULL DEFAULT 'idle',
+        profile       TEXT NOT NULL DEFAULT 'coder',
+        worktree      TEXT,
+        branch        TEXT,
+        windows       INTEGER DEFAULT 1,
+        last_activity TEXT,
+        collected_at  TEXT NOT NULL,
+        created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at    TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+    `);
+  }
+
+  prepare(query: string) {
+    return new D1PreparedStatement(this.db, query);
+  }
+
+  async batch(stmts: D1PreparedStatement[]) {
+    for (const s of stmts) await s.run();
+    return [];
+  }
+
+  async exec(query: string) {
+    this.db.exec(query);
+    return { count: 0, duration: 0 };
+  }
+}
+
+function makeEnv(db: MockSessionsD1): Env {
+  return {
+    DB: db as unknown as D1Database,
+    GITHUB_TOKEN: "",
+    JWT_SECRET: "test",
+    GITHUB_REPO: "KTDS-AXBD/Foundry-X",
+    CACHE: {} as KVNamespace,
+    AI: {} as Ai,
+    FILES_BUCKET: {} as R2Bucket,
+  };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("WorkService.getSessions", () => {
+  let db: MockSessionsD1;
+
+  beforeAll(() => {
+    db = new MockSessionsD1();
+  });
+
+  it("returns empty list when no sessions", async () => {
+    const svc = new WorkService(makeEnv(db));
+    const result = await svc.getSessions();
+    expect(result.sessions).toEqual([]);
+    expect(result.worktrees).toEqual([]);
+    expect(result.last_sync).toBeDefined();
+  });
+});
+
+describe("WorkService.syncSessions", () => {
+  let db: MockSessionsD1;
+
+  beforeAll(() => {
+    db = new MockSessionsD1();
+  });
+
+  const sampleInput = {
+    sessions: [
+      { name: "sprint-262", status: "busy", profile: "coder", windows: 2, last_activity: 1744450800 },
+      { name: "sprint-261", status: "idle", profile: "reviewer", windows: 1, last_activity: 1744447200 },
+    ],
+    worktrees: [
+      { path: "/home/sinclair/work/worktrees/Foundry-X/sprint-262", branch: "refs/heads/sprint/262" },
+    ],
+    collected_at: "2026-04-12T10:00:00Z",
+  };
+
+  it("syncs sessions and returns correct counts", async () => {
+    const svc = new WorkService(makeEnv(db));
+    const result = await svc.syncSessions(sampleInput);
+    expect(result.synced).toBe(2);
+    expect(result.removed).toBe(0);
+  });
+
+  it("getSessions returns synced data", async () => {
+    const svc = new WorkService(makeEnv(db));
+    const result = await svc.getSessions();
+    expect(result.sessions).toHaveLength(2);
+
+    const busy = result.sessions.find(s => s.name === "sprint-262");
+    expect(busy?.status).toBe("busy");
+    expect(busy?.profile).toBe("coder");
+    expect(busy?.windows).toBe(2);
+
+    const idle = result.sessions.find(s => s.name === "sprint-261");
+    expect(idle?.status).toBe("idle");
+    expect(idle?.profile).toBe("reviewer");
+  });
+
+  it("removes stale sessions on re-sync", async () => {
+    const svc = new WorkService(makeEnv(db));
+
+    const result = await svc.syncSessions({
+      sessions: [{ name: "sprint-262", status: "busy", profile: "coder", windows: 2, last_activity: 1744450800 }],
+      worktrees: [],
+      collected_at: "2026-04-12T10:01:00Z",
+    });
+    expect(result.synced).toBe(1);
+    expect(result.removed).toBe(1);
+
+    const list = await svc.getSessions();
+    expect(list.sessions).toHaveLength(1);
+    expect(list.sessions[0]?.name).toBe("sprint-262");
+  });
+
+  it("normalises unknown status to idle", async () => {
+    const svc = new WorkService(makeEnv(db));
+    await svc.syncSessions({
+      sessions: [{ name: "sprint-263", status: "unknown_state", profile: "coder", windows: 1, last_activity: 0 }],
+      worktrees: [],
+      collected_at: "2026-04-12T10:02:00Z",
+    });
+    const list = await svc.getSessions();
+    const s = list.sessions.find(x => x.name === "sprint-263");
+    expect(s?.status).toBe("idle");
+  });
+
+  it("normalises unknown profile to unknown", async () => {
+    const svc = new WorkService(makeEnv(db));
+    await svc.syncSessions({
+      sessions: [{ name: "sprint-264", status: "idle", profile: "super-agent", windows: 1, last_activity: 0 }],
+      worktrees: [],
+      collected_at: "2026-04-12T10:03:00Z",
+    });
+    const list = await svc.getSessions();
+    const s = list.sessions.find(x => x.name === "sprint-264");
+    expect(s?.profile).toBe("unknown");
+  });
+
+  it("clears all sessions when empty array is synced", async () => {
+    const svc = new WorkService(makeEnv(db));
+    await svc.syncSessions({
+      sessions: [],
+      worktrees: [],
+      collected_at: "2026-04-12T10:05:00Z",
+    });
+    const list = await svc.getSessions();
+    expect(list.sessions).toHaveLength(0);
+  });
+});

--- a/packages/api/src/db/migrations/0126_agent_sessions.sql
+++ b/packages/api/src/db/migrations/0126_agent_sessions.sql
@@ -1,0 +1,18 @@
+-- Migration: 0126_agent_sessions.sql
+-- Feature: F510 fx-multi-agent-session M4
+
+CREATE TABLE IF NOT EXISTS agent_sessions (
+  id            TEXT PRIMARY KEY,
+  name          TEXT NOT NULL,
+  status        TEXT NOT NULL DEFAULT 'idle',
+  profile       TEXT NOT NULL DEFAULT 'coder',
+  worktree      TEXT,
+  branch        TEXT,
+  windows       INTEGER DEFAULT 1,
+  last_activity TEXT,
+  collected_at  TEXT NOT NULL,
+  created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_status ON agent_sessions(status);

--- a/packages/api/src/routes/work.ts
+++ b/packages/api/src/routes/work.ts
@@ -4,6 +4,9 @@ import {
   WorkContextSchema,
   ClassifyInputSchema,
   ClassifyOutputSchema,
+  SessionListSchema,
+  SessionSyncInputSchema,
+  SessionSyncOutputSchema,
 } from "../schemas/work.js";
 import type { Env } from "../env.js";
 import { WorkService } from "../services/work.service.js";
@@ -78,5 +81,55 @@ workRoute.openapi(classifyWork, async (c) => {
   const { text } = c.req.valid("json");
   const svc = new WorkService(c.env);
   const result = await svc.classify(text);
+  return c.json(result);
+});
+
+// ─── GET /api/work/sessions (F510 M4) ───────────────────────────────────────
+
+const getSessions = createRoute({
+  method: "get",
+  path: "/work/sessions",
+  tags: ["Work Observability"],
+  summary: "Agent session list collected from local tmux/git state",
+  responses: {
+    200: {
+      content: { "application/json": { schema: SessionListSchema } },
+      description: "Agent sessions",
+    },
+  },
+});
+
+workRoute.openapi(getSessions, async (c) => {
+  const svc = new WorkService(c.env);
+  const data = await svc.getSessions();
+  return c.json(data);
+});
+
+// ─── POST /api/work/sessions/sync (F510 M4) ──────────────────────────────────
+
+const syncSessions = createRoute({
+  method: "post",
+  path: "/work/sessions/sync",
+  tags: ["Work Observability"],
+  summary: "Upsert agent session state from local collector script",
+  request: {
+    body: { content: { "application/json": { schema: SessionSyncInputSchema } } },
+  },
+  responses: {
+    200: {
+      content: { "application/json": { schema: SessionSyncOutputSchema } },
+      description: "Sync result",
+    },
+    400: {
+      content: { "application/json": { schema: z.object({ error: z.string() }) } },
+      description: "Invalid input",
+    },
+  },
+});
+
+workRoute.openapi(syncSessions, async (c) => {
+  const body = c.req.valid("json");
+  const svc = new WorkService(c.env);
+  const result = await svc.syncSessions(body);
   return c.json(result);
 });

--- a/packages/api/src/schemas/work.ts
+++ b/packages/api/src/schemas/work.ts
@@ -53,6 +53,49 @@ export const ClassifyInputSchema = z.object({
   text: z.string().min(1).max(500),
 });
 
+// ─── Agent Sessions (F510 M4) ──────────────────────────────────────────────
+
+export const AgentSessionSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  status: z.enum(["busy", "idle", "done"]),
+  profile: z.enum(["coder", "reviewer", "tester", "unknown"]),
+  worktree: z.string().optional(),
+  branch: z.string().optional(),
+  windows: z.number(),
+  last_activity: z.string().optional(),
+  collected_at: z.string(),
+});
+
+export const SessionListSchema = z.object({
+  sessions: z.array(AgentSessionSchema),
+  worktrees: z.array(z.object({
+    path: z.string(),
+    branch: z.string(),
+  })),
+  last_sync: z.string(),
+});
+
+export const SessionSyncInputSchema = z.object({
+  sessions: z.array(z.object({
+    name: z.string(),
+    status: z.string(),
+    profile: z.string(),
+    windows: z.number(),
+    last_activity: z.number(),
+  })),
+  worktrees: z.array(z.object({
+    path: z.string(),
+    branch: z.string(),
+  })),
+  collected_at: z.string(),
+});
+
+export const SessionSyncOutputSchema = z.object({
+  synced: z.number(),
+  removed: z.number(),
+});
+
 export const ClassifyOutputSchema = z.object({
   track: z.enum(["F", "B", "C", "X"]),
   priority: z.enum(["P0", "P1", "P2", "P3"]),

--- a/packages/api/src/services/work.service.ts
+++ b/packages/api/src/services/work.service.ts
@@ -232,6 +232,106 @@ export class WorkService {
     };
   }
 
+  // ─── Agent Sessions (F510 M4) ────────────────────────────────────────────
+
+  async getSessions() {
+    const result = await this.env.DB.prepare(
+      `SELECT id, name, status, profile, worktree, branch, windows, last_activity, collected_at
+       FROM agent_sessions ORDER BY status ASC, last_activity DESC`
+    ).all<{
+      id: string; name: string; status: string; profile: string;
+      worktree: string | null; branch: string | null; windows: number;
+      last_activity: string | null; collected_at: string;
+    }>();
+
+    const rows = result.results ?? [];
+    const lastSync = rows[0]?.collected_at ?? new Date(0).toISOString();
+
+    // Fetch paired worktrees from dedicated sync table column aggregation
+    const wtResult = await this.env.DB.prepare(
+      `SELECT DISTINCT worktree AS path, branch FROM agent_sessions WHERE worktree IS NOT NULL`
+    ).all<{ path: string; branch: string }>();
+
+    return {
+      sessions: rows.map(r => ({
+        id: r.id,
+        name: r.name,
+        status: r.status as "busy" | "idle" | "done",
+        profile: r.profile as "coder" | "reviewer" | "tester" | "unknown",
+        worktree: r.worktree ?? undefined,
+        branch: r.branch ?? undefined,
+        windows: r.windows,
+        last_activity: r.last_activity ?? undefined,
+        collected_at: r.collected_at,
+      })),
+      worktrees: (wtResult.results ?? []).map(r => ({ path: r.path, branch: r.branch })),
+      last_sync: lastSync,
+    };
+  }
+
+  async syncSessions(input: {
+    sessions: Array<{ name: string; status: string; profile: string; windows: number; last_activity: number }>;
+    worktrees: Array<{ path: string; branch: string }>;
+    collected_at: string;
+  }) {
+    const now = new Date().toISOString();
+
+    // Upsert each session (id = session name, stable identifier)
+    const stmts = input.sessions.map(s => {
+      const lastActivityIso = s.last_activity
+        ? new Date(s.last_activity * 1000).toISOString()
+        : null;
+
+      // Normalise profile to allowed enum values
+      let profile = s.profile;
+      if (!["coder", "reviewer", "tester"].includes(profile)) profile = "unknown";
+
+      // Normalise status
+      let status = s.status;
+      if (!["busy", "idle", "done"].includes(status)) status = "idle";
+
+      return this.env.DB.prepare(
+        `INSERT INTO agent_sessions (id, name, status, profile, windows, last_activity, collected_at, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET
+           status       = excluded.status,
+           profile      = excluded.profile,
+           windows      = excluded.windows,
+           last_activity= excluded.last_activity,
+           collected_at = excluded.collected_at,
+           updated_at   = excluded.updated_at`
+      ).bind(s.name, s.name, status, profile, s.windows, lastActivityIso, input.collected_at, now, now);
+    });
+
+    if (stmts.length > 0) {
+      await this.env.DB.batch(stmts);
+    }
+
+    // Remove sessions not present in this batch (stale = terminated)
+    const activeNames = input.sessions.map(s => `'${s.name.replace(/'/g, "''")}'`).join(",");
+    let removed = 0;
+    if (activeNames.length > 0) {
+      const del = await this.env.DB.prepare(
+        `DELETE FROM agent_sessions WHERE id NOT IN (${activeNames})`
+      ).run();
+      removed = del.meta.changes ?? 0;
+    } else {
+      // No sessions reported → clear all
+      const del = await this.env.DB.prepare(`DELETE FROM agent_sessions`).run();
+      removed = del.meta.changes ?? 0;
+    }
+
+    // Upsert worktree info into sessions rows where name matches branch suffix
+    for (const wt of input.worktrees) {
+      const branch = wt.branch.replace(/^refs\/heads\//, "");
+      await this.env.DB.prepare(
+        `UPDATE agent_sessions SET worktree = ?, branch = ? WHERE name LIKE ? AND worktree IS NULL`
+      ).bind(wt.path, branch, `%${branch.split("/").pop() ?? ""}%`).run();
+    }
+
+    return { synced: input.sessions.length, removed };
+  }
+
   private classifyWithRegex(text: string) {
     const lower = text.toLowerCase();
 

--- a/packages/web/e2e/work-management.spec.ts
+++ b/packages/web/e2e/work-management.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from "./fixtures/auth";
 
 // @service: portal
-// @sprint: 261
-// @tagged-by: F509
+// @sprint: 261, 262
+// @tagged-by: F509, F510
 // @spec: docs/specs/fx-work-observability/prd-v1.md §5.2.1 (End-to-end 시나리오 S1)
 
 // ─── Mock payloads ───────────────────────────────────────────────────────────
@@ -32,6 +32,26 @@ const MOCK_CONTEXT = {
   note: "test-only mock context",
 };
 
+const MOCK_SESSIONS = {
+  sessions: [
+    {
+      id: "sprint-262", name: "sprint-262", status: "busy", profile: "coder",
+      worktree: "/home/sinclair/work/worktrees/Foundry-X/sprint-262",
+      branch: "sprint/262", windows: 2, last_activity: "2026-04-12T10:00:00Z",
+      collected_at: "2026-04-12T10:00:00Z",
+    },
+    {
+      id: "sprint-261", name: "sprint-261", status: "idle", profile: "reviewer",
+      branch: "sprint/261", windows: 1, last_activity: "2026-04-12T09:30:00Z",
+      collected_at: "2026-04-12T10:00:00Z",
+    },
+  ],
+  worktrees: [
+    { path: "/home/sinclair/work/worktrees/Foundry-X/sprint-262", branch: "sprint/262" },
+  ],
+  last_sync: "2026-04-12T10:00:00Z",
+};
+
 const MOCK_CLASSIFY = {
   track: "F" as const,
   priority: "P1" as const,
@@ -55,6 +75,13 @@ async function mockWorkApi(page: import("@playwright/test").Page) {
       status: 200,
       contentType: "application/json",
       body: JSON.stringify(MOCK_CONTEXT),
+    }),
+  );
+  await page.route("**/api/work/sessions", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(MOCK_SESSIONS),
     }),
   );
   await page.route("**/api/work/classify", (route) => {
@@ -129,6 +156,29 @@ test.describe("Work Management (F509 Walking Skeleton)", () => {
     await expect(page.getByText("다음 가능 Action")).toBeVisible();
     await expect(page.getByText("Sprint 261 F509 post-merge 검증")).toBeVisible();
     await expect(page.getByText("fx.minu.best /work-management 실물 확인")).toBeVisible();
+  });
+
+  test("sessions tab — renders session cards and worktrees (F510 M4)", async ({ authenticatedPage: page }) => {
+    await mockWorkApi(page);
+    await page.goto("/work-management");
+
+    await page.getByRole("button", { name: "Sessions" }).click();
+
+    // Status summary bar
+    await expect(page.getByText("Busy", { exact: true })).toBeVisible();
+    await expect(page.getByText("Idle", { exact: true })).toBeVisible();
+
+    // Session cards
+    await expect(page.getByText("sprint-262")).toBeVisible();
+    await expect(page.getByText("sprint-261")).toBeVisible();
+
+    // Profile badges
+    await expect(page.getByText("coder", { exact: true }).first()).toBeVisible();
+    await expect(page.getByText("reviewer", { exact: true }).first()).toBeVisible();
+
+    // Worktrees section
+    await expect(page.getByText("Worktrees (1)")).toBeVisible();
+    await expect(page.getByText("sprint/262")).toBeVisible();
   });
 
   test("classify flow — PRD §5.2.1 S1 step 2 (자연어 → track/priority/title)", async ({ authenticatedPage: page }) => {

--- a/packages/web/src/routes/work-management.tsx
+++ b/packages/web/src/routes/work-management.tsx
@@ -40,6 +40,27 @@ interface ClassifyResult {
   method: "llm" | "regex";
 }
 
+type SessionStatus = "busy" | "idle" | "done";
+type SessionProfile = "coder" | "reviewer" | "tester" | "unknown";
+
+interface AgentSession {
+  id: string;
+  name: string;
+  status: SessionStatus;
+  profile: SessionProfile;
+  worktree?: string;
+  branch?: string;
+  windows: number;
+  last_activity?: string;
+  collected_at: string;
+}
+
+interface SessionList {
+  sessions: AgentSession[];
+  worktrees: Array<{ path: string; branch: string }>;
+  last_sync: string;
+}
+
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 const COLUMNS: { key: WorkStatus; label: string; color: string }[] = [
@@ -122,6 +143,198 @@ function ItemCard({ item }: { item: WorkItem }) {
         {item.priority && <Badge label={priority} color={PRIORITY_COLORS[priority] ?? "#6b7280"} />}
         {item.req_code && <Badge label={item.req_code} color="#0ea5e9" />}
       </div>
+    </div>
+  );
+}
+
+const STATUS_META: Record<SessionStatus, { label: string; dot: string; color: string }> = {
+  busy:  { label: "BUSY",  dot: "🟢", color: "#22c55e" },
+  idle:  { label: "IDLE",  dot: "🟡", color: "#f59e0b" },
+  done:  { label: "DONE",  dot: "⚫", color: "#6b7280" },
+};
+
+const PROFILE_META: Record<SessionProfile, { label: string; color: string }> = {
+  coder:    { label: "coder",    color: "#3b82f6" },
+  reviewer: { label: "reviewer", color: "#8b5cf6" },
+  tester:   { label: "tester",   color: "#06b6d4" },
+  unknown:  { label: "unknown",  color: "#6b7280" },
+};
+
+function SessionCard({ session }: { session: AgentSession }) {
+  const statusMeta = STATUS_META[session.status];
+  const profileMeta = PROFILE_META[session.profile];
+  return (
+    <div
+      style={{
+        background: "#1e293b",
+        border: `1px solid ${statusMeta.color}44`,
+        borderRadius: 8,
+        padding: "10px 12px",
+        display: "flex",
+        flexDirection: "column",
+        gap: 6,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <span style={{ fontSize: 14 }}>{statusMeta.dot}</span>
+        <span style={{ fontWeight: 600, fontSize: 13, color: "#f1f5f9", flex: 1 }}>{session.name}</span>
+        <Badge label={statusMeta.label} color={statusMeta.color} />
+      </div>
+      <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+        <Badge label={profileMeta.label} color={profileMeta.color} />
+        {session.windows > 1 && (
+          <Badge label={`${session.windows}w`} color="#475569" />
+        )}
+      </div>
+      {session.branch && (
+        <div style={{ fontSize: 11, color: "#64748b", fontFamily: "monospace" }}>
+          {session.branch}
+        </div>
+      )}
+      {session.last_activity && (
+        <div style={{ fontSize: 11, color: "#334155" }}>
+          활동: {formatDate(session.last_activity)}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SessionsTab({ data }: { data: SessionList | null }) {
+  if (!data) {
+    return <div style={{ color: "#94a3b8", padding: 20 }}>불러오는 중…</div>;
+  }
+
+  const busy = data.sessions.filter(s => s.status === "busy");
+  const idle = data.sessions.filter(s => s.status === "idle");
+  const done = data.sessions.filter(s => s.status === "done");
+
+  const syncAge = data.last_sync
+    ? Math.round((Date.now() - new Date(data.last_sync).getTime()) / 1000)
+    : null;
+
+  const syncStale = syncAge !== null && syncAge > 120;
+
+  return (
+    <div>
+      {/* Status bar */}
+      <div
+        style={{
+          display: "flex",
+          gap: 20,
+          marginBottom: 20,
+          background: "#0f172a",
+          padding: "10px 14px",
+          borderRadius: 8,
+          alignItems: "center",
+        }}
+      >
+        {[
+          { label: "Busy",  value: busy.length,  color: "#22c55e" },
+          { label: "Idle",  value: idle.length,  color: "#f59e0b" },
+          { label: "Done",  value: done.length,  color: "#6b7280" },
+        ].map(({ label, value, color }) => (
+          <div key={label} style={{ textAlign: "center" }}>
+            <div style={{ fontSize: 22, fontWeight: 700, color }}>{value}</div>
+            <div style={{ fontSize: 11, color: "#64748b" }}>{label}</div>
+          </div>
+        ))}
+        <div style={{ marginLeft: "auto", fontSize: 11, color: syncStale ? "#ef4444" : "#334155" }}>
+          {syncAge !== null
+            ? syncStale
+              ? `⚠️ sync 끊김 (${syncAge}s ago)`
+              : `Last sync: ${syncAge}s ago`
+            : "동기화 대기 중"}
+        </div>
+      </div>
+
+      {data.sessions.length === 0 ? (
+        <div
+          style={{
+            border: "1px dashed #1e293b",
+            borderRadius: 8,
+            padding: 24,
+            color: "#475569",
+            textAlign: "center",
+            fontSize: 13,
+          }}
+        >
+          활성 세션 없음 — session-collector.sh가 실행 중인지 확인하세요
+        </div>
+      ) : (
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 12, marginBottom: 24 }}>
+          {[
+            { label: "BUSY",  items: busy,  color: "#22c55e" },
+            { label: "IDLE",  items: idle,  color: "#f59e0b" },
+            { label: "DONE",  items: done,  color: "#6b7280" },
+          ].map(col => (
+            <div key={col.label}>
+              <div
+                style={{
+                  padding: "6px 10px",
+                  background: col.color + "22",
+                  border: `1px solid ${col.color}44`,
+                  borderRadius: 6,
+                  marginBottom: 8,
+                  fontWeight: 600,
+                  fontSize: 12,
+                  color: col.color,
+                  display: "flex",
+                  justifyContent: "space-between",
+                }}
+              >
+                <span>{col.label}</span>
+                <span style={{ opacity: 0.7 }}>{col.items.length}</span>
+              </div>
+              <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                {col.items.length === 0 ? (
+                  <div
+                    style={{
+                      border: "1px dashed #1e293b",
+                      borderRadius: 6,
+                      padding: 12,
+                      color: "#334155",
+                      fontSize: 12,
+                      textAlign: "center",
+                    }}
+                  >
+                    비어있음
+                  </div>
+                ) : (
+                  col.items.map(s => <SessionCard key={s.id} session={s} />)
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Worktrees */}
+      {data.worktrees.length > 0 && (
+        <section>
+          <h3 style={{ color: "#94a3b8", fontSize: 13, marginBottom: 10 }}>
+            Worktrees ({data.worktrees.length})
+          </h3>
+          <div style={{ fontFamily: "monospace" }}>
+            {data.worktrees.map((wt, i) => (
+              <div
+                key={i}
+                style={{
+                  padding: "6px 10px",
+                  borderBottom: "1px solid #1e293b",
+                  fontSize: 12,
+                  display: "flex",
+                  gap: 10,
+                }}
+              >
+                <span style={{ color: "#64748b" }}>└</span>
+                <span style={{ color: "#cbd5e1", flex: 1 }}>{wt.path}</span>
+                <span style={{ color: "#f59e0b" }}>{wt.branch}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
     </div>
   );
 }
@@ -436,12 +649,13 @@ function ClassifyTab() {
 
 // ─── Main Route Component ─────────────────────────────────────────────────────
 
-type Tab = "kanban" | "context" | "classify";
+type Tab = "kanban" | "context" | "classify" | "sessions";
 
 export function Component() {
   const [tab, setTab] = useState<Tab>("kanban");
   const [snapshot, setSnapshot] = useState<WorkSnapshot | null>(null);
   const [ctx, setCtx] = useState<WorkContext | null>(null);
+  const [sessions, setSessions] = useState<SessionList | null>(null);
   const [lastUpdate, setLastUpdate] = useState<Date | null>(null);
 
   const fetchSnapshot = useCallback(async () => {
@@ -467,18 +681,34 @@ export function Component() {
     }
   }, []);
 
+  const fetchSessions = useCallback(async () => {
+    try {
+      const res = await fetch(`${BASE_URL}/work/sessions`);
+      if (res.ok) {
+        setSessions((await res.json()) as SessionList);
+      }
+    } catch {
+      // ignore
+    }
+  }, []);
+
   // Initial fetch + 5s polling
   useEffect(() => {
     fetchSnapshot();
     fetchContext();
-    const id = setInterval(fetchSnapshot, 5000);
+    fetchSessions();
+    const id = setInterval(() => {
+      fetchSnapshot();
+      fetchSessions();
+    }, 5000);
     return () => clearInterval(id);
-  }, [fetchSnapshot, fetchContext]);
+  }, [fetchSnapshot, fetchContext, fetchSessions]);
 
   const tabs: { key: Tab; label: string }[] = [
     { key: "kanban",   label: "Kanban" },
     { key: "context",  label: "Context Resume" },
     { key: "classify", label: "Classify" },
+    { key: "sessions", label: "Sessions" },
   ];
 
   return (
@@ -529,6 +759,7 @@ export function Component() {
       {tab === "kanban"   && <KanbanTab   snapshot={snapshot} />}
       {tab === "context"  && <ContextTab  ctx={ctx} />}
       {tab === "classify" && <ClassifyTab />}
+      {tab === "sessions" && <SessionsTab data={sessions} />}
     </div>
   );
 }

--- a/scripts/session-collector.sh
+++ b/scripts/session-collector.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# session-collector.sh — cs/tmux 세션 상태를 Foundry-X D1에 동기화
+# Usage: ./scripts/session-collector.sh
+# Cron:  */1 * * * * /home/sinclair/work/axbd/Foundry-X/scripts/session-collector.sh
+#
+# Required env:
+#   FOUNDRY_API_TOKEN — JWT (from `claude auth` or manual login)
+# Optional env:
+#   FOUNDRY_API_URL   — defaults to production Workers URL
+
+set -euo pipefail
+
+API_URL="${FOUNDRY_API_URL:-https://foundry-x-api.ktds-axbd.workers.dev}"
+API_TOKEN="${FOUNDRY_API_TOKEN:-}"
+
+if [ -z "$API_TOKEN" ]; then
+  echo "❌ FOUNDRY_API_TOKEN is not set" >&2
+  exit 1
+fi
+
+COLLECTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# ── 1. tmux 세션 목록 수집 ─────────────────────────────────────────────────
+
+sessions_raw=$(tmux list-sessions -F '#{session_name}|#{session_activity}|#{session_windows}' 2>/dev/null || true)
+
+# ── 2. git worktree 목록 수집 ─────────────────────────────────────────────
+
+REPO_DIR="${FOUNDRY_REPO_DIR:-$HOME/work/axbd/Foundry-X}"
+worktrees_raw=$(git -C "$REPO_DIR" worktree list --porcelain 2>/dev/null \
+  | awk '/^worktree /{wt=$2} /^branch /{br=$2; print wt"|"br}' || true)
+
+# ── 3. JSON 페이로드 조립 ──────────────────────────────────────────────────
+
+now_epoch=$(date +%s)
+
+sessions_json="["
+first_s=true
+
+while IFS='|' read -r name activity windows; do
+  [ -z "$name" ] && continue
+
+  # busy/idle 판정: 60초 이내 활동
+  diff=$(( now_epoch - activity ))
+  status="idle"
+  [ "$diff" -lt 60 ] && status="busy"
+
+  # 프로파일 추론 (session name 패턴)
+  profile="unknown"
+  case "$name" in
+    *sonnet*|*coder*)    profile="coder" ;;
+    *opus*|*reviewer*)   profile="reviewer" ;;
+    *haiku*|*tester*)    profile="tester" ;;
+    sprint-*)            profile="coder" ;;
+  esac
+
+  # JSON 특수문자 이스케이프 (name)
+  name_escaped=$(printf '%s' "$name" | sed 's/\\/\\\\/g; s/"/\\"/g')
+
+  $first_s || sessions_json+=","
+  first_s=false
+  sessions_json+="{\"name\":\"$name_escaped\",\"status\":\"$status\",\"profile\":\"$profile\",\"windows\":$windows,\"last_activity\":$activity}"
+done <<< "$sessions_raw"
+
+sessions_json+="]"
+
+worktrees_json="["
+first_w=true
+
+while IFS='|' read -r wt_path wt_branch; do
+  [ -z "$wt_path" ] && continue
+
+  path_escaped=$(printf '%s' "$wt_path" | sed 's/\\/\\\\/g; s/"/\\"/g')
+  branch_escaped=$(printf '%s' "$wt_branch" | sed 's/\\/\\\\/g; s/"/\\"/g')
+
+  $first_w || worktrees_json+=","
+  first_w=false
+  worktrees_json+="{\"path\":\"$path_escaped\",\"branch\":\"$branch_escaped\"}"
+done <<< "$worktrees_raw"
+
+worktrees_json+="]"
+
+payload="{\"sessions\":$sessions_json,\"worktrees\":$worktrees_json,\"collected_at\":\"$COLLECTED_AT\"}"
+
+# ── 4. API로 전송 ──────────────────────────────────────────────────────────
+
+response=$(curl -s -w "\n%{http_code}" -X POST "$API_URL/api/work/sessions/sync" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $API_TOKEN" \
+  -d "$payload")
+
+http_code=$(printf '%s' "$response" | tail -n1)
+body=$(printf '%s' "$response" | head -n -1)
+
+if [ "$http_code" = "200" ]; then
+  echo "✅ sync OK — $body"
+else
+  echo "❌ sync failed (HTTP $http_code): $body" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- D1 migration `0126_agent_sessions.sql` — `agent_sessions` 테이블 (id/name/status/profile/worktree/branch/windows/last_activity/collected_at)
- `GET /api/work/sessions` + `POST /api/work/sessions/sync` 2 엔드포인트
- `WorkService.getSessions/syncSessions` — upsert + stale 세션 자동 제거 + profile/status 정규화
- Zod 스키마 3종 추가 (`AgentSessionSchema`, `SessionListSchema`, `SessionSyncInputSchema`)
- Web `/work-management` Sessions 탭 — busy/idle/done 3컬럼 Kanban + Worktrees 패널 + sync stale 경고
- `scripts/session-collector.sh` — tmux list-sessions + git worktree 파싱 → POST sync (cron 용)
- Vitest 7개 (getSessions + syncSessions 단위 테스트) + E2E Sessions 탭 테스트 추가

## Design reference
`docs/specs/fx-multi-agent-session/design.md §6`

## Test plan
- [ ] `pnpm test src/__tests__/work-sessions.test.ts` — 7 tests pass
- [ ] E2E: `pnpm e2e --grep "sessions tab"` — Sessions 탭 카드 + Worktrees 렌더링 확인
- [ ] D1 migration CI auto-apply (deploy.yml)
- [ ] `FOUNDRY_API_TOKEN=<jwt> ./scripts/session-collector.sh` 수동 실행 → sync OK 확인 (M4 통합 테스트)

🤖 Generated with [Claude Code](https://claude.com/claude-code)