### PR TITLE
fix(work-mgmt): C43~C49 Quick Fix — Changelog/Roadmap/Backlog/Classify 개선

### DIFF
--- a/packages/api/src/routes/work.ts
+++ b/packages/api/src/routes/work.ts
@@ -11,6 +11,7 @@ import {
   PhaseProgressSchema,
   BacklogHealthSchema,
   ChangelogSchema,
+  RoadmapSchema,
 } from "../schemas/work.js";
 import type { Env } from "../env.js";
 import { WorkService } from "../services/work.service.js";
@@ -219,5 +220,26 @@ const getChangelog = createRoute({
 workRoute.openapi(getChangelog, async (c) => {
   const svc = new WorkService(c.env);
   const data = await svc.getChangelog();
+  return c.json(data);
+});
+
+// ─── GET /api/work/roadmap ───────────────────────────────────────────────────
+
+const getRoadmap = createRoute({
+  method: "get",
+  path: "/work/roadmap",
+  tags: ["Work Observability"],
+  summary: "ROADMAP.md content — short/mid/long-term plans",
+  responses: {
+    200: {
+      content: { "application/json": { schema: RoadmapSchema } },
+      description: "Roadmap content",
+    },
+  },
+});
+
+workRoute.openapi(getRoadmap, async (c) => {
+  const svc = new WorkService(c.env);
+  const data = await svc.getRoadmap();
   return c.json(data);
 });

--- a/packages/api/src/schemas/work.ts
+++ b/packages/api/src/schemas/work.ts
@@ -148,3 +148,10 @@ export const ChangelogSchema = z.object({
   content: z.string(),
   generated_at: z.string(),
 });
+
+// ─── Roadmap ────────────────────────────────────────────────────────────────
+
+export const RoadmapSchema = z.object({
+  content: z.string(),
+  generated_at: z.string(),
+});

--- a/packages/api/src/services/work.service.ts
+++ b/packages/api/src/services/work.service.ts
@@ -82,7 +82,10 @@ export class WorkService {
     return this.classifyWithRegex(text);
   }
 
-  private async parseSpecItems(): Promise<WorkItem[]> {
+  private specTextCache: string | null = null;
+
+  private async fetchSpecText(): Promise<string> {
+    if (this.specTextCache) return this.specTextCache;
     try {
       const repo = this.env.GITHUB_REPO || "KTDS-AXBD/Foundry-X";
       const url = `https://raw.githubusercontent.com/${repo}/master/SPEC.md`;
@@ -91,12 +94,18 @@ export class WorkService {
           ? { Authorization: `token ${this.env.GITHUB_TOKEN}` }
           : {},
       });
-      if (!res.ok) return [];
-      const text = await res.text();
-      return this.parseFItems(text);
+      if (!res.ok) return "";
+      this.specTextCache = await res.text();
+      return this.specTextCache;
     } catch {
-      return [];
+      return "";
     }
+  }
+
+  private async parseSpecItems(): Promise<WorkItem[]> {
+    const text = await this.fetchSpecText();
+    if (!text) return [];
+    return [...this.parseFItems(text), ...this.parseBacklogItems(text)];
   }
 
   private parseFItems(specText: string): WorkItem[] {
@@ -119,6 +128,38 @@ export class WorkService {
         title: title.trim().slice(0, 100),
         status,
         sprint,
+        priority: title.match(/P[0-3]/)?.[0],
+        req_code: title.match(/FX-REQ-\d+/)?.[0],
+      });
+    }
+
+    return items;
+  }
+
+  // C45/C49: Parse Backlog table rows (C/B/X tracks)
+  // Format: | C43 | C | title... | REQ | Sprint | 상태 | 비고 |
+  private parseBacklogItems(specText: string): WorkItem[] {
+    const linePattern = /^\|\s*([CBXF]\d+)\s*\|\s*[CBXF]\s*\|\s*([^|]{3,}?)\s*\|[^|]*\|[^|]*\|\s*([^|]*?)\s*\|/gm;
+    const items: WorkItem[] = [];
+
+    for (const match of specText.matchAll(linePattern)) {
+      const id = match[1] ?? "";
+      const title = match[2] ?? "";
+      const statusCol = match[3] ?? "";
+
+      if (!id || id.startsWith("F")) continue; // F-items already parsed above
+
+      let status: WorkItem["status"] = "backlog";
+      const st = statusCol.trim().toUpperCase();
+      if (st === "DONE" || st.includes("✅")) status = "done";
+      else if (st.includes("IN_PROGRESS") || st.includes("🔧")) status = "in_progress";
+      else if (st.includes("PLANNED") || st.includes("📋")) status = "planned";
+      else if (st.includes("CANCELLED") || st.includes("CLOSED") || st.includes("REJECTED")) status = "rejected";
+
+      items.push({
+        id: id.trim(),
+        title: title.trim().slice(0, 100),
+        status,
         priority: title.match(/P[0-3]/)?.[0],
         req_code: title.match(/FX-REQ-\d+/)?.[0],
       });
@@ -269,36 +310,80 @@ export class WorkService {
   }
 
   async getPhaseProgress() {
-    const items = await this.parseSpecItems();
-
-    // Group by phase inferred from F-item numbering (every ~30 items = one phase)
-    const phaseMap = new Map<number, { total: number; done: number; in_progress: number }>();
-    const ITEMS_PER_PHASE = 15;
-
-    for (const item of items) {
-      const num = parseInt(item.id.replace("F", ""), 10);
-      const phaseId = Math.max(1, Math.ceil(num / ITEMS_PER_PHASE));
-      const entry = phaseMap.get(phaseId) ?? { total: 0, done: 0, in_progress: 0 };
-      entry.total++;
-      if (item.status === "done") entry.done++;
-      if (item.status === "in_progress") entry.in_progress++;
-      phaseMap.set(phaseId, entry);
+    const specText = await this.fetchSpecText();
+    if (!specText) {
+      return { phases: [], current_phase: 1, generated_at: new Date().toISOString() };
     }
 
-    const phases = Array.from(phaseMap.entries())
-      .sort(([a], [b]) => a - b)
-      .map(([id, data]) => ({
-        id,
-        name: `Phase ${id}`,
-        total: data.total,
-        done: data.done,
-        in_progress: data.in_progress,
-        pct: data.total > 0 ? Math.round((data.done / data.total) * 100) : 0,
-      }));
+    // Parse SPEC §3 Phase table directly instead of inferring from F-item numbers
+    // Format: | Phase 33 Work Observability (F509) | ✅ Sprint 261 |
+    // or:     | **Phase 36 Work Management Enhancement** (...) | | | |
+    const phasePattern = /^\|\s*\*{0,2}Phase\s+(\d+)[:\s]*([^(|*]*)/gm;
+    const statusPattern = /\|\s*(✅|🔧|📋)/;
 
-    const current_phase = phases.length > 0 ? (phases[phases.length - 1]?.id ?? 1) : 1;
+    const phases: Array<{ id: number; name: string; total: number; done: number; in_progress: number; pct: number }> = [];
+    const seen = new Set<number>();
+
+    for (const match of specText.matchAll(phasePattern)) {
+      const id = parseInt(match[1] ?? "0", 10);
+      if (id === 0 || seen.has(id)) continue;
+      seen.add(id);
+
+      const rawName = (match[2] ?? "").trim().replace(/\*+$/, "").trim();
+      const name = rawName || `Phase ${id}`;
+
+      // Find status in the same line
+      const lineEnd = specText.indexOf("\n", match.index ?? 0);
+      const fullLine = specText.slice(match.index ?? 0, lineEnd > 0 ? lineEnd : undefined);
+      const statusMatch = fullLine.match(statusPattern);
+      const statusEmoji = statusMatch?.[1] ?? "";
+
+      // Count F-items belonging to this phase by checking next Phase boundary
+      const items = await this.parseSpecItems();
+      const phaseItems = items.filter(i => {
+        if (!i.id.startsWith("F")) return false;
+        // Check if item is mentioned in the Phase section header or nearby rows
+        const itemIdx = specText.indexOf(`| ${i.id} |`);
+        if (itemIdx < 0) return false;
+        const phaseIdx = match.index ?? 0;
+        // Find next Phase header
+        const nextPhaseMatch = specText.slice(phaseIdx + 1).match(/^\|\s*\*{0,2}Phase\s+\d+/m);
+        const nextPhaseIdx = nextPhaseMatch ? phaseIdx + 1 + (nextPhaseMatch.index ?? specText.length) : specText.length;
+        return itemIdx > phaseIdx && itemIdx < nextPhaseIdx;
+      });
+
+      const total = phaseItems.length || 1;
+      const done = phaseItems.filter(i => i.status === "done").length || (statusEmoji === "✅" ? 1 : 0);
+      const in_progress = phaseItems.filter(i => i.status === "in_progress").length || (statusEmoji === "🔧" ? 1 : 0);
+      const pct = total > 0 ? Math.round((done / total) * 100) : (statusEmoji === "✅" ? 100 : 0);
+
+      phases.push({ id, name, total, done, in_progress, pct });
+    }
+
+    phases.sort((a, b) => a.id - b.id);
+    const current_phase = phases.find(p => p.pct < 100 && p.pct > 0)?.id
+      ?? phases[phases.length - 1]?.id
+      ?? 1;
 
     return { phases, current_phase, generated_at: new Date().toISOString() };
+  }
+
+  // C44: Parse ROADMAP.md for future plans
+  async getRoadmap() {
+    try {
+      const repo = this.env.GITHUB_REPO || "KTDS-AXBD/Foundry-X";
+      const url = `https://raw.githubusercontent.com/${repo}/master/docs/ROADMAP.md`;
+      const res = await fetch(url, {
+        headers: this.env.GITHUB_TOKEN
+          ? { Authorization: `token ${this.env.GITHUB_TOKEN}` }
+          : {},
+      });
+      if (!res.ok) return { content: "", generated_at: new Date().toISOString() };
+      const content = await res.text();
+      return { content, generated_at: new Date().toISOString() };
+    } catch {
+      return { content: "", generated_at: new Date().toISOString() };
+    }
   }
 
   async getBacklogHealth() {

--- a/packages/web/e2e/work-management.spec.ts
+++ b/packages/web/e2e/work-management.spec.ts
@@ -49,6 +49,11 @@ const MOCK_BACKLOG_HEALTH = {
   generated_at: "2026-04-12T11:00:00Z",
 };
 
+const MOCK_ROADMAP = {
+  content: "## 3. Mid-term (Phase 37~38)\n\n| 후보 | 방향 |\n|------|------|\n| 웹 대시보드 관리 기능 | F-item 상태 전이 |\n| 에이전트 자율 운영 강화 | autopilot Gap% E2E 측정 확장 |\n",
+  generated_at: "2026-04-12T11:00:00Z",
+};
+
 const MOCK_CHANGELOG = {
   content: "# Changelog\n\n## [Unreleased]\n\n### Added\n- Roadmap 뷰 추가\n- Changelog 웹 뷰 추가\n\n## [Phase 32] - 2026-04-11\n\n### Added\n- F501: GitHub Projects Board\n",
   generated_at: "2026-04-12T11:00:00Z",
@@ -91,6 +96,13 @@ async function mockWorkApi(page: import("@playwright/test").Page) {
       status: 200,
       contentType: "application/json",
       body: JSON.stringify(MOCK_CHANGELOG),
+    }),
+  );
+  await page.route("**/api/work/roadmap", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(MOCK_ROADMAP),
     }),
   );
 }
@@ -166,6 +178,9 @@ test.describe("Work Management (F509 Walking Skeleton)", () => {
     await expect(page.getByText(/2\/4/)).toBeVisible();
     // Completed section — Phase 33 (pct: 100)
     await expect(page.getByText(/완료/)).toBeVisible();
+    // Future plans from ROADMAP.md
+    await expect(page.getByText("향후 계획")).toBeVisible();
+    await expect(page.getByText(/웹 대시보드 관리 기능/)).toBeVisible();
   });
 
   // ─── Changelog Tab ────────────────────────────────────────────────────────
@@ -209,6 +224,9 @@ test.describe("Work Management (F509 Walking Skeleton)", () => {
     await page.goto("/work-management");
 
     await page.getByRole("button", { name: "작업 분류" }).click();
+
+    // C45: 사용 방법 안내 표시 확인
+    await expect(page.getByText("사용 방법")).toBeVisible();
 
     const textarea = page.getByPlaceholder("예: 작업 관찰성 view에 burndown chart 추가 필요");
     await expect(textarea).toBeVisible();

--- a/packages/web/src/routes/work-management.tsx
+++ b/packages/web/src/routes/work-management.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { fetchApi, postApi, ApiError } from "@/lib/api-client";
+import ReactMarkdown from "react-markdown";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -412,9 +413,23 @@ function ClassifyTab() {
 
   return (
     <div style={{ maxWidth: 600, fontFamily: T.font }}>
-      <p style={{ color: T.text.secondary, fontSize: 13, marginBottom: 16 }}>
-        자연어로 작업을 입력하면 유형과 우선순위를 자동으로 분류해요.
-      </p>
+      <div style={{ marginBottom: 20 }}>
+        <p style={{ color: T.text.secondary, fontSize: 13, marginBottom: 8 }}>
+          자연어로 작업 아이디어를 입력하면 AI가 자동으로 분류해요.
+        </p>
+        <div style={{ background: T.bg.card, border: `1px solid ${T.border.subtle}`, borderRadius: 8, padding: "10px 14px", fontSize: 12, color: T.text.muted, lineHeight: 1.6 }}>
+          <div style={{ fontWeight: 600, color: T.text.secondary, marginBottom: 4 }}>사용 방법</div>
+          <div>1. 아래 텍스트 영역에 하고 싶은 작업을 자연어로 입력해요</div>
+          <div>2. <strong style={{ color: T.text.primary }}>분류하기</strong> 버튼을 누르면 AI가 유형(F/B/C/X)과 우선순위(P0~P3)를 분류해요</div>
+          <div>3. 결과를 확인하고 CLI에서 <code style={{ background: T.bg.inset, padding: "1px 4px", borderRadius: 3, fontFamily: T.mono, fontSize: 11 }}>task-start.sh</code> 명령으로 등록해요</div>
+          <div style={{ marginTop: 6, color: T.text.muted, fontSize: 11 }}>
+            유형: <strong style={{ color: "#8b5cf6" }}>F</strong>=Feature &nbsp;
+            <strong style={{ color: "#ef4444" }}>B</strong>=Bug &nbsp;
+            <strong style={{ color: "#6b7280" }}>C</strong>=Chore &nbsp;
+            <strong style={{ color: "#06b6d4" }}>X</strong>=Experiment
+          </div>
+        </div>
+      </div>
 
       <textarea
         value={input}
@@ -522,7 +537,7 @@ function getPhaseLabel(id: number, name: string): string {
 
 // ─── Roadmap Tab ─────────────────────────────────────────────────────────────
 
-function RoadmapTab({ phaseProgress }: { phaseProgress: PhaseProgressData | null }) {
+function RoadmapTab({ phaseProgress, roadmapContent }: { phaseProgress: PhaseProgressData | null; roadmapContent: string | null }) {
   if (!phaseProgress) {
     return <div style={{ color: T.text.secondary, padding: 20, fontFamily: T.font }}>불러오는 중…</div>;
   }
@@ -627,6 +642,61 @@ function RoadmapTab({ phaseProgress }: { phaseProgress: PhaseProgressData | null
           )}
         </section>
       )}
+
+      {/* Future plans from ROADMAP.md */}
+      {roadmapContent && (
+        <section style={{ marginTop: 32, borderTop: `1px solid ${T.border.subtle}`, paddingTop: 24 }}>
+          {sectionLabel("향후 계획", T.text.accent)}
+          <div
+            style={{
+              background: T.bg.card,
+              borderRadius: 10,
+              padding: "16px 20px",
+              border: `1px solid ${T.border.subtle}`,
+              fontSize: 13,
+              lineHeight: 1.7,
+              color: T.text.secondary,
+            }}
+          >
+            <ReactMarkdown
+              components={{
+                h2: ({ children }) => (
+                  <div style={{ fontWeight: 700, color: T.text.primary, margin: "18px 0 8px", fontSize: 15, fontFamily: T.font }}>{children}</div>
+                ),
+                h3: ({ children }) => (
+                  <div style={{ fontWeight: 600, color: T.text.primary, margin: "14px 0 6px", fontSize: 13 }}>{children}</div>
+                ),
+                li: ({ children }) => (
+                  <li style={{ marginBottom: 4, color: T.text.secondary, fontSize: 12 }}>{children}</li>
+                ),
+                strong: ({ children }) => (
+                  <strong style={{ color: T.text.primary }}>{children}</strong>
+                ),
+                a: ({ href, children }) => (
+                  <a href={href} target="_blank" rel="noreferrer" style={{ color: T.text.accent }}>{children}</a>
+                ),
+                code: ({ children }) => (
+                  <code style={{ background: T.bg.inset, padding: "1px 5px", borderRadius: 3, fontSize: 11, fontFamily: T.mono }}>{children}</code>
+                ),
+                table: ({ children }) => (
+                  <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12, margin: "8px 0" }}>{children}</table>
+                ),
+                th: ({ children }) => (
+                  <th style={{ textAlign: "left", padding: "6px 10px", borderBottom: `1px solid ${T.border.subtle}`, color: T.text.muted, fontWeight: 600 }}>{children}</th>
+                ),
+                td: ({ children }) => (
+                  <td style={{ padding: "6px 10px", borderBottom: `1px solid ${T.border.subtle}` }}>{children}</td>
+                ),
+                p: ({ children }) => (
+                  <p style={{ margin: "6px 0" }}>{children}</p>
+                ),
+              }}
+            >
+              {roadmapContent}
+            </ReactMarkdown>
+          </div>
+        </section>
+      )}
     </div>
   );
 }
@@ -715,30 +785,46 @@ function ChangelogTab() {
             <div
               style={{
                 padding: "14px 18px",
-                fontSize: 12,
-                lineHeight: 1.8,
+                fontSize: 13,
+                lineHeight: 1.7,
                 color: T.text.secondary,
-                whiteSpace: "pre-wrap",
-                fontFamily: T.mono,
-                maxHeight: 400,
+                maxHeight: 500,
                 overflow: "auto",
               }}
+              className="changelog-md"
             >
-              {section.lines
-                .filter(l => l.trim())
-                .map((line, j) => {
-                  if (line.startsWith("### ")) {
-                    return (
-                      <div key={j} style={{ fontWeight: 700, color: T.text.primary, margin: "14px 0 6px", fontSize: 13, fontFamily: T.font }}>
-                        {line.replace("### ", "")}
-                      </div>
-                    );
-                  }
-                  if (line.trimStart().startsWith("- ")) {
-                    return <div key={j} style={{ paddingLeft: 12 }}>{line}</div>;
-                  }
-                  return <div key={j}>{line}</div>;
-                })}
+              <ReactMarkdown
+                components={{
+                  h3: ({ children }) => (
+                    <div style={{ fontWeight: 700, color: T.text.primary, margin: "16px 0 8px", fontSize: 14, fontFamily: T.font }}>
+                      {children}
+                    </div>
+                  ),
+                  li: ({ children }) => (
+                    <li style={{ marginBottom: 4, paddingLeft: 4, color: T.text.secondary, fontSize: 12 }}>
+                      {children}
+                    </li>
+                  ),
+                  strong: ({ children }) => (
+                    <strong style={{ color: T.text.primary, fontWeight: 600 }}>{children}</strong>
+                  ),
+                  a: ({ href, children }) => (
+                    <a href={href} target="_blank" rel="noreferrer" style={{ color: T.text.accent, textDecoration: "none" }}>
+                      {children}
+                    </a>
+                  ),
+                  code: ({ children }) => (
+                    <code style={{ background: T.bg.inset, padding: "1px 5px", borderRadius: 3, fontSize: 11, fontFamily: T.mono, color: T.status.planned }}>
+                      {children}
+                    </code>
+                  ),
+                  p: ({ children }) => (
+                    <p style={{ margin: "6px 0", fontSize: 12, lineHeight: 1.6 }}>{children}</p>
+                  ),
+                }}
+              >
+                {section.lines.join("\n")}
+              </ReactMarkdown>
             </div>
           </div>
         );
@@ -754,6 +840,7 @@ export function Component() {
   const [snapshot, setSnapshot] = useState<WorkSnapshot | null>(null);
   const [phaseProgress, setPhaseProgress] = useState<PhaseProgressData | null>(null);
   const [backlogHealth, setBacklogHealth] = useState<BacklogHealthData | null>(null);
+  const [roadmapContent, setRoadmapContent] = useState<string | null>(null);
   const [lastUpdate, setLastUpdate] = useState<Date | null>(null);
   const [fetchError, setFetchError] = useState<string | null>(null);
   const hasSnapshotData = useRef(false);
@@ -779,6 +866,10 @@ export function Component() {
   const fetchAnalytics = useCallback(async () => {
     try { setPhaseProgress(await fetchApi<PhaseProgressData>("/work/phase-progress")); } catch { /* ignore */ }
     try { setBacklogHealth(await fetchApi<BacklogHealthData>("/work/backlog-health")); } catch { /* ignore */ }
+    try {
+      const rm = await fetchApi<{ content: string }>("/work/roadmap");
+      setRoadmapContent(rm.content);
+    } catch { /* ignore */ }
   }, []);
 
   useEffect(() => {
@@ -878,7 +969,7 @@ export function Component() {
         </div>
       )}
       {(!fetchError || snapshot) && tab === "kanban"   && <KanbanTab snapshot={snapshot} />}
-      {tab === "roadmap"   && <RoadmapTab phaseProgress={phaseProgress} />}
+      {tab === "roadmap"   && <RoadmapTab phaseProgress={phaseProgress} roadmapContent={roadmapContent} />}
       {tab === "backlog"   && <BacklogHealthTab health={backlogHealth} />}
       {tab === "changelog" && <ChangelogTab />}
       {tab === "classify"  && <ClassifyTab />}


### PR DESCRIPTION
## Summary
- **C43**: Changelog 마크다운 렌더링 (react-markdown 적용)
- **C44**: Roadmap에 ROADMAP.md 미래 계획 표시 + Phase 파싱 근본 개선
- **C45**: Backlog C/B/X-track 파싱 확장 + 작업 분류 사용법 안내
- **C49**: Kanban 데이터 보강 (F-item + Backlog 통합 파싱)

## Test plan
- [x] API typecheck pass
- [x] Web typecheck + build pass
- [x] API tests 103 pass
- [x] E2E work-management 9/9 pass
- [ ] 프로덕션 배포 후 fx.minu.best/work-management 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)