### PR TITLE
fix(msa): fx-gateway + fx-discovery eslint config 추가

### DIFF
--- a/packages/fx-discovery/eslint.config.js
+++ b/packages/fx-discovery/eslint.config.js
@@ -1,0 +1,22 @@
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    rules: {
+      '@typescript-eslint/no-unused-vars': ['error', {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+      }],
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/consistent-type-imports': 'error',
+      'no-console': 'off',
+    },
+  },
+  {
+    ignores: ['dist/', 'node_modules/', '**/*.test.ts'],
+  },
+);

--- a/packages/fx-gateway/eslint.config.js
+++ b/packages/fx-gateway/eslint.config.js
@@ -1,0 +1,22 @@
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    rules: {
+      '@typescript-eslint/no-unused-vars': ['error', {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+      }],
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/consistent-type-imports': 'error',
+      'no-console': 'off',
+    },
+  },
+  {
+    ignores: ['dist/', 'node_modules/', '**/*.test.ts'],
+  },
+);


### PR DESCRIPTION
## Summary
- Sprint 277 (PR #544) MSA 패키지 생성 시 eslint.config.js 누락 → CI test job 실패
- gate-x 패키지의 config를 fx-gateway, fx-discovery에 복사

## Test plan
- [ ] `turbo lint` PASS (fx-gateway + fx-discovery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)