### PR TITLE
fix(web): work-management 401 Unauthorized

### DIFF
--- a/packages/web/e2e/work-management.spec.ts
+++ b/packages/web/e2e/work-management.spec.ts
@@ -176,9 +176,9 @@ test.describe("Work Management (F509 Walking Skeleton)", () => {
     await expect(page.getByText("coder", { exact: true }).first()).toBeVisible();
     await expect(page.getByText("reviewer", { exact: true }).first()).toBeVisible();
 
-    // Worktrees section
+    // Worktrees section (sprint/262 appears in session card branch + worktree list)
     await expect(page.getByText("Worktrees (1)")).toBeVisible();
-    await expect(page.getByText("sprint/262")).toBeVisible();
+    await expect(page.getByText("sprint/262").first()).toBeVisible();
   });
 
   test("classify flow — PRD §5.2.1 S1 step 2 (자연어 → track/priority/title)", async ({ authenticatedPage: page }) => {

--- a/packages/web/e2e/work-management.spec.ts
+++ b/packages/web/e2e/work-management.spec.ts
@@ -168,8 +168,8 @@ test.describe("Work Management (F509 Walking Skeleton)", () => {
     await expect(page.getByText("Busy", { exact: true })).toBeVisible();
     await expect(page.getByText("Idle", { exact: true })).toBeVisible();
 
-    // Session cards
-    await expect(page.getByText("sprint-262")).toBeVisible();
+    // Session cards (sprint-262 appears in both card and worktree path, use .first())
+    await expect(page.getByText("sprint-262").first()).toBeVisible();
     await expect(page.getByText("sprint-261")).toBeVisible();
 
     // Profile badges

--- a/packages/web/src/routes/work-management.tsx
+++ b/packages/web/src/routes/work-management.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
-import { BASE_URL } from "@/lib/api-client";
+import { fetchApi, postApi } from "@/lib/api-client";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -547,13 +547,7 @@ function ClassifyTab() {
     setError(null);
     setResult(null);
     try {
-      const res = await fetch(`${BASE_URL}/work/classify`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ text: input }),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = (await res.json()) as ClassifyResult;
+      const data = await postApi<ClassifyResult>("/work/classify", { text: input });
       setResult(data);
     } catch (e) {
       setError(e instanceof Error ? e.message : "분류 실패");
@@ -660,11 +654,9 @@ export function Component() {
 
   const fetchSnapshot = useCallback(async () => {
     try {
-      const res = await fetch(`${BASE_URL}/work/snapshot`);
-      if (res.ok) {
-        setSnapshot((await res.json()) as WorkSnapshot);
-        setLastUpdate(new Date());
-      }
+      const data = await fetchApi<WorkSnapshot>("/work/snapshot");
+      setSnapshot(data);
+      setLastUpdate(new Date());
     } catch {
       // silently ignore — stale data shows
     }
@@ -672,10 +664,7 @@ export function Component() {
 
   const fetchContext = useCallback(async () => {
     try {
-      const res = await fetch(`${BASE_URL}/work/context`);
-      if (res.ok) {
-        setCtx((await res.json()) as WorkContext);
-      }
+      setCtx(await fetchApi<WorkContext>("/work/context"));
     } catch {
       // ignore
     }
@@ -683,10 +672,7 @@ export function Component() {
 
   const fetchSessions = useCallback(async () => {
     try {
-      const res = await fetch(`${BASE_URL}/work/sessions`);
-      if (res.ok) {
-        setSessions((await res.json()) as SessionList);
-      }
+      setSessions(await fetchApi<SessionList>("/work/sessions"));
     } catch {
       // ignore
     }


### PR DESCRIPTION
## Summary
- `/api/work/snapshot`, `/api/work/context`, `/api/work/sessions`, `/api/work/classify` 4개 엔드포인트가 프로덕션에서 401 Unauthorized 반환
- 원인: `work-management.tsx`가 `api-client.ts`의 인증 패턴을 사용하지 않고 plain `fetch()` 호출
- 수정: `fetchApi<T>()` / `postApi<T>()` 로 교체 → JWT 자동 첨부 + 401 시 토큰 refresh 자동 retry

## Test plan
- [ ] 로컬 dev server에서 `/work-management` 라우트 진입 후 Kanban/Context/Sessions/Classify 4탭 정상 데이터 로드 확인
- [ ] 프로덕션 배포 후 `fx.minu.best/work-management` 에서 401 해소 확인
- [ ] E2E `work-management.spec.ts` 6 tests all passing (mock 기반, 변경에 무영향)

🤖 Generated with [Claude Code](https://claude.com/claude-code)