### PR TITLE
fix(sync): daily-check 수치 보정 Sprint 275 + D1 0131

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Foundry-X가 이를 읽고 분석하고 동기화를 강제해요.
 |------|------|
 | Phase | 37 (Sprint 275) |
 | Sprints | 275 완료 |
-| API Routes | ~10 |
-| API Services | ~30 |
+| API Routes | ~11 |
+| API Services | ~31 |
 | API Schemas | ~14 |
 | Tests | ~3,452 + E2E 273 |
-| D1 Migrations | 141 (latest: 0130) |
+| D1 Migrations | 142 (latest: 0131) |
 <!-- README_SYNC_END -->
 
 ## 주요 기능

--- a/SPEC.md
+++ b/SPEC.md
@@ -46,7 +46,7 @@ Foundry-X — AX 사업개발 라이프사이클을 AI 에이전트로 자동화
 > ```
 > wc -l SPEC.md && find packages/api/src/db/migrations/*.sql | sort | tail -1
 > ```
-> **마지막 실측** (Sprint 275, 2026-04-13): ~10 routes, ~30 services, ~14 schemas, D1 0130, 10 packages, tests ~3452 (E2E 273) — F517 🔧 Sprint 274, F518 🔧 Sprint 275 진행
+> **마지막 실측** (Sprint 275, 2026-04-13): ~11 routes, ~31 services, ~14 schemas, D1 0131, 10 packages, tests ~3452 (E2E 273) — Phase 37 F516~F518 ✅ 완료
 
 ## §3 Phase 진행 현황
 

--- a/packages/web/content/landing/hero.md
+++ b/packages/web/content/landing/hero.md
@@ -12,7 +12,7 @@ stats:
     label: "AI 에이전트"
   - value: "63"
     label: "자동화 스킬"
-  - value: "270"
+  - value: "275"
     label: "Sprints"
 ---
 

--- a/packages/web/src/components/landing/footer.tsx
+++ b/packages/web/src/components/landing/footer.tsx
@@ -69,7 +69,7 @@ export function Footer() {
             &copy; {new Date().getFullYear()} KTDS AX BD. All rights reserved.
           </p>
           <p className="font-mono text-xs text-muted-foreground/60">
-            Sprint 270 &middot; Phase 37
+            Sprint 275 &middot; Phase 37
           </p>
         </div>
       </div>

--- a/packages/web/src/routes/landing.tsx
+++ b/packages/web/src/routes/landing.tsx
@@ -69,7 +69,7 @@ function getSectionOrder(section: string): number {
    ═══════════════════════════════════════════════ */
 
 const SITE_META_FALLBACK = {
-  sprint: "Sprint 270",
+  sprint: "Sprint 275",
   phase: "Phase 37",
   phaseTitle: "Work Lifecycle Platform",
   tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼",
@@ -79,7 +79,7 @@ const STATS_FALLBACK = [
   { value: "2", label: "BD 파이프라인" },
   { value: "10+", label: "AI 에이전트" },
   { value: "63", label: "자동화 스킬" },
-  { value: "270", label: "Sprints" },
+  { value: "275", label: "Sprints" },
 ];
 
 // Build-time content from TinaCMS-managed Markdown


### PR DESCRIPTION
## Summary
- SPEC.md/README.md: routes ~11, services ~31, D1 142 (0131)
- hero.md + landing.tsx + footer.tsx: Sprint 270→275 (5 Sprint 누적 drift 해소)
- `/ax:daily-check` full 자동 보정

## Test plan
- [ ] `turbo typecheck` PASS (캐시 히트)
- [ ] 랜딩 페이지 Sprint 표기 275 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)