### PR TITLE
docs(taxonomy): C38 — 작업 단위 용어사전 + 승격기준 + Phase 진행현황

### DIFF
--- a/.claude/rules/task-promotion.md
+++ b/.claude/rules/task-promotion.md
@@ -1,0 +1,95 @@
+# Backlog → F-item 승격 기준
+
+> **버전**: 1.0 | **날짜**: 2026-04-12  
+> **근거**: `docs/specs/fx-work-unit-taxonomy/diagnostic-report.md` 개선안 D  
+> **SSOT**: 이 파일. `docs/specs/fx-work-unit-taxonomy/taxonomy.md §1 Backlog Item`에서 참조
+
+---
+
+## 배경
+
+C11→F500 승격 사례처럼 Backlog 작업이 F-item으로 전환되는 경우가 있었으나, 기준이 암묵적이었다. 이 파일은 그 기준을 명문화하여 "F-item으로 등록해야 하나, Backlog로 처리해야 하나"를 일관되게 판단할 수 있게 한다.
+
+---
+
+## 승격 기준 (ANY 1개 충족 시 F-item)
+
+### 기준 1: D1 Migration 포함
+
+새 SQL migration 파일(`packages/api/src/db/migrations/*.sql`)이 필요한 작업.
+
+- **이유**: DB 스키마 변경은 되돌리기 어렵고, TDD + Gap Analysis가 필수적
+- **예외**: `--command` 방식의 1-line fix는 Backlog C-track 유지 가능 (drift 위험 주의)
+
+### 기준 2: 3개 이상 파일 변경
+
+단일 PR에서 3개 이상의 `packages/**` 소스 파일을 수정하는 작업.
+
+- **이유**: 규모가 크면 Design 문서와 Gap Analysis 없이 회귀 위험 증가
+- **측정**: 테스트 파일, 타입 선언 파일 포함. docs/meta 파일은 제외
+
+### 기준 3: 사용자 관찰 가능한 기능 변화
+
+API 엔드포인트 추가, UI 컴포넌트 신규, CLI 커맨드 추가처럼 외부에서 관찰 가능한 변화.
+
+- **이유**: F-item의 정의("사용자가 관찰 가능한 기능 변화")에 직접 부합
+- **경계**: 내부 리팩토링, 성능 최적화, 버그픽스는 Backlog 유지 가능
+
+### 기준 4: Sprint 배정 필요
+
+작업 규모가 4시간 이상으로 예상되거나, 별도 Worktree가 필요한 작업.
+
+- **이유**: Sprint = Worktree = Plan/Design 문서 세트. F-item이어야 sprint N 생성 가능
+- **경계**: 1~2시간 내 완료 가능한 작업은 Backlog WT-less 경로로 처리
+
+---
+
+## Backlog 유지 기준 (전부 해당 시)
+
+- D1 migration 없음
+- 변경 파일 2개 이하
+- 사용자에게 직접 관찰되지 않는 내부 개선
+- 2시간 이내 완료 예상
+
+---
+
+## 승격 절차
+
+```
+1. Backlog 작업 착수 중 승격 기준 충족 발견
+   ↓
+2. task-complete.sh로 현재 진행 중단 (commit + stash 포함)
+   ↓
+3. SPEC.md §5에 F-item + FX-REQ 등록 (master 직접 commit)
+   ↓
+4. Sprint N 생성: bash -i -c "sprint N"
+   ↓
+5. sprint N에서 기존 Backlog 컨텍스트 이어받아 TDD 사이클 시작
+```
+
+### 기존 Backlog 이력 처리
+
+- Backlog 항목(예: C11)은 SPEC.md §5 Backlog 섹션에 "→ F500으로 승격" 표시
+- GitHub Issue는 F-item Issue에 "Promoted from C11" 링크 포함
+- 이미 작성한 코드는 Sprint WT로 이동 (cherry-pick 또는 stash apply)
+
+---
+
+## 판단 예시
+
+| 작업 | 기준 | 결정 |
+|------|------|------|
+| `task-start.sh`에 `--reuse-id` 플래그 추가 (C24) | 기준 2 충족(3파일+) | F 승격 검토 → 하지만 내부 툴 개선으로 기준 3 불충족 → **Backlog 유지** |
+| `agent_sessions` D1 테이블 신규 (F510) | 기준 1+3 충족 | **F-item** |
+| 버그 1줄 픽스 (hotfix) | 전부 미충족 | **Backlog C-track** |
+| Work Management 대시보드 신규 (F509) | 기준 1+2+3+4 충족 | **F-item** |
+| statusline-command.sh 계정 표시 수정 (C28) | 기준 3 경계(내부 인프라) | 기준 2+4 검토 → 3파일+ 변경이면 F 검토 → 실제 2파일 → **Backlog 유지** |
+
+---
+
+## 관련 규칙
+
+- `process-lifecycle.md` — F-item 6단계 라이프사이클
+- `git-workflow.md` — meta vs code 변경 분류
+- `tdd-workflow.md` — F-item TDD 필수 적용 범위
+- `docs/specs/fx-work-unit-taxonomy/taxonomy.md` — 전체 개념 용어 사전

