### PR TITLE
fix(sync): Sprint 275→277 콘텐츠 동기화

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Sprint 277 MSA Phase 2** (PR #544, Gap 97%): F522 shared 타입 슬리밍(Discovery 전용 3파일 fx-discovery 이동) + F523 D1 격리(fx-discovery items GET 라우트 이관, fx-gateway DISCOVERY binding 하드와이어, deploy.yml MSA job, D1 접근 규약 문서)
+- **Sprint 276 Dashboard Overhaul** (PR #543): F519 대시보드 현행화 — 파이프라인 6→2단계, 퀵 액션 정리, 위젯 삭제, ToDo UX
 - **Sprint 268 MSA Walking Skeleton** (PR #535): `packages/fx-gateway/` API 게이트웨이 Worker + `packages/fx-discovery/` Discovery 독립 Worker 생성 (F520/F521 ✅, Gap 100%). PRD: `docs/specs/fx-msa-roadmap/prd-final.md` (3-AI R2 검토, Ambiguity 0.150)
 - **S268** (PR #532, #534): /work-management 대시보드 대폭 개선 — Roadmap 탭(Phase 타임라인 + ROADMAP.md 미래 계획), Changelog 탭(react-markdown 렌더링), 불필요 탭 4개 제거(Context Resume/Sessions/Pipeline/Velocity), AXIS 디자인 토큰 적용, 탭 한글화, `GET /api/work/changelog` + `GET /api/work/roadmap` 엔드포인트
 - **C44/C45/C49** (PR #534): Backlog C/B/X-track 파싱(`parseBacklogItems`), 작업 분류 사용법 안내, `getPhaseProgress` SPEC §3 직접 파싱, `fetchSpecText` 캐시

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Foundry-X가 이를 읽고 분석하고 동기화를 강제해요.
 <!-- README_SYNC_START: daily-check가 SPEC.md 실측값 기준으로 자동 동기화 -->
 | 항목 | 수치 |
 |------|------|
-| Phase | 37 (Sprint 275) |
-| Sprints | 275 완료 |
+| Phase | 39 (Sprint 277) |
+| Sprints | 277 완료 |
 | API Routes | ~11 |
 | API Services | ~31 |
 | API Schemas | ~14 |

--- a/SPEC.md
+++ b/SPEC.md
@@ -4,7 +4,7 @@ title: Foundry-X Project Specification
 version: 5.80
 status: Active
 category: SPEC
-system-version: Sprint 275
+system-version: Sprint 277
 created: 2026-03-16
 updated: 2026-04-13
 author: Sinclair Seo
@@ -48,7 +48,7 @@ Foundry-X — AX 사업개발 라이프사이클을 AI 에이전트로 자동화
 > ```
 > wc -l SPEC.md && find packages/api/src/db/migrations/*.sql | sort | tail -1
 > ```
-> **마지막 실측** (Sprint 275, 2026-04-13): ~11 routes, ~31 services, ~14 schemas, D1 0131, 10 packages, tests ~3452 (E2E 273) — Phase 37 F516~F518 ✅ 완료
+> **마지막 실측** (Sprint 277, 2026-04-13): ~11 routes, ~30 services, ~14 schemas, D1 0131, 10 packages, tests ~3452 (E2E 273) — Phase 38+39 완료 (F519/F522/F523 ✅)
 
 ## §3 Phase 진행 현황
 

--- a/packages/web/content/landing/hero.md
+++ b/packages/web/content/landing/hero.md
@@ -3,8 +3,8 @@ title: Foundry-X
 section: hero
 sort_order: 0
 tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼"
-phase: "Phase 37"
-phaseTitle: "Work Lifecycle Platform"
+phase: "Phase 39"
+phaseTitle: "MSA Walking Skeleton"
 stats:
   - value: "2"
     label: "BD 파이프라인"
@@ -12,7 +12,7 @@ stats:
     label: "AI 에이전트"
   - value: "63"
     label: "자동화 스킬"
-  - value: "275"
+  - value: "277"
     label: "Sprints"
 ---
 

--- a/packages/web/src/components/landing/footer.tsx
+++ b/packages/web/src/components/landing/footer.tsx
@@ -69,7 +69,7 @@ export function Footer() {
             &copy; {new Date().getFullYear()} KTDS AX BD. All rights reserved.
           </p>
           <p className="font-mono text-xs text-muted-foreground/60">
-            Sprint 275 &middot; Phase 37
+            Sprint 277 &middot; Phase 39
           </p>
         </div>
       </div>

--- a/packages/web/src/routes/landing.tsx
+++ b/packages/web/src/routes/landing.tsx
@@ -69,9 +69,9 @@ function getSectionOrder(section: string): number {
    ═══════════════════════════════════════════════ */
 
 const SITE_META_FALLBACK = {
-  sprint: "Sprint 275",
-  phase: "Phase 37",
-  phaseTitle: "Work Lifecycle Platform",
+  sprint: "Sprint 277",
+  phase: "Phase 39",
+  phaseTitle: "MSA Walking Skeleton",
   tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼",
 } as const;
 
@@ -79,7 +79,7 @@ const STATS_FALLBACK = [
   { value: "2", label: "BD 파이프라인" },
   { value: "10+", label: "AI 에이전트" },
   { value: "63", label: "자동화 스킬" },
-  { value: "275", label: "Sprints" },
+  { value: "277", label: "Sprints" },
 ];
 
 // Build-time content from TinaCMS-managed Markdown


### PR DESCRIPTION
## Summary
- SPEC.md system-version Sprint 277, 실측 수치 보정
- README/Landing 페이지 Sprint+Phase 번호 갱신
- CHANGELOG Sprint 276/277 Added 항목

## Test plan
- [ ] typecheck/lint pass
- [ ] 랜딩 페이지 Sprint/Phase 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)