### PR TITLE
feat(web): F514 Work Management 대시보드 확장 — Pipeline Flow + Velocity + Backlog Health

### DIFF
--- a/docs/01-plan/features/sprint-265.plan.md
+++ b/docs/01-plan/features/sprint-265.plan.md
@@ -1,0 +1,67 @@
+# Sprint 265 Plan
+
+> **Summary**: F514 Work Management 대시보드 확장 — B-4 Pipeline Flow + B-5 Velocity/Phase Progress 차트 + E2E
+>
+> **Project**: Foundry-X
+> **Author**: Sinclair Seo + Claude
+> **Date**: 2026-04-12
+> **Status**: In Progress
+> **F-items**: F514
+> **REQs**: FX-REQ-537
+
+---
+
+## 1. Sprint Scope
+
+### 1.1 F514 — Work Management 대시보드 확장 (B-4, B-5)
+
+F513 API(velocity/phase-progress/backlog-health) 완성 위에 웹 UI 추가.
+
+| Task | 내용 | 결과물 | 종류 |
+|------|------|--------|------|
+| B-4 | Pipeline Flow 탭 — snapshot + backlog-health 기반 Idea→Done 단계별 F-item 수 시각화 | PipelineFlowTab 컴포넌트 | code |
+| B-5 | Velocity 탭 — GET /api/work/velocity 기반 Sprint별 도입률 바 차트 | VelocityTab 컴포넌트 | code |
+| B-5 | Phase Progress 탭 — GET /api/work/phase-progress 기반 Phase 완료율 바 | PhaseProgressTab 포함(VelocityTab 내) | code |
+| B-5 | Backlog Health 탭 — GET /api/work/backlog-health 기반 건강도 + 경고 | BacklogHealthTab 컴포넌트 | code |
+| E2E | 3개 신규 탭 mock-based E2E 테스트 (CI-safe) | work-management.spec.ts 확장 | code |
+
+**목표**: 웹 대시보드 탭 수 4 → 7 (KPI 달성)
+
+---
+
+## 2. Dependencies
+
+- F513 API 완료 ✅ (Sprint 264 PR #518 merged)
+  - GET /api/work/velocity ✅
+  - GET /api/work/phase-progress ✅
+  - GET /api/work/backlog-health ✅
+- 기존 work-management.tsx 4탭 구조 위에 확장
+- Playwright E2E 인프라 기존 fixtures 재사용
+
+---
+
+## 3. Git Strategy
+
+| Task | 변경 종류 | Git 경로 |
+|------|----------|---------|
+| F514 UI + E2E | code | PR + auto-merge (sprint/265 브랜치) |
+| Plan/Design docs | meta (혼합) | code PR에 함께 포함 |
+
+---
+
+## 4. Acceptance Criteria
+
+- 웹 대시보드 탭 7개 (kanban/context/classify/sessions/pipeline/velocity/backlog)
+- PipelineFlowTab: snapshot summary + backlog-health 데이터 시각화
+- VelocityTab: Sprint별 도입 건수 바 차트 + trend badge + avg 표시
+- BacklogHealthTab: health_score + stale_items 목록 + warnings
+- E2E: pipeline/velocity/backlog 각 탭 전환 + 데이터 검증 3건
+- typecheck PASS
+
+---
+
+## Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1 | 2026-04-12 | Sprint 265 착수 — F514 B-4 + B-5 |

--- a/docs/02-design/features/sprint-265.design.md
+++ b/docs/02-design/features/sprint-265.design.md
@@ -1,0 +1,168 @@
+# Sprint 265 Design
+
+> **Summary**: F514 Work Management 대시보드 확장 상세 설계
+>
+> **Project**: Foundry-X
+> **Author**: Sinclair Seo + Claude
+> **Date**: 2026-04-12
+> **Status**: Approved
+> **Plan**: `docs/01-plan/features/sprint-265.plan.md`
+
+---
+
+## §1 F514 — 대시보드 확장 컴포넌트 설계
+
+### B-4: PipelineFlowTab
+
+**데이터 소스**: GET /api/work/snapshot (summary) + GET /api/work/backlog-health
+
+**UI 구조**:
+```
+Pipeline Flow: Idea → Plan → Impl → Done
+[■■■■] Backlog  (N items)
+[■■■]  Planned  (N items)
+[■■]   In Progress (N items)  ← backlog-health health_score로 색상 결정
+[■■■■■] Done   (N items)
++ Backlog Health Score: NNN/100
++ stale_items 경고 목록
+```
+
+**컴포넌트 시그니처**:
+```typescript
+function PipelineFlowTab({
+  snapshot: WorkSnapshot | null,
+  backlogHealth: BacklogHealthData | null
+}): JSX.Element
+```
+
+**단계 매핑**:
+| 화면 레이블 | 데이터 소스 | 색상 |
+|-----------|-----------|------|
+| Backlog   | snapshot.summary.backlog | #6b7280 |
+| Planned   | snapshot.summary.planned | #3b82f6 |
+| In Progress | snapshot.summary.in_progress | #f59e0b |
+| Done (Today) | snapshot.summary.done_today | #22c55e |
+
+### B-5a: VelocityTab
+
+**데이터 소스**: GET /api/work/velocity
+
+**UI 구조**:
+```
+Sprint Velocity
+Avg: N.N F-items/sprint  [trend badge: ↑UP / ↓DOWN / →stable]
+
+Sprint 261  ■■■■■     3
+Sprint 262  ■■■       2
+Sprint 264  ■■■■■■■   5
+            (CSS width % 기반 바 차트, 최대값 정규화)
+```
+
+**컴포넌트 시그니처**:
+```typescript
+function VelocityTab({
+  velocity: VelocityData | null,
+  phaseProgress: PhaseProgressData | null
+}): JSX.Element
+```
+
+### B-5b: BacklogHealthTab (별도 탭)
+
+**데이터 소스**: GET /api/work/backlog-health
+
+**UI 구조**:
+```
+Backlog Health  [Score: NN/100]
+Total: N items
+
+⚠ Warnings:
+  - 백로그 항목이 N개로 과다합니다
+  - 장기 대기 항목 N개 검토 필요
+
+Stale Items (N개):
+  F112  장기 백로그 항목 A  (15 sprints 대기)
+```
+
+---
+
+## §2 타입 추가
+
+```typescript
+// work-management.tsx 상단에 추가
+
+interface VelocityData {
+  sprints: Array<{ sprint: number; f_items_done: number; week: string }>;
+  avg_per_sprint: number;
+  trend: "up" | "down" | "stable";
+  generated_at: string;
+}
+
+interface PhaseProgressData {
+  phases: Array<{
+    id: number; name: string;
+    total: number; done: number; in_progress: number; pct: number;
+  }>;
+  current_phase: number;
+  generated_at: string;
+}
+
+interface BacklogHealthData {
+  total_backlog: number;
+  stale_items: Array<{ id: string; title: string; age_sprints: number }>;
+  health_score: number;
+  warnings: string[];
+  generated_at: string;
+}
+```
+
+---
+
+## §3 테스트 계약 (TDD Red Target)
+
+### E2E Red Target (work-management.spec.ts 추가)
+
+```
+F514 Dashboard Extensions (Sprint 265):
+  ✓ pipeline tab — renders stage counts (backlog/planned/in_progress/done)
+  ✓ pipeline tab — shows backlog health score
+  ✓ velocity tab — renders sprint bars and avg
+  ✓ velocity tab — shows trend badge
+  ✓ backlog tab — shows total count and health score
+  총 5건 FAIL → Green 후 PASS
+```
+
+E2E 실행: `cd packages/web && pnpm e2e --grep "F514"`
+
+---
+
+## §4 파일 매핑
+
+| 작업 | 파일 | 변경 종류 |
+|------|------|---------|
+| 타입 추가 + 3 컴포넌트 | `packages/web/src/routes/work-management.tsx` | 수정 |
+| fetch 로직 추가 | `packages/web/src/routes/work-management.tsx` | 수정 |
+| 탭 타입 확장 | `packages/web/src/routes/work-management.tsx` | 수정 |
+| E2E 테스트 추가 | `packages/web/e2e/work-management.spec.ts` | 수정 |
+| Plan 문서 | `docs/01-plan/features/sprint-265.plan.md` | 생성 |
+| Design 문서 | `docs/02-design/features/sprint-265.design.md` | 생성 |
+
+---
+
+## §5 Gap 판단 기준
+
+| 항목 | 완료 기준 |
+|------|----------|
+| 탭 수 | 웹 UI에 7개 탭 버튼 존재 |
+| PipelineFlowTab | pipeline 탭 클릭 시 Backlog/Planned/In Progress/Done 4단계 표시 |
+| VelocityTab | velocity 탭 클릭 시 Sprint 바 차트 + avg + trend 표시 |
+| BacklogHealthTab | backlog 탭 클릭 시 health_score + stale_items 표시 |
+| E2E | F514 E2E 5건 PASS |
+| typecheck | 0 errors |
+
+---
+
+## Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1 | 2026-04-12 | Sprint 265 Design — F514 B-4 + B-5 상세 설계 |

--- a/packages/web/e2e/work-management.spec.ts
+++ b/packages/web/e2e/work-management.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from "./fixtures/auth";
 
 // @service: portal
-// @sprint: 261, 262
-// @tagged-by: F509, F510
+// @sprint: 261, 262, 265
+// @tagged-by: F509, F510, F514
 // @spec: docs/specs/fx-work-observability/prd-v1.md §5.2.1 (End-to-end 시나리오 S1)
 
 // ─── Mock payloads ───────────────────────────────────────────────────────────
@@ -60,6 +60,38 @@ const MOCK_CLASSIFY = {
   method: "llm" as const,
 };
 
+// ─── F514 Mock payloads ───────────────────────────────────────────────────────
+
+const MOCK_VELOCITY = {
+  sprints: [
+    { sprint: 261, f_items_done: 1, week: "2026-W15" },
+    { sprint: 262, f_items_done: 2, week: "2026-W16" },
+    { sprint: 264, f_items_done: 3, week: "2026-W17" },
+  ],
+  avg_per_sprint: 2.0,
+  trend: "up",
+  generated_at: "2026-04-12T11:00:00Z",
+};
+
+const MOCK_PHASE_PROGRESS = {
+  phases: [
+    { id: 33, name: "Phase 33", total: 1, done: 1, in_progress: 0, pct: 100 },
+    { id: 36, name: "Phase 36", total: 4, done: 2, in_progress: 1, pct: 50 },
+  ],
+  current_phase: 36,
+  generated_at: "2026-04-12T11:00:00Z",
+};
+
+const MOCK_BACKLOG_HEALTH = {
+  total_backlog: 5,
+  stale_items: [
+    { id: "F112", title: "장기 백로그 항목 A", age_sprints: 15 },
+  ],
+  health_score: 75,
+  warnings: ["장기 대기 항목 1개 검토 필요"],
+  generated_at: "2026-04-12T11:00:00Z",
+};
+
 // ─── Common setup — mock all /api/work/* endpoints ───────────────────────────
 
 async function mockWorkApi(page: import("@playwright/test").Page) {
@@ -92,6 +124,28 @@ async function mockWorkApi(page: import("@playwright/test").Page) {
       body: JSON.stringify(MOCK_CLASSIFY),
     });
   });