--- a/SPEC.md
+++ b/SPEC.md
@@ -45,19 +45,20 @@ Foundry-X — AX 사업개발 라이프사이클을 AI 에이전트로 자동화
 > ```
 > **마지막 실측** (Sprint 263): ~10 routes, ~28 services, D1 0126, tests ~3452 (E2E 273)
 
-## §3 마일스톤
+## §3 Phase 진행 현황
 
-> 전체 Phase 마일스톤: [ROADMAP.md](ROADMAP.md)
+> **Milestone = Phase 완료.** v2.5 이후 프로젝트-레벨 SemVer 중단, Phase 완료가 Milestone 역할 수행.  
+> 전체 Phase 계획: [ROADMAP.md](ROADMAP.md) | 용어 정의: [taxonomy.md](docs/specs/fx-work-unit-taxonomy/taxonomy.md)
 
-| 마일스톤 | 상태 |
-|----------|:----:|
+| Phase | 상태 |
+|-------|:----:|
 | Phase 33 Work Observability (F509) | ✅ Sprint 261 |
 | Phase 34 Multi-Agent Sessions (F510) | ✅ Sprint 262 |
 | Phase 35 Quality Hardening (F511) | ✅ Sprint 263 |
 | **Phase 36 Work Management Enhancement** (F512~F515) | 🔧 Sprint 264~266 |
-| Sprint 264 — Phase 36-A(F512) + Phase 36-B 착수(F513) | 🔧 진행 중 |
-| Sprint 265 — Phase 36-B 완성 (F514) | 📋 |
-| Sprint 266 — Phase 36-C (F515) | 📋 |
+| ↳ Sprint 264 — Phase 36-A(F512) + Phase 36-B 착수(F513) | 🔧 진행 중 |
+| ↳ Sprint 265 — Phase 36-B 완성 (F514) | 📋 |
+| ↳ Sprint 266 — Phase 36-C (F515) | 📋 |
 
 ## §4 성공 지표
 

--- a/docs/specs/fx-work-unit-taxonomy/taxonomy.md
+++ b/docs/specs/fx-work-unit-taxonomy/taxonomy.md
@@ -1,0 +1,159 @@
+# Foundry-X 작업 단위 용어 사전 (Taxonomy)
+
+**버전:** 1.0  
+**날짜:** 2026-04-12  
+**상태:** 확정  
+**근거:** `diagnostic-report.md` 개선안 E
+
+---
+
+## 개요
+
+Foundry-X는 7개의 작업 단위 개념을 사용한다. 이 문서는 각 개념의 정의, 경계, 상호 관계를 명확히 하여 "어디에 뭘 기록해야 하는지" 모호함을 없앤다.
+
+---
+
+## 1. 개념 정의
+
+### F-item (Feature Item)
+
+| 항목 | 내용 |
+|------|------|
+| **정의** | 사용자가 관찰 가능한 기능 변화를 만드는 최소 작업 단위 |
+| **SSOT** | `SPEC.md §5` |
+| **식별자** | `F{NNN}` (예: F512) |
+| **라이프사이클** | `📋(idea)` → `📋(groomed)` → `📋(plan)` → `🔧(design)` → `🔧(impl)` → `🔧(review)` → `🔧(test)` → `✅` → `✅(deployed)` |
+| **관계** | 1 Sprint에 1~5개, FX-REQ 1:1, GitHub Issue 1:1 |
+| **생성 조건** | D1 migration 포함 또는 3개 이상 파일 변경 (→ Backlog 승격 기준 참조) |
+| **상세** | `.claude/rules/process-lifecycle.md` |
+
+---
+
+### Sprint
+
+| 항목 | 내용 |
+|------|------|
+| **정의** | 1~5개 F-item을 묶어 TDD 사이클로 실행하는 개발 단위 |
+| **SSOT** | `SPEC.md §2` (현황) + `docs/01-plan/features/sprint-{N}.plan.md` (계획) |
+| **식별자** | Sprint N (예: Sprint 264) |
+| **라이프사이클** | Plan → Design → TDD Red → TDD Green → Gap Analysis → Report → Deploy |
+| **관계** | 1 Phase에 1~15개, Worktree 1:1 |
+| **생성 방법** | `bash -i -c "sprint N"` (직접 `git worktree add` 금지) |
+| **완료 기준** | Gap Match Rate ≥ 90% + PR merge + CI 통과 |
+
+---
+
+### Phase
+
+| 항목 | 내용 |
+|------|------|
+| **정의** | 사용자가 인지할 수 있는 제품 역량 도약을 이루는 Sprint 묶음. 완료 시 Milestone으로 기록됨 |
+| **SSOT** | `SPEC.md §3` + `ROADMAP.md` |
+| **식별자** | Phase {N} (예: Phase 36) |
+| **라이프사이클** | PRD 작성 → Sprint 할당 → 전체 Sprint 완료 → ✅ 태그 |
+| **관계** | 1 Phase = 1~15 Sprints. Phase 완료 = Milestone 도달 |
+| **완료 표시** | SPEC.md §3에 ✅ 기록 + ROADMAP.md 갱신 |
+
+---
+
+### Milestone
+
+| 항목 | 내용 |
+|------|------|
+| **정의** | Phase 완료 시점을 나타내는 체크포인트. "Milestone = Phase 완료"로 동의어 취급 |
+| **SSOT** | `SPEC.md §3` (Phase 완료 행이 곧 Milestone 행) |
+| **식별자** | "Phase N 완료" 또는 SemVer git tag (v1.8.0 등) |
+| **버전 정책** | v2.5 이후 프로젝트-레벨 SemVer 중단. 패키지별 Independent SemVer 사용 (`gov-version` 스킬). Phase 완료 ≠ 자동 태그 (수동 판단) |
+| **관계** | Phase와 1:1. SemVer 태그는 선택적 부가 정보 |
+| **주의** | Phase와 별개 개념이 아님. "Milestone 표" = "Phase 진행 표" |
+
+---
+
+### FX-REQ (Requirement)
+
+| 항목 | 내용 |
+|------|------|
+| **정의** | F-item의 요구사항 코드. F-item과 1:1 대응하며 외부 추적(GitHub Issues, PRD) 시 참조 ID로 활용 |
+| **SSOT** | `SPEC.md §5` F-item 행의 괄호 안 (예: `FX-REQ-535`) |
+| **식별자** | `FX-REQ-{NNN}` |
+| **라이프사이클** | F-item 생성 시 동시 부여 → F-item 완료 시 DONE |
+| **관계** | F-item 1:1 (alias 역할). GitHub Issue와도 1:1 |
+| **한계** | 독자적 요구사항 역할보다 추적 ID 역할이 주. 별도 REQ 문서 관리는 오버헤드 |
+
+---
+
+### Backlog Item (B/C/X Track)
+
+| 항목 | 내용 |
+|------|------|
+| **정의** | F-item 등록 임계값 미달의 소규모 작업. Task Orchestrator로 관리 |
+| **SSOT** | `SPEC.md §5` Backlog 섹션 또는 `scripts/task/task-start.sh` |
+| **식별자** | `B{N}` (기능보완), `C{N}` (인프라/자동화), `X{N}` (기타/실험) |
+| **라이프사이클** | `task-start.sh` → WT(선택) → PR → merge → `task-complete.sh` |
+| **F-item 승격 기준** | `.claude/rules/task-promotion.md` 참조 |
+| **완료 건수** | 37건 완료 (2026-04-12 기준) |
+
+---
+
+### Roadmap
+
+| 항목 | 내용 |
+|------|------|
+| **정의** | Phase 전체 시퀀스와 시간 계획을 담는 장기 문서 |
+| **SSOT** | `ROADMAP.md` |
+| **식별자** | 없음 (단일 문서) |
+| **라이프사이클** | Phase 36-A에서 신규 도입. SPEC.md §3과 연동 |
+| **관계** | SPEC.md §3의 현황 표를 보완하는 장기 뷰 |
+
+---
+
+## 2. 계층 구조 (포함 관계)
+
+```
+Roadmap (장기 시간축 계획)
+    │
+    └── Phase (기능 도약 묶음, 완료 = Milestone)
+             │
+             └── Sprint (TDD 실행 단위, 1~15개/Phase)
+                      │
+                      └── F-item (사용자 관찰 가능 기능, 1~5개/Sprint)
+                               ├── FX-REQ (추적 ID, 1:1)
+                               └── GitHub Issue (이슈 추적, 1:1)
+
+Backlog B/C/X (F-item 임계값 미달, 독립 트랙)
+    └── 승격 시 → F-item (`.claude/rules/task-promotion.md` 기준)
+```
+
+---
+
+## 3. 혼동하기 쉬운 경계
+
+| 질문 | 답변 |
+|------|------|
+| Phase와 Milestone의 차이? | 동의어. Phase 완료 = Milestone 도달. 별개 개념 아님 |
+| FX-REQ가 없으면 F-item이 아닌가? | REQ는 자동 부여. F-item 등록 시 항상 동시 부여 |
+| Backlog C-track과 F-item 중 어디 등록? | 승격 기준(`task-promotion.md`)으로 판단. 애매하면 C-track으로 시작, 나중에 승격 |
+| Sprint 없이 F-item만 있을 수 있나? | `📋(idea)` 상태는 가능. Sprint 배정 전 상태 |
+| Roadmap과 SPEC.md §3의 차이? | §3은 현재 진행/완료 상태 표. Roadmap은 장기 계획 문서 |
+
+---
+
+## 4. 각 개념의 기록 위치 요약
+
+| 개념 | 현황 기록 | 계획 기록 | 완료 기록 |
+|------|----------|----------|----------|
+| F-item | SPEC.md §5 | sprint-{N}.plan.md | SPEC.md §5 ✅ |
+| Sprint | SPEC.md §2 | sprint-{N}.plan.md | sprint-{N}.plan.md 완료 표시 |
+| Phase | SPEC.md §3 | ROADMAP.md | SPEC.md §3 ✅ |
+| Milestone | SPEC.md §3 (Phase 완료 행) | — | git tag (선택) |
+| FX-REQ | SPEC.md §5 (F-item 행) | — | SPEC.md §5 DONE |
+| Backlog | SPEC.md §5 Backlog 섹션 | — | task-complete.sh |
+| Roadmap | ROADMAP.md | ROADMAP.md | — |
+
+---
+
+## 변경 이력
+
+| 날짜 | 버전 | 내용 |
+|------|------|------|
+| 2026-04-12 | 1.0 | 최초 작성 — diagnostic-report.md 개선안 E |


### PR DESCRIPTION
## Summary

- **E**: `docs/specs/fx-work-unit-taxonomy/taxonomy.md` 신규 — 7개 개념 정의, 계층 구조, 기록 위치 표
- **D**: `.claude/rules/task-promotion.md` 신규 — Backlog→F-item 승격 4기준 + 절차 + 예시
- **A**: `SPEC.md §3` Milestone→Phase 진행현황 통합 (섹션명 변경, 동의어 명시, taxonomy 링크)

## 배경

`diagnostic-report.md`에서 진단된 모호점 M1(Phase↔Milestone 이중 구조), M4(Backlog 승격 경계), 전체(용어 산재) 해소.
모두 meta-only 변경. Sprint 264 경합 없음 (§5/§6 미수정).

## Test plan

- [x] 3개 파일 변경 확인 (`git diff --stat`)
- [x] `turbo typecheck` — meta-only 변경이라 코드 영향 없음 (api worktree node_modules 미설치는 기존 환경 문제)
- [x] SPEC.md §3 §4 경계 무손상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)