### PR TITLE
chore(ci): bump dorny/paths-filter v3 → v4 (Node 24)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |


### PR DESCRIPTION
## Summary
- `dorny/paths-filter@v3` → `@v4` — Node 24 런타임 호환성 확보
- GitHub Actions가 2026-06-02부터 Node 24 강제 전환, v3은 node20 기반
- 나머지 actions (checkout@v4, setup-node@v4, pnpm/action-setup@v4, wrangler-action@v3)는 현재 major 내에서 node24 지원 확인

## Test plan
- [ ] CI deploy workflow 정상 실행 확인 (paths-filter 출력 변동 없음)
- [ ] api/web/code 필터 결과가 기존과 동일한지 확인

Refs: FX-REQ-529 (C34)

🤖 Generated with [Claude Code](https://claude.com/claude-code)