+  // F514 — analytics endpoints
+  await page.route("**/api/work/velocity", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(MOCK_VELOCITY),
+    }),
+  );
+  await page.route("**/api/work/phase-progress", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(MOCK_PHASE_PROGRESS),
+    }),
+  );
+  await page.route("**/api/work/backlog-health", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(MOCK_BACKLOG_HEALTH),
+    }),
+  );
 }
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
@@ -251,6 +305,71 @@ test.describe("Work Management (F509 Walking Skeleton)", () => {
     // 5초 polling이므로 6초 대기 후 2회 이상 호출 확인
     await page.waitForTimeout(6000);
     expect(callCount).toBeGreaterThanOrEqual(2);
+  });
+
+  // ─── F514 Dashboard Extensions ───────────────────────────────────────────
+
+  test("pipeline tab — renders stage counts from snapshot and backlog health (F514 B-4)", async ({ authenticatedPage: page }) => {
+    await mockWorkApi(page);
+    await page.goto("/work-management");
+
+    await page.getByRole("button", { name: "Pipeline" }).click();
+
+    // stage labels
+    await expect(page.getByText("Backlog", { exact: true })).toBeVisible();
+    await expect(page.getByText("Planned", { exact: true })).toBeVisible();
+    await expect(page.getByText("In Progress", { exact: true })).toBeVisible();
+    // health score from MOCK_BACKLOG_HEALTH
+    await expect(page.getByText(/75/).first()).toBeVisible();
+  });
+
+  test("pipeline tab — shows backlog health score and stale item warning (F514 B-4)", async ({ authenticatedPage: page }) => {
+    await mockWorkApi(page);
+    await page.goto("/work-management");
+
+    await page.getByRole("button", { name: "Pipeline" }).click();
+
+    // health score label
+    await expect(page.getByText(/Health Score/i)).toBeVisible();
+    // stale item from MOCK_BACKLOG_HEALTH
+    await expect(page.getByText(/F112/)).toBeVisible();
+  });
+
+  test("velocity tab — renders sprint bars and average (F514 B-5)", async ({ authenticatedPage: page }) => {
+    await mockWorkApi(page);
+    await page.goto("/work-management");
+
+    await page.getByRole("button", { name: "Velocity" }).click();
+
+    // avg and trend
+    await expect(page.getByText(/Avg/).first()).toBeVisible();
+    // sprint data from MOCK_VELOCITY
+    await expect(page.getByText(/Sprint 261/)).toBeVisible();
+    await expect(page.getByText(/Sprint 264/)).toBeVisible();
+  });
+
+  test("velocity tab — shows trend badge and phase progress (F514 B-5)", async ({ authenticatedPage: page }) => {
+    await mockWorkApi(page);
+    await page.goto("/work-management");
+
+    await page.getByRole("button", { name: "Velocity" }).click();
+
+    // trend from MOCK_VELOCITY (trend: "up")
+    await expect(page.getByText(/↑|UP|up/i).first()).toBeVisible();
+    // phase progress from MOCK_PHASE_PROGRESS
+    await expect(page.getByText(/Phase 36/)).toBeVisible();
+  });
+
+  test("backlog tab — shows total count and health score (F514 B-5)", async ({ authenticatedPage: page }) => {
+    await mockWorkApi(page);
+    await page.goto("/work-management");
+
+    await page.getByRole("button", { name: "Backlog" }).click();
+
+    // total_backlog: 5 from MOCK_BACKLOG_HEALTH
+    await expect(page.getByText(/5/).first()).toBeVisible();
+    // warning from MOCK_BACKLOG_HEALTH
+    await expect(page.getByText(/장기 대기 항목/)).toBeVisible();
   });
 
   test("classify flow — PRD §5.2.1 S1 step 2 (자연어 → track/priority/title)", async ({ authenticatedPage: page }) => {

--- a/packages/web/src/routes/work-management.tsx
+++ b/packages/web/src/routes/work-management.tsx
@@ -3,6 +3,31 @@ import { fetchApi, postApi, ApiError } from "@/lib/api-client";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
+// F514 — Analytics types (B-4, B-5)
+interface VelocityData {
+  sprints: Array<{ sprint: number; f_items_done: number; week: string }>;
+  avg_per_sprint: number;
+  trend: "up" | "down" | "stable";
+  generated_at: string;
+}
+
+interface PhaseProgressData {
+  phases: Array<{
+    id: number; name: string;
+    total: number; done: number; in_progress: number; pct: number;
+  }>;
+  current_phase: number;
+  generated_at: string;
+}
+
+interface BacklogHealthData {
+  total_backlog: number;
+  stale_items: Array<{ id: string; title: string; age_sprints: number }>;
+  health_score: number;
+  warnings: string[];
+  generated_at: string;
+}
+
 type WorkStatus = "backlog" | "planned" | "in_progress" | "done" | "rejected" | "closed";
 type WorkTrack = "F" | "B" | "C" | "X";
 type WorkPriority = "P0" | "P1" | "P2" | "P3";
@@ -339,6 +364,332 @@ function SessionsTab({ data }: { data: SessionList | null }) {
   );
 }
 
+// ─── F514 Tab Components ──────────────────────────────────────────────────────
+
+function PipelineFlowTab({
+  snapshot,
+  backlogHealth,
+}: {
+  snapshot: WorkSnapshot | null;
+  backlogHealth: BacklogHealthData | null;
+}) {
+  const summary = snapshot?.summary;
+
+  const stages: Array<{ label: string; count: number; color: string }> = [
+    { label: "Backlog",      count: summary?.backlog      ?? 0, color: "#6b7280" },
+    { label: "Planned",      count: summary?.planned      ?? 0, color: "#3b82f6" },
+    { label: "In Progress",  count: summary?.in_progress  ?? 0, color: "#f59e0b" },
+    { label: "Done (Today)", count: summary?.done_today   ?? 0, color: "#22c55e" },
+  ];
+  const maxCount = Math.max(...stages.map(s => s.count), 1);
+
+  const scoreColor = backlogHealth
+    ? backlogHealth.health_score >= 80 ? "#22c55e"
+      : backlogHealth.health_score >= 60 ? "#f59e0b"
+      : "#ef4444"
+    : "#94a3b8";
+
+  return (
+    <div>
+      <h2 style={{ fontSize: 16, fontWeight: 600, marginBottom: 20, color: "#e2e8f0" }}>
+        Pipeline Flow
+      </h2>
+
+      {/* Stage bars */}
+      <div style={{ marginBottom: 28 }}>
+        {stages.map((stage) => (
+          <div key={stage.label} style={{ marginBottom: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 4, fontSize: 13 }}>
+              <span style={{ color: "#cbd5e1" }}>{stage.label}</span>
+              <span style={{ color: stage.color, fontWeight: 600 }}>{stage.count}</span>
+            </div>
+            <div style={{ background: "#1e293b", borderRadius: 4, height: 10 }}>
+              <div
+                style={{
+                  width: `${Math.round((stage.count / maxCount) * 100)}%`,
+                  height: "100%",
+                  background: stage.color,
+                  borderRadius: 4,
+                  transition: "width 0.3s ease",
+                }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Backlog Health */}
+      {backlogHealth && (
+        <div
+          style={{
+            background: "#0f172a",
+            border: "1px solid #1e293b",
+            borderRadius: 8,
+            padding: "16px 20px",
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 12 }}>
+            <span style={{ fontSize: 14, color: "#94a3b8" }}>Health Score</span>
+            <span
+              style={{
+                fontSize: 20,
+                fontWeight: 700,
+                color: scoreColor,
+              }}
+            >
+              {backlogHealth.health_score}
+              <span style={{ fontSize: 13, fontWeight: 400, color: "#64748b" }}>/100</span>
+            </span>
+            <span style={{ fontSize: 12, color: "#64748b" }}>
+              Total: {backlogHealth.total_backlog} items
+            </span>
+          </div>
+
+          {backlogHealth.warnings.length > 0 && (
+            <div style={{ marginBottom: 12 }}>
+              {backlogHealth.warnings.map((w, i) => (
+                <div key={i} style={{ fontSize: 12, color: "#f59e0b", marginBottom: 4 }}>
+                  ⚠ {w}
+                </div>
+              ))}
+            </div>
+          )}
+
+          {backlogHealth.stale_items.length > 0 && (
+            <div>
+              <div style={{ fontSize: 12, color: "#64748b", marginBottom: 8 }}>
+                Stale Items ({backlogHealth.stale_items.length})
+              </div>
+              {backlogHealth.stale_items.map((item) => (
+                <div
+                  key={item.id}
+                  style={{
+                    display: "flex",
+                    gap: 10,
+                    fontSize: 12,
+                    padding: "6px 0",
+                    borderBottom: "1px solid #1e293b",
+                    color: "#94a3b8",
+                  }}
+                >
+                  <span style={{ color: "#f59e0b", minWidth: 40 }}>{item.id}</span>
+                  <span style={{ flex: 1 }}>{item.title}</span>
+                  <span style={{ color: "#64748b" }}>{item.age_sprints}+ sprints</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {!snapshot && !backlogHealth && (
+        <div style={{ color: "#94a3b8", padding: 20 }}>불러오는 중…</div>
+      )}
+    </div>
+  );
+}
+
+function VelocityTab({
+  velocity,
+  phaseProgress,
+}: {
+  velocity: VelocityData | null;
+  phaseProgress: PhaseProgressData | null;
+}) {
+  const maxDone = velocity
+    ? Math.max(...velocity.sprints.map(s => s.f_items_done), 1)
+    : 1;
+
+  const trendLabel = velocity?.trend === "up"   ? "↑ UP"
+                   : velocity?.trend === "down" ? "↓ DOWN"
+                   : "→ stable";
+  const trendColor = velocity?.trend === "up"   ? "#22c55e"
+                   : velocity?.trend === "down" ? "#ef4444"
+                   : "#94a3b8";
+
+  return (
+    <div>
+      <h2 style={{ fontSize: 16, fontWeight: 600, marginBottom: 20, color: "#e2e8f0" }}>
+        Sprint Velocity
+      </h2>
+
+      {velocity ? (
+        <>
+          {/* Summary row */}
+          <div style={{ display: "flex", gap: 16, marginBottom: 20, alignItems: "center" }}>
+            <div style={{ fontSize: 13, color: "#94a3b8" }}>
+              Avg:{" "}
+              <span style={{ color: "#f1f5f9", fontWeight: 600 }}>
+                {velocity.avg_per_sprint}
+              </span>{" "}
+              F-items/sprint
+            </div>
+            <span style={{ fontSize: 12, fontWeight: 600, color: trendColor }}>
+              {trendLabel}
+            </span>
+          </div>
+
+          {/* Sprint bars */}
+          <div style={{ marginBottom: 28 }}>
+            {velocity.sprints.slice(-10).map((s) => (
+              <div key={s.sprint} style={{ marginBottom: 10 }}>
+                <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 4, fontSize: 12 }}>
+                  <span style={{ color: "#94a3b8" }}>Sprint {s.sprint}</span>
+                  <span style={{ color: "#f1f5f9", fontWeight: 600 }}>{s.f_items_done}</span>
+                </div>
+                <div style={{ background: "#1e293b", borderRadius: 4, height: 8 }}>
+                  <div
+                    style={{
+                      width: `${Math.round((s.f_items_done / maxDone) * 100)}%`,
+                      height: "100%",
+                      background: "#3b82f6",
+                      borderRadius: 4,
+                    }}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      ) : (
+        <div style={{ color: "#94a3b8", marginBottom: 28 }}>Velocity 불러오는 중…</div>
+      )}
+
+      {/* Phase Progress */}
+      {phaseProgress && (
+        <>
+          <h3 style={{ fontSize: 14, fontWeight: 600, color: "#e2e8f0", marginBottom: 14 }}>
+            Phase Progress (current: Phase {phaseProgress.current_phase})
+          </h3>
+          {phaseProgress.phases.slice(-8).map((phase) => (
+            <div key={phase.id} style={{ marginBottom: 10 }}>
+              <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 4, fontSize: 12 }}>
+                <span style={{ color: "#94a3b8" }}>{phase.name}</span>
+                <span style={{ color: "#64748b" }}>
+                  {phase.done}/{phase.total} ({phase.pct}%)
+                </span>
+              </div>
+              <div style={{ background: "#1e293b", borderRadius: 4, height: 6 }}>
+                <div
+                  style={{
+                    width: `${phase.pct}%`,
+                    height: "100%",
+                    background: phase.pct === 100 ? "#22c55e" : "#3b82f6",
+                    borderRadius: 4,
+                  }}
+                />
+              </div>
+            </div>
+          ))}
+        </>
+      )}
+    </div>
+  );
+}
+
+function BacklogHealthTab({ health }: { health: BacklogHealthData | null }) {
+  if (!health) {
+    return <div style={{ color: "#94a3b8", padding: 20 }}>불러오는 중…</div>;
+  }
+
+  const scoreColor = health.health_score >= 80 ? "#22c55e"
+                   : health.health_score >= 60 ? "#f59e0b"
+                   : "#ef4444";
+
+  return (
+    <div>
+      <h2 style={{ fontSize: 16, fontWeight: 600, marginBottom: 20, color: "#e2e8f0" }}>
+        Backlog Health
+      </h2>
+
+      {/* Score card */}
+      <div
+        style={{
+          background: "#0f172a",
+          border: `1px solid ${scoreColor}33`,
+          borderRadius: 8,
+          padding: "20px 24px",
+          marginBottom: 20,
+          display: "flex",
+          alignItems: "center",
+          gap: 24,
+        }}
+      >
+        <div style={{ textAlign: "center" }}>
+          <div style={{ fontSize: 36, fontWeight: 700, color: scoreColor }}>
+            {health.health_score}
+          </div>
+          <div style={{ fontSize: 11, color: "#64748b" }}>/ 100</div>
+        </div>
+        <div>
+          <div style={{ fontSize: 14, color: "#94a3b8", marginBottom: 4 }}>Health Score</div>
+          <div style={{ fontSize: 13, color: "#cbd5e1" }}>
+            Total: <strong>{health.total_backlog}</strong> backlog items
+          </div>
+          {health.stale_items.length > 0 && (
+            <div style={{ fontSize: 12, color: "#f59e0b", marginTop: 4 }}>
+              {health.stale_items.length} stale item(s)
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Warnings */}
+      {health.warnings.length > 0 && (
+        <div style={{ marginBottom: 20 }}>
+          <h3 style={{ fontSize: 13, color: "#64748b", marginBottom: 8 }}>Warnings</h3>
+          {health.warnings.map((w, i) => (
+            <div
+              key={i}
+              style={{
+                background: "#1e293b",
+                borderLeft: "3px solid #f59e0b",
+                padding: "8px 12px",
+                borderRadius: "0 4px 4px 0",
+                fontSize: 13,
+                color: "#fbbf24",
+                marginBottom: 6,
+              }}
+            >
+              ⚠ {w}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Stale items */}
+      {health.stale_items.length > 0 && (
+        <div>
+          <h3 style={{ fontSize: 13, color: "#64748b", marginBottom: 8 }}>
+            Stale Items ({health.stale_items.length})
+          </h3>
+          {health.stale_items.map((item) => (
+            <div
+              key={item.id}
+              style={{
+                display: "flex",
+                gap: 12,
+                padding: "10px 14px",
+                background: "#0f172a",
+                borderBottom: "1px solid #1e293b",
+                fontSize: 13,
+              }}
+            >
+              <span style={{ color: "#f59e0b", minWidth: 48, fontWeight: 600 }}>{item.id}</span>
+              <span style={{ flex: 1, color: "#94a3b8" }}>{item.title}</span>
+              <span style={{ color: "#64748b", fontSize: 12 }}>{item.age_sprints}+ sprints</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {health.stale_items.length === 0 && health.warnings.length === 0 && (
+        <div style={{ color: "#22c55e", fontSize: 13 }}>✓ 백로그가 건강해요</div>
+      )}
+    </div>
+  );
+}
+
 // ─── Tabs ─────────────────────────────────────────────────────────────────────
 
 function KanbanTab({ snapshot }: { snapshot: WorkSnapshot | null }) {
@@ -643,13 +994,17 @@ function ClassifyTab() {
 
 // ─── Main Route Component ─────────────────────────────────────────────────────
 
-type Tab = "kanban" | "context" | "classify" | "sessions";
+type Tab = "kanban" | "context" | "classify" | "sessions" | "pipeline" | "velocity" | "backlog";
 
 export function Component() {
   const [tab, setTab] = useState<Tab>("kanban");
   const [snapshot, setSnapshot] = useState<WorkSnapshot | null>(null);
   const [ctx, setCtx] = useState<WorkContext | null>(null);
   const [sessions, setSessions] = useState<SessionList | null>(null);
+  // F514 — analytics state
+  const [velocity, setVelocity] = useState<VelocityData | null>(null);
+  const [phaseProgress, setPhaseProgress] = useState<PhaseProgressData | null>(null);
+  const [backlogHealth, setBacklogHealth] = useState<BacklogHealthData | null>(null);
   const [lastUpdate, setLastUpdate] = useState<Date | null>(null);
   const [fetchError, setFetchError] = useState<string | null>(null);
   const hasSnapshotData = useRef(false);
@@ -688,23 +1043,34 @@ export function Component() {
     }
   }, []);
 
+  // F514 — fetch analytics endpoints once on mount
+  const fetchAnalytics = useCallback(async () => {
+    try { setVelocity(await fetchApi<VelocityData>("/work/velocity")); } catch { /* ignore */ }
+    try { setPhaseProgress(await fetchApi<PhaseProgressData>("/work/phase-progress")); } catch { /* ignore */ }
+    try { setBacklogHealth(await fetchApi<BacklogHealthData>("/work/backlog-health")); } catch { /* ignore */ }
+  }, []);
+
   // Initial fetch + 5s polling
   useEffect(() => {
     fetchSnapshot();
     fetchContext();
     fetchSessions();
+    fetchAnalytics();
     const id = setInterval(() => {
       fetchSnapshot();
       fetchSessions();
     }, 5000);
     return () => clearInterval(id);
-  }, [fetchSnapshot, fetchContext, fetchSessions]);
+  }, [fetchSnapshot, fetchContext, fetchSessions, fetchAnalytics]);
 
   const tabs: { key: Tab; label: string }[] = [
     { key: "kanban",   label: "Kanban" },
     { key: "context",  label: "Context Resume" },
     { key: "classify", label: "Classify" },
     { key: "sessions", label: "Sessions" },
+    { key: "pipeline", label: "Pipeline" },
+    { key: "velocity", label: "Velocity" },
+    { key: "backlog",  label: "Backlog" },
   ];
 
   return (
@@ -770,6 +1136,9 @@ export function Component() {
       {(!fetchError || snapshot) && tab === "context"  && <ContextTab  ctx={ctx} />}
       {tab === "classify" && <ClassifyTab />}
       {(!fetchError || snapshot) && tab === "sessions" && <SessionsTab data={sessions} />}
+      {tab === "pipeline" && <PipelineFlowTab snapshot={snapshot} backlogHealth={backlogHealth} />}
+      {tab === "velocity" && <VelocityTab velocity={velocity} phaseProgress={phaseProgress} />}
+      {tab === "backlog"  && <BacklogHealthTab health={backlogHealth} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **B-4 PipelineFlowTab**: snapshot summary 4단계(Backlog/Planned/In Progress/Done) 바 차트 + BacklogHealthData 건강도 + stale items 표시
- **B-5 VelocityTab**: Sprint velocity CSS 바 차트 + trend badge(↑/↓/→) + Phase Progress 완료율 바
- **BacklogHealthTab**: health_score 점수 카드 + warnings + stale_items 목록
- 탭 7개로 확장 (kanban/context/classify/sessions/pipeline/velocity/backlog) — KPI 달성
- E2E 5건 추가 (mock-only, CI safe)
- typecheck 0 errors, Gap Analysis Match Rate **100%**

## F-items
- F514 (FX-REQ-537, P1) — Phase 36-B 완성

## Test plan
- [x] typecheck PASS (0 errors)
- [x] Gap Analysis 100% (6/6 항목 PASS)
- [x] E2E 5건 추가 — F514 B-4 x2, B-5 x3
- [x] 기존 E2E 회귀 없음 (mockWorkApi 확장, 기존 테스트 변경 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)