### PR TITLE
fix(web): 작업 현황 sidebar topItems 이동

### DIFF
--- a/packages/web/content/navigation/sidebar.json
+++ b/packages/web/content/navigation/sidebar.json
@@ -2,7 +2,8 @@
   "navId": "main-sidebar",
   "topItems": [
     { "href": "/dashboard", "label": "대시보드", "iconKey": "LayoutDashboard", "visible": true, "sortOrder": 0 },
-    { "href": "/getting-started", "label": "새 아이템", "iconKey": "Plus", "visible": true, "sortOrder": 1 }
+    { "href": "/work-management", "label": "작업 현황", "iconKey": "Kanban", "visible": true, "sortOrder": 1 },
+    { "href": "/getting-started", "label": "새 아이템", "iconKey": "Plus", "visible": true, "sortOrder": 2 }
   ],
   "processGroups": [
     {
@@ -95,8 +96,7 @@
       "badge": "core",
       "items": [
         { "href": "/agents", "label": "에이전트", "iconKey": "Bot", "visible": true, "sortOrder": 0 },
-        { "href": "/work-management", "label": "작업 현황", "iconKey": "Kanban", "visible": true, "sortOrder": 1 },
-        { "href": "/architecture", "label": "아키텍처", "iconKey": "Blocks", "visible": true, "sortOrder": 2 },
+        { "href": "/architecture", "label": "아키텍처", "iconKey": "Blocks", "visible": true, "sortOrder": 1 },
         { "href": "/methodologies", "label": "방법론", "iconKey": "Library", "visible": true, "sortOrder": 3 }
       ]
     }


### PR DESCRIPTION
## Summary
- `작업 현황` (/work-management)이 adminGroups의 admin-core에 있어서 admin 역할 없이는 sidebar에 안 보임
- topItems로 이동 (대시보드, 새 아이템과 같은 레벨) → 모든 사용자 접근 가능
- admin-core에서 중복 항목 제거

## Test plan
- [ ] 비-admin 사용자로 로그인 → sidebar 상단에 `작업 현황` 링크 표시 확인
- [ ] 클릭 시 `/work-management` 라우트 정상 진입 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)