### PR TITLE
fix(web): 랜딩 Sprint 270→274

### DIFF
--- a/packages/web/content/landing/hero.md
+++ b/packages/web/content/landing/hero.md
@@ -12,7 +12,7 @@ stats:
     label: "AI 에이전트"
   - value: "63"
     label: "자동화 스킬"
-  - value: "270"
+  - value: "274"
     label: "Sprints"
 ---
 

--- a/packages/web/src/components/landing/footer.tsx
+++ b/packages/web/src/components/landing/footer.tsx
@@ -69,7 +69,7 @@ export function Footer() {
             &copy; {new Date().getFullYear()} KTDS AX BD. All rights reserved.
           </p>
           <p className="font-mono text-xs text-muted-foreground/60">
-            Sprint 270 &middot; Phase 37
+            Sprint 274 &middot; Phase 37
           </p>
         </div>
       </div>

--- a/packages/web/src/routes/landing.tsx
+++ b/packages/web/src/routes/landing.tsx
@@ -69,7 +69,7 @@ function getSectionOrder(section: string): number {
    ═══════════════════════════════════════════════ */
 
 const SITE_META_FALLBACK = {
-  sprint: "Sprint 270",
+  sprint: "Sprint 274",
   phase: "Phase 37",
   phaseTitle: "Work Lifecycle Platform",
   tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼",
@@ -79,7 +79,7 @@ const STATS_FALLBACK = [
   { value: "2", label: "BD 파이프라인" },
   { value: "10+", label: "AI 에이전트" },
   { value: "63", label: "자동화 스킬" },
-  { value: "270", label: "Sprints" },
+  { value: "274", label: "Sprints" },
 ];
 
 // Build-time content from TinaCMS-managed Markdown


### PR DESCRIPTION
## Summary
- 랜딩 3파일 Sprint 270→274 갱신 (S271 session-end 후속)
- `content-sync-check.sh` drift 0 확인

## Test plan
- [ ] 랜딩 페이지 footer Sprint 표시 확인
- [ ] hero 영역 Sprints 수치 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)