### PR TITLE
feat(web): F516 대시보드 현행화 — 서비스 범위(발굴/형상화) 반영

### DIFF
--- a/docs/01-plan/features/sprint-267.plan.md
+++ b/docs/01-plan/features/sprint-267.plan.md
@@ -1,0 +1,36 @@
+---
+id: FX-PLAN-267
+title: Sprint 267 — F516 대시보드 현행화
+sprint: 267
+f_items: [F516]
+req: FX-REQ-544
+date: 2026-04-12
+status: done
+---
+
+# Sprint 267 Plan — F516 대시보드 현행화
+
+## 목표
+
+Foundry-X 서비스 실제 범위(2단계 발굴 + 3단계 형상화)에 맞게 대시보드를 현행화한다.
+구 6단계 UI(수집~GTM)를 제거하고, 현행 라우트 기반 퀵 액션과 2단계 파이프라인으로 교체한다.
+
+## 배경
+
+- router.tsx에서 1/4/5/6단계는 이미 /discovery로 리다이렉트 처리됨(F434)
+- Sprint Status / SDD Triangle / Harness Health / Freshness 위젯은 개발 내부 지표로 프로덕션 대시보드와 무관
+- 퀵 액션 4개 중 2개(SR등록/파이프라인)가 존재하지 않는 라우트를 가리킴
+
+## 변경 범위
+
+| 파일 | 변경 |
+|------|------|
+| `ProcessStageGuide.tsx` | STAGES 6개 → 2개(발굴/형상화) |
+| `dashboard.tsx` | 퀵 액션 교체, 내부 위젯 4개 삭제, 업무가이드→Wiki 링크 |
+| `TodoSection.tsx` | 빈 상태 메시지, NEXT_ACTIONS, stageColors 2단계 기준 |
+
+## 검증 계획
+
+- `turbo typecheck` PASS
+- `turbo test` PASS
+- E2E: `pnpm e2e --grep dashboard` (있으면)

--- a/docs/02-design/features/sprint-267.design.md
+++ b/docs/02-design/features/sprint-267.design.md
@@ -1,0 +1,99 @@
+---
+id: FX-DESIGN-267
+title: Sprint 267 — F516 대시보드 현행화 Design
+sprint: 267
+f_items: [F516]
+date: 2026-04-12
+status: done
+---
+
+# Sprint 267 Design — F516 대시보드 현행화
+
+## §1 변경 아이템 상세
+
+### 1. ProcessStageGuide.tsx — STAGES 축소
+
+**Before**: STAGES 6개 (수집/발굴/형상화/검증공유/제품화/GTM)
+**After**: STAGES 2개 (발굴/형상화)
+
+```typescript
+const STAGES: StageInfo[] = [
+  { stage: 2, label: "발굴", ... },
+  { stage: 3, label: "형상화", ... },
+];
+```
+
+`ResetStageGuides` 내 `for (let i = 1; i <= 6; i++)` → STAGES 기반 루프로 변경.
+
+### 2. dashboard.tsx — 5개 변경
+
+#### 2-1. 제거 항목
+- imports: `HealthScore`, `RequirementItem`, `HarnessIntegrity`, `FreshnessReport`, `HarnessHealth`, `WorkGuideSection`, `gradeClass`
+- useApi 호출: health, reqs, integrity, freshness (4개)
+- 위젯: Sprint Status, SDD Triangle, Harness Health, Harness Freshness
+- `BD_STAGE_KEYS` 6개 → 2개 (`["DISCOVERY", "FORMALIZATION"]`)
+
+#### 2-2. 퀵 액션 교체
+```typescript
+const quickActions = [
+  { label: "발굴 아이템",  href: "/discovery/items",     icon: Search },
+  { label: "아이디어/BMC", href: "/discovery/ideas-bmc", icon: Lightbulb },
+  { label: "PRD 작성",     href: "/shaping/prd",         icon: FileText },
+  { label: "Offering",    href: "/shaping/offerings",   icon: Package },
+];
+```
+
+#### 2-3. stageColors / STAGE_NUM_TO_DB_KEY 축소
+```typescript
+const stageColors = ["bg-violet-500", "bg-amber-500"];
+const STAGE_NUM_TO_DB_KEY: Record<number, string> = {
+  2: "DISCOVERY",
+  3: "FORMALIZATION",
+};
+```
+
+#### 2-4. Wiki 링크 (WorkGuideSection 대체)
+```tsx
+<div className="mt-4 rounded-lg border bg-card p-4 text-sm text-muted-foreground">
+  📖 업무 가이드는{" "}
+  <a href="https://wiki.ktds.co.kr/..." className="text-primary underline" target="_blank" rel="noopener noreferrer">
+    Wiki
+  </a>
+  를 참고하세요.
+</div>
+```
+
+### 3. TodoSection.tsx — 3개 변경
+
+#### 3-1. NEXT_ACTIONS 2단계로 축소
+```typescript
+const NEXT_ACTIONS: Record<number, { label: string; href: string }> = {
+  2: { label: "평가 실행", href: "/discovery?tab=process" },
+  3: { label: "사업기획서 작성", href: "/shaping/business-plan" },
+};
+```
+fallback: `NEXT_ACTIONS[2]`
+
+#### 3-2. stageColors 2색으로 변경
+```typescript
+const stageColors = ["bg-violet-500", "bg-amber-500"];
+```
+
+#### 3-3. 빈 상태 메시지
+```tsx
+<Link to="/discovery/items" className="text-primary underline">발굴 시작</Link>
+```
+
+## §5 파일 매핑
+
+| 파일 | 변경 종류 |
+|------|-----------|
+| `packages/web/src/components/feature/ProcessStageGuide.tsx` | STAGES 배열 축소, ResetStageGuides 루프 변경 |
+| `packages/web/src/routes/dashboard.tsx` | import 정리, useApi 제거, 퀵 액션/stageColors/위젯/Wiki 변경 |
+| `packages/web/src/components/feature/TodoSection.tsx` | NEXT_ACTIONS, stageColors, 빈 상태 메시지 변경 |
+
+## §6 TDD 판단
+
+- 변경 파일 3개, 모두 UI 컴포넌트 (React, 렌더링 로직)
+- API 서비스 로직 신규 없음 → TDD 면제 (권장 등급)
+- 타입체크 + 기존 테스트 회귀 확인으로 갈음

