### PR TITLE
fix(web): 랜딩 페이지 수치 현행화 + fx-gateway lockfile

### DIFF
--- a/packages/web/content/landing/hero.md
+++ b/packages/web/content/landing/hero.md
@@ -3,16 +3,16 @@ title: Foundry-X
 section: hero
 sort_order: 0
 tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼"
-phase: "Phase 33 ✅"
-phaseTitle: "Work Management Observability"
+phase: "Phase 37"
+phaseTitle: "Work Lifecycle Platform"
 stats:
-  - value: "6"
+  - value: "2"
     label: "BD 파이프라인"
   - value: "10+"
     label: "AI 에이전트"
-  - value: "22"
+  - value: "63"
     label: "자동화 스킬"
-  - value: "261"
+  - value: "270"
     label: "Sprints"
 ---
 

--- a/packages/web/src/components/landing/footer.tsx
+++ b/packages/web/src/components/landing/footer.tsx
@@ -69,7 +69,7 @@ export function Footer() {
             &copy; {new Date().getFullYear()} KTDS AX BD. All rights reserved.
           </p>
           <p className="font-mono text-xs text-muted-foreground/60">
-            Sprint 261 &middot; Phase 33
+            Sprint 270 &middot; Phase 37
           </p>
         </div>
       </div>

--- a/packages/web/src/routes/landing.tsx
+++ b/packages/web/src/routes/landing.tsx
@@ -69,17 +69,17 @@ function getSectionOrder(section: string): number {
    ═══════════════════════════════════════════════ */
 
 const SITE_META_FALLBACK = {
-  sprint: "Sprint 261",
-  phase: "Phase 33 ✅",
-  phaseTitle: "Work Management Observability",
+  sprint: "Sprint 270",
+  phase: "Phase 37",
+  phaseTitle: "Work Lifecycle Platform",
   tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼",
 } as const;
 
 const STATS_FALLBACK = [
-  { value: "6", label: "BD 파이프라인" },
+  { value: "2", label: "BD 파이프라인" },
   { value: "10+", label: "AI 에이전트" },
-  { value: "22", label: "자동화 스킬" },
-  { value: "261", label: "Sprints" },
+  { value: "63", label: "자동화 스킬" },
+  { value: "270", label: "Sprints" },
 ];
 
 // Build-time content from TinaCMS-managed Markdown

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,44 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@29.0.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.12.12(@types/node@22.19.15)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/fx-discovery:
+    dependencies:
+      hono:
+        specifier: ^4.0.0
+        version: 4.12.8
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20241218.0
+        version: 4.20260316.1
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.37
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@20.19.37)(jiti@2.6.1)(jsdom@29.0.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.12.12(@types/node@20.19.37)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
+
+  packages/fx-gateway:
+    dependencies:
+      hono:
+        specifier: ^4.0.0
+        version: 4.12.8
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20241218.0
+        version: 4.20260316.1
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.37
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@20.19.37)(jiti@2.6.1)(jsdom@29.0.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.12.12(@types/node@20.19.37)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
+
   packages/gate-x:
     dependencies:
       '@foundry-x/harness-kit':


### PR DESCRIPTION
## Summary
- 랜딩 페이지 3파일(hero.md, landing.tsx, footer.tsx) Phase 33→37, Sprint 261→270 갱신
- BD 파이프라인 6→2 (S269 정비 반영), 자동화 스킬 22→63 (S264-B 실측)
- fx-gateway pnpm-lock.yaml 누락분 보정 (Sprint 268 PR #535 후속)

## Test plan
- [ ] `pnpm typecheck` 통과 확인
- [ ] 랜딩 페이지 hero 영역 수치 표시 확인
- [ ] footer Sprint/Phase 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)