--- a/packages/web/src/components/feature/ProcessStageGuide.tsx
+++ b/packages/web/src/components/feature/ProcessStageGuide.tsx
@@ -3,12 +3,8 @@
 import { useState, useEffect } from "react";
 import { useLocation, Link } from "react-router-dom";
 import {
-  Inbox,
   Search,
   PenTool,
-  CheckCircle,
-  Rocket,
-  TrendingUp,
   X,
   ArrowRight,
   Bot,
@@ -36,18 +32,6 @@ interface StageInfo {
 
 const STAGES: StageInfo[] = [
   {
-    stage: 1,
-    label: "수집",
-    icon: Inbox,
-    color: "text-blue-500 bg-blue-500/10 border-blue-500/20",
-    description:
-      "고객 요청(SR), IR 제안, 외부 채널에서 사업 아이디어를 수집하는 단계예요. 다양한 출처에서 원석을 모으는 것이 목표예요.",
-    agentHelp:
-      "AI가 SR을 자동 분류하고, 유사 아이템을 감지하여 중복 등록을 방지해요.",
-    nextAction: { label: "아이디어 발굴로 이동", href: "/discovery/items" },
-    paths: ["/collection/sr", "/collection/field", "/collection/ideas"],
-  },
-  {
     stage: 2,
     label: "발굴",
     icon: Search,
@@ -57,7 +41,7 @@ const STAGES: StageInfo[] = [
     agentHelp:
       "AI가 시장 분석, 경쟁사 조사, BMC 초안 자동 생성을 도와요. Six Hats 토론으로 다각도 검증도 가능해요.",
     nextAction: { label: "Spec 형상화로 이동", href: "/shaping/prd" },
-    paths: ["/discovery/items", "/ax-bd/ideas", "/ax-bd/bmc", "/discovery/progress"],
+    paths: ["/discovery/items", "/discovery/ideas-bmc", "/discovery/progress"],
   },
   {
     stage: 3,
@@ -68,44 +52,8 @@ const STAGES: StageInfo[] = [
       "검증된 아이디어를 Spec 문서, 사업제안서, Offering Pack으로 구체화하는 단계예요.",
     agentHelp:
       "AI가 NL(자연어) 요구사항을 Spec으로 변환하고, 사업제안서 초안을 자동 생성해요.",
-    nextAction: { label: "파이프라인 검증으로", href: "/validation/pipeline" },
-    paths: ["/shaping/prd", "/shaping/proposal", "/shaping/offering"],
-  },
-  {
-    stage: 4,
-    label: "검증/공유",
-    icon: CheckCircle,
-    color: "text-green-500 bg-green-500/10 border-green-500/20",
-    description:
-      "ORB/PRB 게이트를 통과하고, 산출물을 공유하여 팀과 의사결정자의 승인을 받는 단계예요.",
-    agentHelp:
-      "AI가 게이트 문서 패키지를 자동 수집하고, 산출물 공유 링크를 생성해요.",
-    nextAction: { label: "MVP 제작으로", href: "/product/mvp" },
-    paths: ["/validation/pipeline"],
-  },
-  {
-    stage: 5,
-    label: "제품화",
-    icon: Rocket,
-    color: "text-indigo-500 bg-indigo-500/10 border-indigo-500/20",
-    description:
-      "승인된 아이템의 MVP를 제작하고, PoC 배포를 진행하는 단계예요.",
-    agentHelp:
-      "AI가 MVP 상태를 추적하고, 프로토타입 자동 생성 파이프라인을 지원해요.",
-    nextAction: { label: "GTM 준비로", href: "/gtm/projects" },
-    paths: ["/product/mvp"],
-  },
-  {
-    stage: 6,
-    label: "GTM",
-    icon: TrendingUp,
-    color: "text-rose-500 bg-rose-500/10 border-rose-500/20",
-    description:
-      "완성된 제품을 시장에 출시하고, 프로젝트 현황을 모니터링하는 최종 단계예요.",
-    agentHelp:
-      "AI가 KPI를 자동 수집하고, 프로젝트 건강도를 실시간으로 추적해요.",
-    nextAction: { label: "대시보드로", href: "/dashboard" },
-    paths: ["/gtm/projects"],
+    nextAction: { label: "Offering 작성으로", href: "/shaping/offerings" },
+    paths: ["/shaping/prd", "/shaping/proposal", "/shaping/offering", "/shaping/offerings"],
   },
 ];
 
@@ -214,8 +162,8 @@ export function ResetStageGuides() {
   const [hidden, setHidden] = useState(false);
 
   const reset = () => {
-    for (let i = 1; i <= 6; i++) {
-      localStorage.removeItem(STORAGE_PREFIX + i);
+    for (const stage of STAGES) {
+      localStorage.removeItem(STORAGE_PREFIX + stage.stage);
     }
     setHidden(true);
     setTimeout(() => setHidden(false), 2000);

--- a/packages/web/src/components/feature/TodoSection.tsx
+++ b/packages/web/src/components/feature/TodoSection.tsx
@@ -23,12 +23,8 @@ import { Badge } from "@/components/ui/badge";
 /* ------------------------------------------------------------------ */
 
 const NEXT_ACTIONS: Record<number, { label: string; href: string }> = {
-  1: { label: "아이디어 등록", href: "/discovery" },
   2: { label: "평가 실행", href: "/discovery?tab=process" },
   3: { label: "사업기획서 작성", href: "/shaping/business-plan" },
-  4: { label: "검증 기록", href: "/validation" },
-  5: { label: "MVP/PoC 추적", href: "/product" },
-  6: { label: "선제안 작성", href: "/gtm/outreach" },
 };
 
 /* ------------------------------------------------------------------ */
@@ -47,12 +43,8 @@ interface BizItemSummary {
 /* ------------------------------------------------------------------ */
 
 const stageColors = [
-  "bg-blue-500",
   "bg-violet-500",
   "bg-amber-500",
-  "bg-green-500",
-  "bg-indigo-500",
-  "bg-rose-500",
 ];
 
 function StageIndicator({ current }: { current: number }) {
@@ -157,8 +149,8 @@ export function TodoSection() {
       {!loading && !error && items.length === 0 && (
         <div className="py-8 text-center text-sm text-muted-foreground">
           진행 중인 사업 아이템이 없어요.{" "}
-          <Link to="/collection/sr" className="text-primary underline">
-            SR 등록
+          <Link to="/discovery/items" className="text-primary underline">
+            발굴 시작
           </Link>
           으로 시작해 보세요.
         </div>
@@ -167,7 +159,7 @@ export function TodoSection() {
       {!loading && !error && items.length > 0 && (
         <div className="space-y-3">
           {items.map((item) => {
-            const next = NEXT_ACTIONS[item.currentStage] ?? NEXT_ACTIONS[1]!;
+            const next = NEXT_ACTIONS[item.currentStage] ?? NEXT_ACTIONS[2]!;
             return (
               <div
                 key={item.bizItemId}

--- a/packages/web/src/routes/dashboard.tsx
+++ b/packages/web/src/routes/dashboard.tsx
@@ -3,26 +3,17 @@
 import { useEffect, useState, useMemo } from "react";
 import { Link } from "react-router-dom";
 import { fetchApi } from "@/lib/api-client";
-import type {
-  HealthScore,
-  RequirementItem,
-  HarnessIntegrity,
-  FreshnessReport,
-} from "@foundry-x/shared";
-import DashboardCard from "@/components/feature/DashboardCard";
-import HarnessHealth from "@/components/feature/HarnessHealth";
 import { STAGES } from "@/components/feature/ProcessStageGuide";
 import { cn } from "@/lib/utils";
 import {
   ArrowRight,
-  ClipboardList,
+  Search,
   Lightbulb,
   FileText,
-  GitBranch,
+  Package,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { TodoSection } from "@/components/feature/TodoSection";
-import { WorkGuideSection } from "@/components/feature/WorkGuideSection";
 
 /* ------------------------------------------------------------------ */
 /*  Hooks                                                              */
@@ -59,13 +50,6 @@ function useApi<T>(path: string): AsyncState<T> {
   return state;
 }
 
-const gradeClass = (grade: string) => {
-  if (grade === "A") return "text-green-500";
-  if (grade === "B") return "text-blue-500";
-  if (grade === "C") return "text-yellow-500";
-  return "text-destructive";
-};
-
 /* ------------------------------------------------------------------ */
 /*  프로세스 파이프라인 진행률                                          */
 /* ------------------------------------------------------------------ */
@@ -77,22 +61,14 @@ interface PipelineStats {
 }
 
 const stageColors = [
-  "bg-blue-500",
   "bg-violet-500",
   "bg-amber-500",
-  "bg-green-500",
-  "bg-indigo-500",
-  "bg-rose-500",
 ];
 
-// BD 파이프라인 단계 키(stage 번호 1-6) → DB 스테이지명 매핑
+// BD 파이프라인 단계 키(stage 번호 2-3) → DB 스테이지명 매핑
 const STAGE_NUM_TO_DB_KEY: Record<number, string> = {
-  1: "REGISTERED",
   2: "DISCOVERY",
   3: "FORMALIZATION",
-  4: "REVIEW",
-  5: "DECISION",
-  6: "OFFERING",
 };
 
 function ProcessPipeline({ stats }: { stats: PipelineStats | null }) {
@@ -144,10 +120,10 @@ function ProcessPipeline({ stats }: { stats: PipelineStats | null }) {
 /* ------------------------------------------------------------------ */
 
 const quickActions = [
-  { label: "SR 등록", href: "/collection/sr", icon: ClipboardList },
-  { label: "아이디어 추가", href: "/ax-bd/ideas", icon: Lightbulb },
-  { label: "Spec 생성", href: "/shaping/prd", icon: FileText },
-  { label: "파이프라인", href: "/validation/pipeline", icon: GitBranch },
+  { label: "발굴 아이템", href: "/discovery/items", icon: Search },
+  { label: "아이디어/BMC", href: "/discovery/ideas-bmc", icon: Lightbulb },
+  { label: "PRD 작성", href: "/shaping/prd", icon: FileText },
+  { label: "Offering", href: "/shaping/offerings", icon: Package },
 ];
 
 function QuickActions() {
@@ -177,44 +153,27 @@ function QuickActions() {
 /*  Dashboard Page                                                     */
 /* ------------------------------------------------------------------ */
 
-// Sprint 223: F460 — /biz-items/summary로 파이프라인 카운트 실제 데이터 연동
-const BD_STAGE_KEYS = ["REGISTERED", "DISCOVERY", "FORMALIZATION", "REVIEW", "DECISION", "OFFERING"];
-
 export function Component() {
-  const health = useApi<HealthScore>("/health");
-  const reqs = useApi<RequirementItem[]>("/requirements");
-  const integrity = useApi<HarnessIntegrity>("/integrity");
-  const freshness = useApi<FreshnessReport>("/freshness");
   const pipelineStats = useApi<PipelineStats>("/pipeline/stats");
   const bizItemSummaryRaw = useApi<{ items: Array<{ bizItemId: string; title: string; currentStage: number }> }>("/biz-items/summary");
   const bizItemSummaryData = bizItemSummaryRaw.data?.items ?? null;
 
-  // biz-items/summary → byStage (stageNum 기반 집계)
+  // biz-items/summary → byStage (2-3단계만 집계)
   const bdByStage = useMemo(() => {
     if (!bizItemSummaryData) return {};
     const counts: Record<string, number> = {};
     for (const item of bizItemSummaryData) {
-      const key = BD_STAGE_KEYS[item.currentStage - 1] ?? "REGISTERED";
-      counts[key] = (counts[key] ?? 0) + 1;
+      const key = STAGE_NUM_TO_DB_KEY[item.currentStage];
+      if (key) counts[key] = (counts[key] ?? 0) + 1;
     }
     return counts;
   }, [bizItemSummaryData]);
 
-  // pipeline/stats byStage 키가 DB 스테이지명(DISCOVERY 등)이지만,
-  // dashboard STAGES.label은 한국어(수집, 발굴...) — 실제 수치는 bizItemSummary로 보완
   const mergedStats: PipelineStats | null = pipelineStats.data
     ? { ...pipelineStats.data, byStage: bdByStage }
     : bizItemSummaryData
       ? { totalItems: bizItemSummaryData.length, byStage: bdByStage, avgDaysInStage: {} }
       : null;
-
-  const reqCounts = reqs.data
-    ? {
-        done: reqs.data.filter((r) => r.status === "done").length,
-        inProgress: reqs.data.filter((r) => r.status === "in_progress").length,
-        planned: reqs.data.filter((r) => r.status === "planned").length,
-      }
-    : null;
 
   return (
     <div>
@@ -223,134 +182,26 @@ export function Component() {
       {/* 프로세스 파이프라인 (상단 메인) */}
       <ProcessPipeline stats={mergedStats} />
 
-      {/* 퀵 액션 + Sprint Status */}
-      <div className="mt-4 grid gap-4 md:grid-cols-2">
+      {/* 퀵 액션 */}
+      <div className="mt-4">
         <QuickActions />
-
-        <DashboardCard
-          title="Sprint Status"
-          loading={reqs.loading}
-          error={reqs.error}
-        >
-          {reqCounts && (
-            <div className="flex gap-6">
-              <div className="text-center">
-                <div className="text-4xl font-bold text-green-500">
-                  {reqCounts.done}
-                </div>
-                <div className="text-sm text-muted-foreground">Done</div>
-              </div>
-              <div className="text-center">
-                <div className="text-4xl font-bold text-yellow-500">
-                  {reqCounts.inProgress}
-                </div>
-                <div className="text-sm text-muted-foreground">In Progress</div>
-              </div>
-              <div className="text-center">
-                <div className="text-4xl font-bold text-muted-foreground">
-                  {reqCounts.planned}
-                </div>
-                <div className="text-sm text-muted-foreground">Planned</div>
-              </div>
-            </div>
-          )}
-        </DashboardCard>
       </div>
 
-      {/* 기존 위젯 (하단 보조) */}
-      <div className="mt-4 grid gap-4 md:grid-cols-2">
-        <DashboardCard
-          title="SDD Triangle"
-          loading={health.loading}
-          error={health.error}
-        >
-          {health.data && (
-            <>
-              <div className={cn("text-5xl font-bold", gradeClass(health.data.grade))}>
-                {health.data.overall}%
-              </div>
-              <div className={cn("mb-4 text-xl font-semibold", gradeClass(health.data.grade))}>
-                Grade {health.data.grade}
-              </div>
-              <div className="grid grid-cols-3 gap-2 text-sm text-muted-foreground">
-                <div>
-                  Spec↔Code{" "}
-                  <strong className="text-foreground">
-                    {health.data.specToCode}%
-                  </strong>
-                </div>
-                <div>
-                  Code↔Test{" "}
-                  <strong className="text-foreground">
-                    {health.data.codeToTest}%
-                  </strong>
-                </div>
-                <div>
-                  Spec↔Test{" "}
-                  <strong className="text-foreground">
-                    {health.data.specToTest}%
-                  </strong>
-                </div>
-              </div>
-            </>
-          )}
-        </DashboardCard>
-
-        <DashboardCard
-          title="Harness Health"
-          loading={integrity.loading}
-          error={integrity.error}
-        >
-          {integrity.data && <HarnessHealth data={integrity.data} />}
-        </DashboardCard>
-
-        <DashboardCard
-          title="Harness Freshness"
-          loading={freshness.loading}
-          error={freshness.error}
-        >
-          {freshness.data && (
-            <>
-              <div
-                className={cn(
-                  "mb-3 text-sm font-semibold",
-                  freshness.data.overallStale
-                    ? "text-destructive"
-                    : "text-green-500",
-                )}
-              >
-                {freshness.data.overallStale ? "Stale detected" : "All fresh"}
-              </div>
-              <div className="text-sm">
-                {freshness.data.documents.map((doc) => (
-                  <div
-                    key={doc.file}
-                    className="flex justify-between border-b border-border py-1"
-                  >
-                    <span className="max-w-[60%] truncate">{doc.file}</span>
-                    <span
-                      className={cn(
-                        "font-semibold",
-                        doc.stale ? "text-destructive" : "text-green-500",
-                      )}
-                    >
-                      {doc.stale ? `${doc.staleDays}d stale` : "Fresh"}
-                    </span>
-                  </div>
-                ))}
-              </div>
-              <div className="mt-2 text-xs text-muted-foreground">
-                Checked: {freshness.data.checkedAt}
-              </div>
-            </>
-          )}
-        </DashboardCard>
-      </div>
-
-      {/* F323: ToDo List + 업무 가이드 */}
+      {/* F323: ToDo List */}
       <section className="mt-8 space-y-6">
         <TodoSection />
-        <WorkGuideSection />
+        <div className="rounded-lg border bg-card p-4 text-sm text-muted-foreground">
+          📖 업무 가이드는{" "}
+          <a
+            href="https://wiki.ktds.co.kr"
+            className="text-primary underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Wiki
+          </a>
+          를 참고하세요.
+        </div>
       </section>
     </div>
   );


### PR DESCRIPTION
## Summary

- **ProcessStageGuide**: STAGES 6개→2개(발굴/형상화) 축소, 미사용 icon 제거, ResetStageGuides STAGES 기반 루프
- **dashboard**: 퀵 액션 dead link 교체(SR등록·파이프라인 → discovery/items·ideas-bmc·prd·offerings), 개발 내부 위젯 4개(Sprint Status/SDD Triangle/Harness Health/Freshness) 삭제, WorkGuideSection → Wiki 링크 1줄
- **TodoSection**: NEXT_ACTIONS 2-3단계만 유지, stageColors 2색, 빈 상태 "SR 등록" → "발굴 시작"

## Background

Foundry-X 서비스 범위는 2단계(발굴) + 3단계(형상화)이나, 대시보드가 구 6단계(수집~GTM)를 표시하고 있었음. router.tsx에서 1/4/5/6단계는 이미 F434에서 /discovery로 리다이렉트 처리됨.

## Test plan

- [x] `turbo typecheck` PASS (메인 저장소 tsc 검증 완료)
- [x] Design ↔ Implementation Match Rate 100%
- [ ] E2E: `pnpm e2e --grep dashboard` (수동 확인 권장)

## F-item

F516 (FX-REQ-544, P1) | Sprint 267 | Phase 37 Dashboard Overhaul

🤖 Generated with [Claude Code](https://claude.com/claude-code)