### PR TITLE
feat(agent): Sprint 280 — F527 Agent Runtime (L2)

### DIFF
--- a/docs/01-plan/features/sprint-280.plan.md
+++ b/docs/01-plan/features/sprint-280.plan.md
@@ -1,0 +1,83 @@
+---
+id: FX-PLAN-280
+title: Sprint 280 — F527 Agent Runtime (L2)
+sprint: 280
+f_items: [F527]
+req_codes: [FX-REQ-555]
+date: 2026-04-13
+status: active
+---
+
+# Sprint 280 Plan — F527 Agent Runtime (L2)
+
+## 목표
+
+HyperFX Agent Stack의 Layer 2(Agent Runtime)를 구현한다.
+기존 7개 전문 에이전트가 하드코딩된 패턴을 선언적 `AgentSpec` + `AgentRuntime` 으로 표준화.
+
+## 범위 (F-L2-1 ~ F-L2-7)
+
+| 서브기능 | 설명 | 파일 |
+|---------|------|------|
+| F-L2-1 | `defineTool()` — 도구 정의 표준 유틸리티 | `runtime/define-tool.ts` |
+| F-L2-2 | `AgentSpec` YAML 스키마 (TS 타입 + 파서) | `shared/agent-runtime.ts` + `runtime/agent-spec-loader.ts` |
+| F-L2-3 | `AgentRuntime` — 추론→도구→결과→반복 루프 | `runtime/agent-runtime.ts` |
+| F-L2-4 | Hooks — 라이프사이클 이벤트 (before/after Model/Tool/Invocation) | `runtime/agent-runtime.ts` 내장 |
+| F-L2-5 | `TokenTracker` — 에이전트별 토큰 추적 | `runtime/token-tracker.ts` |
+| F-L2-6 | `ToolRegistry` — 도구 등록/검색/카테고리화 | `runtime/tool-registry.ts` |
+| F-L2-7 | 기존 7개 에이전트 YAML 마이그레이션 | `specs/*.agent.yaml` |
+
+## 아키텍처 결정
+
+### YAML 파싱 전략
+- 공용 `yaml` npm 패키지 없이 경량 파서 구현 (Workers 호환)
+- `AgentSpec`은 TypeScript 타입으로 정의 (JSON 직렬화 가능)
+- YAML 파일은 human-readable 소스, 파서가 TS 객체로 변환
+- Workers 런타임에서는 KV 또는 번들 string으로 제공
+
+### Claude API 연동
+- `AgentRuntime`은 기존 `fetch`→Anthropic API 패턴 유지
+- 도구 호출은 Claude의 `tool_use` content block 처리
+- 스트리밍은 F529(Sprint 282)에서 추가 — 이번 스프린트는 비스트리밍
+
+### 기존 코드 영향
+- 기존 `ClaudeApiRunner`, `OrchestrationLoop` 수정 없음
+- `AgentRuntime`은 별도 레이어 — F528에서 O-G-D Loop 래핑 시 연결
+
+## TDD 계획
+
+**적용 등급**: 필수 (새 서비스 로직)
+
+| 테스트 대상 | Red 시나리오 |
+|------------|-------------|
+| `defineTool()` | 스키마 검증, name/description 필수 |
+| `ToolRegistry` | register/get/list/category 필터 |
+| `TokenTracker` | track/getUsage/total 집계 |
+| `AgentRuntime` | stop reason 처리, hooks 실행 순서 |
+| `AgentSpecLoader` | 유효/무효 YAML 파싱 |
+
+## 파일 매핑
+
+```
+packages/
+  shared/src/
+    agent-runtime.ts          (신규: AgentSpec, ToolDefinition, hooks 타입)
+  api/src/
+    core/agent/runtime/
+      index.ts                (barrel export)
+      define-tool.ts          (F-L2-1)
+      tool-registry.ts        (F-L2-6)
+      token-tracker.ts        (F-L2-5)
+      agent-spec-loader.ts    (F-L2-2 파서)
+      agent-runtime.ts        (F-L2-3 + F-L2-4)
+    core/agent/specs/
+      planner.agent.yaml
+      architect.agent.yaml
+      reviewer.agent.yaml
+      test.agent.yaml
+      security.agent.yaml
+      qa.agent.yaml
+      infra.agent.yaml
+    __tests__/services/
+      agent-runtime.test.ts   (TDD Red→Green)
+```

--- a/docs/02-design/features/sprint-280.design.md
+++ b/docs/02-design/features/sprint-280.design.md
@@ -1,0 +1,315 @@
+---
+id: FX-DESIGN-280
+title: Sprint 280 Design — F527 Agent Runtime (L2)
+sprint: 280
+f_items: [F527]
+date: 2026-04-13
+status: active
+---
+
+# Sprint 280 Design — F527 Agent Runtime (L2)
+
+## §1 타입 설계 (`packages/shared/src/agent-runtime.ts`)
+
+```typescript
+// F-L2-1: 도구 정의
+export interface ToolDefinition<TInput = unknown, TOutput = unknown> {
+  name: string;
+  description: string;
+  inputSchema: ZodType<TInput>;
+  outputSchema?: ZodType<TOutput>;
+  category: 'builtin' | 'mcp' | 'agent' | 'custom';
+  permissions?: string[];
+  execute: (input: TInput, ctx: ToolExecutionContext) => Promise<TOutput>;
+}
+
+export interface ToolExecutionContext {
+  agentId: string;
+  sessionId: string;
+  db?: D1Database;
+}
+
+// F-L2-2: AgentSpec YAML 스키마
+export interface AgentSpec {
+  name: string;
+  version?: string;
+  model: string;
+  systemPrompt: string;
+  tools: string[];          // ToolRegistry keys
+  steering?: {
+    rules: string[];
+  };
+  evaluation?: {
+    criteria: string[];
+    minScore?: number;
+  };
+  constraints?: {
+    maxTokens?: number;
+    maxRounds?: number;
+    timeoutMs?: number;
+  };
+  metadata?: Record<string, unknown>;
+}
+
+// F-L2-4: Hooks
+export interface AgentHooks {
+  beforeInvocation?: (ctx: InvocationContext) => Promise<void>;
+  afterInvocation?: (ctx: InvocationContext, result: RuntimeResult) => Promise<void>;
+  beforeModel?: (ctx: ModelCallContext) => Promise<ModelCallContext | void>;
+  afterModel?: (ctx: ModelCallContext, result: ModelCallResult) => Promise<void>;
+  beforeTool?: (ctx: ToolCallContext) => Promise<ToolCallContext | 'cancel' | void>;
+  afterTool?: (ctx: ToolCallContext, result: ToolCallResult) => Promise<ToolCallResult | void>;
+}
+
+// F-L2-3: Runtime
+export interface RuntimeContext {
+  agentId: string;
+  sessionId: string;
+  apiKey: string;
+  db?: D1Database;
+  hooks?: AgentHooks;
+}
+
+export type StopReason = 'end_turn' | 'tool_use' | 'max_tokens' | 'cancelled' | 'max_rounds';
+
+export interface RuntimeResult {
+  output: string;
+  stopReason: StopReason;
+  rounds: number;
+  tokenUsage: TokenUsageSummary;
+}
+
+// F-L2-5: TokenTracker
+export interface TokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+}
+
+export interface TokenUsageSummary extends TokenUsage {
+  totalTokens: number;
+  estimatedCostUsd?: number;
+}
+
+// Context types
+export interface InvocationContext {
+  agentId: string;
+  sessionId: string;
+  spec: AgentSpec;
+  input: string;
+}
+
+export interface ModelCallContext {
+  messages: AnthropicMessage[];
+  systemPrompt: string;
+  model: string;
+  tools?: AnthropicToolDef[];
+}
+
+export interface ModelCallResult {
+  content: AnthropicContent[];
+  stopReason: string;
+  usage: TokenUsage;
+}
+
+export interface ToolCallContext {
+  toolName: string;
+  toolInput: unknown;
+  toolUseId: string;
+}
+
+export interface ToolCallResult {
+  content: string;
+  isError?: boolean;
+}
+
+export interface AnthropicMessage {
+  role: 'user' | 'assistant';
+  content: string | AnthropicContent[];
+}
+
+export interface AnthropicContent {
+  type: 'text' | 'tool_use' | 'tool_result';
+  text?: string;
+  id?: string;
+  name?: string;
+  input?: unknown;
+  tool_use_id?: string;
+  content?: string;
+  is_error?: boolean;
+}
+
+export interface AnthropicToolDef {
+  name: string;
+  description: string;
+  input_schema: Record<string, unknown>;
+}
+```
+
+## §2 컴포넌트 설계
+
+### `define-tool.ts` (F-L2-1)
+```typescript
+export function defineTool<TInput, TOutput>(
+  def: ToolDefinition<TInput, TOutput>
+): ToolDefinition<TInput, TOutput>
+```
+- name, description 필수 검증
+- category 기본값: 'custom'
+- 그대로 반환 (type-safe wrapper)
+
+### `tool-registry.ts` (F-L2-6)
+```typescript
+class ToolRegistry {
+  register(tool: ToolDefinition): this
+  get(name: string): ToolDefinition | undefined
+  has(name: string): boolean
+  list(filter?: { category?: ToolCategory }): ToolDefinition[]
+  toAnthropicTools(): AnthropicToolDef[]  // Claude API 포맷 변환
+  clear(): void
+}
+```
+
+### `token-tracker.ts` (F-L2-5)
+```typescript
+class TokenTracker {
+  track(agentId: string, usage: TokenUsage): void
+  getUsage(agentId: string): TokenUsageSummary
+  total(): TokenUsageSummary
+  reset(agentId?: string): void
+}
+```
+- 에이전트별 누적 집계
+- `total()`은 모든 에이전트 합산
+
+### `agent-spec-loader.ts` (F-L2-2)
+```typescript
+// 간단한 YAML 파서 (agent spec 전용)
+function parseAgentSpec(yaml: string): AgentSpec
+function validateAgentSpec(spec: unknown): AgentSpec  // zod validation
+```
+- 지원 타입: string, number, boolean, string[]
+- 중첩 객체: 1단계만 (tools, steering, evaluation, constraints, metadata)
+- 파싱 실패 시 명확한 에러 메시지
+
+### `agent-runtime.ts` (F-L2-3 + F-L2-4)
+```typescript
+class AgentRuntime {
+  constructor(registry: ToolRegistry, tracker: TokenTracker)
+  
+  async run(
+    spec: AgentSpec,
+    input: string,
+    ctx: RuntimeContext
+  ): Promise<RuntimeResult>
+}
+```
+
+**에이전트 루프 흐름:**
+```
+1. beforeInvocation hook
+2. 초기 messages = [{ role: 'user', content: input }]
+3. while rounds < maxRounds:
+   a. beforeModel hook → Claude API 호출
+   b. afterModel hook
+   c. stopReason == 'end_turn' → break
+   d. stopReason == 'tool_use' → forEach tool_use:
+      - beforeTool hook (cancel 시 skip)
+      - ToolRegistry.get(name).execute(input, ctx)
+      - afterTool hook (결과 override 가능)
+      - messages에 tool_result 추가
+4. afterInvocation hook
+5. return RuntimeResult
+```
+
+## §3 YAML 파일 구조
+
+```yaml
+# planner.agent.yaml 예시
+name: planner
+version: "1.0"
+model: claude-haiku-4-5-20251001
+systemPrompt: |
+  You are a planning agent for Foundry-X...
+tools:
+  - read_file
+  - search_code
+  - create_plan
+constraints:
+  maxTokens: 4096
+  maxRounds: 10
+```
+
+## §4 기존 에이전트 매핑
+
+| 기존 파일 | YAML 파일 | 핵심 역할 |
+|----------|----------|---------|
+| `planner-agent.ts` | `planner.agent.yaml` | 코드베이스 분석 + 계획 |
+| `architect-agent.ts` 관련 | `architect.agent.yaml` | 아키텍처 설계 |
+| `reviewer-agent.ts` | `reviewer.agent.yaml` | 코드 리뷰 |
+| `test-agent.ts` | `test.agent.yaml` | 테스트 생성 |
+| `security-agent.ts` | `security.agent.yaml` | 보안 분석 |
+| `qa-agent.ts` | `qa.agent.yaml` | QA 검증 |
+| `infra-agent.ts` | `infra.agent.yaml` | 인프라 점검 |
+
+## §4b 구현 중 추가된 유틸리티 (역동기화)
+
+| 함수/속성 | 위치 | 설명 |
+|---------|------|------|
+| `toJsonSchema(schema)` | `define-tool.ts` | Zod→JSON Schema 변환 (toAnthropicTools 내부용) |
+| `validateAgentSpec(obj)` | `agent-spec-loader.ts` | 이미 파싱된 객체 검증 |
+| `ToolRegistry.size` | `tool-registry.ts` | 등록 도구 수 |
+| `TokenTracker.agents()` | `token-tracker.ts` | 추적 중인 에이전트 목록 |
+| `toAnthropicTools(names?)` | `tool-registry.ts` | names 파라미터로 spec.tools 필터링 |
+
+**타입 변경 (의도적)**:
+- `TokenUsage` → `LLMTokenUsage`, `TokenUsageSummary` → `LLMTokenSummary` (shared 내 명확성)
+- `RuntimeContext.db`: `D1Database` → `unknown` (shared에서 Cloudflare 의존 제거)
+- `ToolExecutionContext`: shared → api 패키지 (Zod 의존 회피)
+
+## §5 파일 매핑 (Worker 없음 — 단일 구현)
+
+| 파일 | 신규/수정 | 설명 |
+|------|---------|------|
+| `packages/shared/src/agent-runtime.ts` | 신규 | 공유 타입 |
+| `packages/shared/src/index.ts` | 수정 | export 추가 |
+| `packages/api/src/core/agent/runtime/index.ts` | 신규 | barrel |
+| `packages/api/src/core/agent/runtime/define-tool.ts` | 신규 | F-L2-1 |
+| `packages/api/src/core/agent/runtime/tool-registry.ts` | 신규 | F-L2-6 |
+| `packages/api/src/core/agent/runtime/token-tracker.ts` | 신규 | F-L2-5 |
+| `packages/api/src/core/agent/runtime/agent-spec-loader.ts` | 신규 | F-L2-2 |
+| `packages/api/src/core/agent/runtime/agent-runtime.ts` | 신규 | F-L2-3+4 |
+| `packages/api/src/core/agent/specs/planner.agent.yaml` | 신규 | F-L2-7 |
+| `packages/api/src/core/agent/specs/architect.agent.yaml` | 신규 | F-L2-7 |
+| `packages/api/src/core/agent/specs/reviewer.agent.yaml` | 신규 | F-L2-7 |
+| `packages/api/src/core/agent/specs/test.agent.yaml` | 신규 | F-L2-7 |
+| `packages/api/src/core/agent/specs/security.agent.yaml` | 신규 | F-L2-7 |
+| `packages/api/src/core/agent/specs/qa.agent.yaml` | 신규 | F-L2-7 |
+| `packages/api/src/core/agent/specs/infra.agent.yaml` | 신규 | F-L2-7 |
+| `packages/api/src/__tests__/services/agent-runtime.test.ts` | 신규 | TDD |
+
+## §6 테스트 계약 (TDD Red Target)
+
+```
+describe("F527 Agent Runtime (L2)")
+  describe("defineTool")
+    ✗ name과 description이 있으면 도구를 반환한다
+    ✗ name이 없으면 에러를 던진다
+  describe("ToolRegistry")
+    ✗ register 후 get으로 조회된다
+    ✗ category 필터로 list 가능하다
+    ✗ toAnthropicTools()가 올바른 포맷을 반환한다
+  describe("TokenTracker")
+    ✗ track 후 getUsage에 누적된다
+    ✗ total()이 전체 합산을 반환한다
+    ✗ reset()으로 초기화된다
+  describe("AgentSpecLoader")
+    ✗ 유효한 YAML을 AgentSpec으로 파싱한다
+    ✗ systemPrompt 없는 YAML은 에러를 던진다
+  describe("AgentRuntime")
+    ✗ end_turn 응답 시 단일 라운드로 완료된다
+    ✗ tool_use 응답 시 도구를 실행하고 결과를 이어간다
+    ✗ beforeTool hook이 'cancel'을 반환하면 도구를 건너뛴다
+    ✗ maxRounds 초과 시 max_rounds로 중단된다
+```

--- a/packages/api/src/__tests__/services/agent-runtime.test.ts
+++ b/packages/api/src/__tests__/services/agent-runtime.test.ts
@@ -1,0 +1,393 @@
+// F527 Agent Runtime (L2) — TDD Red Phase
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { defineTool } from "../../core/agent/runtime/define-tool.js";
+import { ToolRegistry } from "../../core/agent/runtime/tool-registry.js";
+import { TokenTracker } from "../../core/agent/runtime/token-tracker.js";
+import { parseAgentSpec } from "../../core/agent/runtime/agent-spec-loader.js";
+import { AgentRuntime } from "../../core/agent/runtime/agent-runtime.js";
+import { z } from "zod";
+import type { RuntimeContext, AgentHooks } from "@foundry-x/shared";
+
+// ─── defineTool ──────────────────────────────────────────────────────────────
+
+describe("F527 Agent Runtime (L2)", () => {
+  describe("defineTool", () => {
+    it("name과 description이 있으면 도구를 반환한다", () => {
+      const tool = defineTool({
+        name: "read_file",
+        description: "Reads a file from disk",
+        inputSchema: z.object({ path: z.string() }),
+        category: "builtin",
+        execute: async ({ path }) => `content of ${path}`,
+      });
+
+      expect(tool.name).toBe("read_file");
+      expect(tool.description).toBe("Reads a file from disk");
+      expect(tool.category).toBe("builtin");
+    });
+
+    it("name이 없으면 에러를 던진다", () => {
+      expect(() =>
+        defineTool({
+          name: "",
+          description: "Some tool",
+          inputSchema: z.object({}),
+          category: "custom",
+          execute: async () => undefined,
+        })
+      ).toThrow("Tool name is required");
+    });
+
+    it("description이 없으면 에러를 던진다", () => {
+      expect(() =>
+        defineTool({
+          name: "my_tool",
+          description: "",
+          inputSchema: z.object({}),
+          category: "custom",
+          execute: async () => undefined,
+        })
+      ).toThrow("Tool description is required");
+    });
+  });
+
+  // ─── ToolRegistry ───────────────────────────────────────────────────────────
+
+  describe("ToolRegistry", () => {
+    let registry: ToolRegistry;
+
+    beforeEach(() => {
+      registry = new ToolRegistry();
+    });
+
+    it("register 후 get으로 조회된다", () => {
+      const tool = defineTool({
+        name: "search_code",
+        description: "Search code",
+        inputSchema: z.object({ query: z.string() }),
+        category: "builtin",
+        execute: async () => "results",
+      });
+
+      registry.register(tool);
+      expect(registry.get("search_code")).toBe(tool);
+    });
+
+    it("없는 도구는 undefined를 반환한다", () => {
+      expect(registry.get("nonexistent")).toBeUndefined();
+    });
+
+    it("has()로 존재 여부를 확인한다", () => {
+      const tool = defineTool({
+        name: "my_tool",
+        description: "A tool",
+        inputSchema: z.object({}),
+        category: "custom",
+        execute: async () => undefined,
+      });
+      registry.register(tool);
+
+      expect(registry.has("my_tool")).toBe(true);
+      expect(registry.has("other_tool")).toBe(false);
+    });
+
+    it("category 필터로 list 가능하다", () => {
+      registry.register(
+        defineTool({ name: "t1", description: "d1", inputSchema: z.object({}), category: "builtin", execute: async () => undefined })
+      );
+      registry.register(
+        defineTool({ name: "t2", description: "d2", inputSchema: z.object({}), category: "custom", execute: async () => undefined })
+      );
+      registry.register(
+        defineTool({ name: "t3", description: "d3", inputSchema: z.object({}), category: "builtin", execute: async () => undefined })
+      );
+
+      const builtins = registry.list({ category: "builtin" });
+      expect(builtins).toHaveLength(2);
+      expect(builtins.map((t) => t.name)).toContain("t1");
+      expect(builtins.map((t) => t.name)).toContain("t3");
+    });
+
+    it("toAnthropicTools()가 올바른 포맷을 반환한다", () => {
+      registry.register(
+        defineTool({
+          name: "do_thing",
+          description: "Does a thing",
+          inputSchema: z.object({ x: z.string() }),
+          category: "custom",
+          execute: async () => undefined,
+        })
+      );
+
+      const anthropicTools = registry.toAnthropicTools();
+      expect(anthropicTools).toHaveLength(1);
+      expect(anthropicTools[0]).toMatchObject({
+        name: "do_thing",
+        description: "Does a thing",
+        input_schema: expect.objectContaining({ type: "object" }),
+      });
+    });
+  });
+
+  // ─── TokenTracker ───────────────────────────────────────────────────────────
+
+  describe("TokenTracker", () => {
+    let tracker: TokenTracker;
+
+    beforeEach(() => {
+      tracker = new TokenTracker();
+    });
+
+    it("track 후 getUsage에 누적된다", () => {
+      tracker.track("agent-1", { inputTokens: 100, outputTokens: 50 });
+      tracker.track("agent-1", { inputTokens: 200, outputTokens: 100 });
+
+      const usage = tracker.getUsage("agent-1");
+      expect(usage.inputTokens).toBe(300);
+      expect(usage.outputTokens).toBe(150);
+      expect(usage.totalTokens).toBe(450);
+    });
+
+    it("다른 에이전트는 별도로 집계된다", () => {
+      tracker.track("agent-1", { inputTokens: 100, outputTokens: 50 });
+      tracker.track("agent-2", { inputTokens: 200, outputTokens: 100 });
+
+      expect(tracker.getUsage("agent-1").totalTokens).toBe(150);
+      expect(tracker.getUsage("agent-2").totalTokens).toBe(300);
+    });
+
+    it("total()이 전체 합산을 반환한다", () => {
+      tracker.track("agent-1", { inputTokens: 100, outputTokens: 50 });
+      tracker.track("agent-2", { inputTokens: 200, outputTokens: 100 });
+
+      const total = tracker.total();
+      expect(total.inputTokens).toBe(300);
+      expect(total.outputTokens).toBe(150);
+      expect(total.totalTokens).toBe(450);
+    });
+
+    it("reset()으로 특정 에이전트 초기화된다", () => {
+      tracker.track("agent-1", { inputTokens: 100, outputTokens: 50 });
+      tracker.reset("agent-1");
+
+      expect(tracker.getUsage("agent-1").totalTokens).toBe(0);
+    });
+
+    it("reset() 인자 없이 전체 초기화된다", () => {
+      tracker.track("agent-1", { inputTokens: 100, outputTokens: 50 });
+      tracker.track("agent-2", { inputTokens: 200, outputTokens: 100 });
+      tracker.reset();
+
+      expect(tracker.total().totalTokens).toBe(0);
+    });
+  });
+
+  // ─── AgentSpecLoader ────────────────────────────────────────────────────────
+
+  describe("AgentSpecLoader", () => {
+    it("유효한 YAML을 AgentSpec으로 파싱한다", () => {
+      const yaml = `
+name: planner
+model: claude-haiku-4-5-20251001
+systemPrompt: You are a planning agent
+tools:
+  - read_file
+  - search_code
+constraints:
+  maxTokens: 4096
+  maxRounds: 10
+`.trim();
+
+      const spec = parseAgentSpec(yaml);
+      expect(spec.name).toBe("planner");
+      expect(spec.model).toBe("claude-haiku-4-5-20251001");
+      expect(spec.systemPrompt).toBe("You are a planning agent");
+      expect(spec.tools).toEqual(["read_file", "search_code"]);
+      expect(spec.constraints?.maxTokens).toBe(4096);
+      expect(spec.constraints?.maxRounds).toBe(10);
+    });
+
+    it("systemPrompt 없는 YAML은 에러를 던진다", () => {
+      const yaml = `
+name: planner
+model: claude-haiku-4-5-20251001
+`.trim();
+
+      expect(() => parseAgentSpec(yaml)).toThrow();
+    });
+
+    it("model 없는 YAML은 에러를 던진다", () => {
+      const yaml = `
+name: planner
+systemPrompt: You are a planning agent
+`.trim();
+
+      expect(() => parseAgentSpec(yaml)).toThrow();
+    });
+  });
+
+  // ─── AgentRuntime ───────────────────────────────────────────────────────────
+
+  describe("AgentRuntime", () => {
+    let registry: ToolRegistry;
+    let tracker: TokenTracker;
+    let runtime: AgentRuntime;
+    const originalFetch = globalThis.fetch;
+
+    const makeContext = (): RuntimeContext => ({
+      agentId: "test-agent",
+      sessionId: "session-123",
+      apiKey: "test-key",
+    });
+
+    const makeSpec = (overrides = {}) => ({
+      name: "test",
+      model: "claude-haiku-4-5-20251001",
+      systemPrompt: "You are a test agent",
+      tools: [],
+      constraints: { maxRounds: 5 },
+      ...overrides,
+    });
+
+    beforeEach(() => {
+      registry = new ToolRegistry();
+      tracker = new TokenTracker();
+      runtime = new AgentRuntime(registry, tracker);
+      globalThis.fetch = originalFetch;
+    });
+
+    it("end_turn 응답 시 단일 라운드로 완료된다", async () => {
+      const mockResponse = {
+        content: [{ type: "text", text: "Plan complete" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 100, output_tokens: 50 },
+      };
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      });
+
+      const result = await runtime.run(makeSpec(), "Plan this task", makeContext());
+
+      expect(result.stopReason).toBe("end_turn");
+      expect(result.output).toBe("Plan complete");
+      expect(result.rounds).toBe(1);
+      expect(result.tokenUsage.totalTokens).toBe(150);
+    });
+
+    it("tool_use 응답 시 도구를 실행하고 결과를 이어간다", async () => {
+      registry.register(
+        defineTool({
+          name: "read_file",
+          description: "Read a file",
+          inputSchema: z.object({ path: z.string() }),
+          category: "builtin",
+          execute: async ({ path }) => `contents of ${path}`,
+        })
+      );
+
+      const toolUseResponse = {
+        content: [
+          { type: "tool_use", id: "tu_1", name: "read_file", input: { path: "src/index.ts" } },
+        ],
+        stop_reason: "tool_use",
+        usage: { input_tokens: 100, output_tokens: 30 },
+      };
+      const finalResponse = {
+        content: [{ type: "text", text: "Done reading" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 200, output_tokens: 40 },
+      };
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(toolUseResponse) })
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(finalResponse) });
+
+      const result = await runtime.run(
+        makeSpec({ tools: ["read_file"] }),
+        "Read the index file",
+        makeContext()
+      );
+
+      expect(result.stopReason).toBe("end_turn");
+      expect(result.output).toBe("Done reading");
+      expect(result.rounds).toBe(2);
+    });
+
+    it("beforeTool hook이 'cancel'을 반환하면 도구를 건너뛴다", async () => {
+      const executeStub = vi.fn();
+      registry.register(
+        defineTool({
+          name: "dangerous_tool",
+          description: "Dangerous",
+          inputSchema: z.object({}),
+          category: "custom",
+          execute: executeStub,
+        })
+      );
+
+      const toolUseResponse = {
+        content: [
+          { type: "tool_use", id: "tu_1", name: "dangerous_tool", input: {} },
+        ],
+        stop_reason: "tool_use",
+        usage: { input_tokens: 50, output_tokens: 20 },
+      };
+      const finalResponse = {
+        content: [{ type: "text", text: "Skipped" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 100, output_tokens: 20 },
+      };
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(toolUseResponse) })
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(finalResponse) });
+
+      const ctx = {
+        ...makeContext(),
+        hooks: {
+          beforeTool: vi.fn().mockResolvedValue("cancel" as const),
+        },
+      };
+
+      await runtime.run(makeSpec({ tools: ["dangerous_tool"] }), "Do dangerous thing", ctx);
+
+      expect(executeStub).not.toHaveBeenCalled();
+      expect(ctx.hooks.beforeTool).toHaveBeenCalled();
+    });
+
+    it("maxRounds 초과 시 max_rounds로 중단된다", async () => {
+      const toolUseResponse = {
+        content: [
+          { type: "tool_use", id: "tu_1", name: "loop_tool", input: {} },
+        ],
+        stop_reason: "tool_use",
+        usage: { input_tokens: 50, output_tokens: 20 },
+      };
+      // 항상 tool_use 반환 → 루프 지속
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(toolUseResponse),
+      });
+
+      registry.register(
+        defineTool({
+          name: "loop_tool",
+          description: "Loops forever",
+          inputSchema: z.object({}),
+          category: "custom",
+          execute: async () => "looping",
+        })
+      );
+
+      const result = await runtime.run(
+        makeSpec({ tools: ["loop_tool"], constraints: { maxRounds: 3 } }),
+        "Loop",
+        makeContext()
+      );
+
+      expect(result.stopReason).toBe("max_rounds");
+      expect(result.rounds).toBe(3);
+    });
+  });
+});

--- a/packages/api/src/core/agent/runtime/agent-runtime.ts
+++ b/packages/api/src/core/agent/runtime/agent-runtime.ts
@@ -1,0 +1,250 @@
+// ─── F527: F-L2-3 AgentRuntime + F-L2-4 Hooks (Sprint 280) ───
+
+import type {
+  AgentSpec,
+  RuntimeContext,
+  RuntimeResult,
+  StopReason,
+  AnthropicMessage,
+  AnthropicContent,
+  AnthropicToolDef,
+  ModelCallContext,
+  ModelCallResult,
+  ToolCallContext,
+  ToolCallResult,
+  LLMTokenUsage,
+} from "@foundry-x/shared";
+import type { ToolRegistry } from "./tool-registry.js";
+import type { TokenTracker } from "./token-tracker.js";
+
+const ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages";
+
+interface AnthropicResponse {
+  content: AnthropicContent[];
+  stop_reason: string;
+  usage: { input_tokens: number; output_tokens: number; cache_read_input_tokens?: number; cache_creation_input_tokens?: number };
+}
+
+/**
+ * AgentRuntime — 추론→도구→결과→반복 루프 엔진.
+ *
+ * Strands SDK의 Agent Loop 패턴:
+ * 1. Claude 호출 (beforeModel hook)
+ * 2. 응답 처리 (afterModel hook)
+ * 3. tool_use → 도구 실행 (beforeTool / afterTool hook)
+ * 4. end_turn / max_rounds / max_tokens → 종료
+ */
+export class AgentRuntime {
+  constructor(
+    private registry: ToolRegistry,
+    private tracker: TokenTracker,
+  ) {}
+
+  async run(spec: AgentSpec, input: string, ctx: RuntimeContext): Promise<RuntimeResult> {
+    const maxRounds = spec.constraints?.maxRounds ?? 10;
+    const maxTokens = spec.constraints?.maxTokens ?? 4096;
+    const hooks = ctx.hooks ?? {};
+
+    const invocationCtx = { agentId: ctx.agentId, sessionId: ctx.sessionId, spec, input };
+
+    await hooks.beforeInvocation?.(invocationCtx);
+
+    const messages: AnthropicMessage[] = [{ role: "user", content: input }];
+    const toolDefs: AnthropicToolDef[] = spec.tools.length > 0
+      ? this.registry.toAnthropicTools(spec.tools)
+      : [];
+
+    let lastOutput = "";
+    let lastStopReason: StopReason = "end_turn";
+    let totalUsage: LLMTokenUsage = { inputTokens: 0, outputTokens: 0 };
+    let rounds = 0;
+
+    while (rounds < maxRounds) {
+      rounds++;
+
+      let modelCtx: ModelCallContext = {
+        messages,
+        systemPrompt: spec.systemPrompt,
+        model: spec.model,
+        tools: toolDefs.length > 0 ? toolDefs : undefined,
+      };
+
+      // beforeModel hook
+      const hookResult = await hooks.beforeModel?.(modelCtx);
+      if (hookResult) modelCtx = hookResult;
+
+      // Claude API 호출
+      const modelResult = await this.callClaude(modelCtx, ctx.apiKey, maxTokens);
+
+      // 토큰 추적
+      this.tracker.track(ctx.agentId, modelResult.usage);
+      totalUsage = {
+        inputTokens: totalUsage.inputTokens + modelResult.usage.inputTokens,
+        outputTokens: totalUsage.outputTokens + modelResult.usage.outputTokens,
+      };
+
+      // afterModel hook
+      await hooks.afterModel?.(modelCtx, modelResult);
+
+      // 텍스트 출력 추출
+      const textContent = modelResult.content
+        .filter((c) => c.type === "text")
+        .map((c) => c.text ?? "")
+        .join("");
+      if (textContent) lastOutput = textContent;
+
+      // 종료 조건 확인
+      const stopReason = modelResult.stopReason as StopReason;
+
+      if (stopReason === "end_turn" || stopReason === "max_tokens") {
+        lastStopReason = stopReason;
+        // assistant 응답 추가
+        messages.push({ role: "assistant", content: modelResult.content });
+        break;
+      }
+
+      if (stopReason === "tool_use") {
+        // assistant 응답 추가 (tool_use 포함)
+        messages.push({ role: "assistant", content: modelResult.content });
+
+        // 도구 호출 처리
+        const toolUseItems = modelResult.content.filter((c) => c.type === "tool_use");
+        const toolResults: AnthropicContent[] = [];
+
+        for (const toolUse of toolUseItems) {
+          if (!toolUse.name || !toolUse.id) continue;
+
+          let toolCtx: ToolCallContext = {
+            toolName: toolUse.name,
+            toolInput: toolUse.input,
+            toolUseId: toolUse.id,
+          };
+
+          // beforeTool hook — 'cancel' 반환 시 도구 건너뜀
+          const beforeResult = await hooks.beforeTool?.(toolCtx);
+          if (beforeResult === "cancel") {
+            toolResults.push({
+              type: "tool_result",
+              tool_use_id: toolUse.id,
+              content: "[cancelled by hook]",
+              is_error: false,
+            });
+            continue;
+          }
+          if (beforeResult && typeof beforeResult === "object") {
+            toolCtx = beforeResult;
+          }
+
+          // 도구 실행
+          let toolResult: ToolCallResult;
+          const toolDef = this.registry.get(toolCtx.toolName);
+
+          if (!toolDef) {
+            toolResult = { content: `Tool '${toolCtx.toolName}' not found in registry`, isError: true };
+          } else {
+            try {
+              const output = await toolDef.execute(toolCtx.toolInput, {
+                agentId: ctx.agentId,
+                sessionId: ctx.sessionId,
+                db: ctx.db,
+              });
+              toolResult = {
+                content: typeof output === "string" ? output : JSON.stringify(output),
+                isError: false,
+              };
+            } catch (err) {
+              toolResult = {
+                content: err instanceof Error ? err.message : String(err),
+                isError: true,
+              };
+            }
+          }
+
+          // afterTool hook — 결과 override 가능
+          const afterResult = await hooks.afterTool?.(toolCtx, toolResult);
+          const finalResult = afterResult ?? toolResult;
+
+          toolResults.push({
+            type: "tool_result",
+            tool_use_id: toolUse.id,
+            content: finalResult.content,
+            is_error: finalResult.isError,
+          });
+        }
+
+        // tool_result를 user 메시지로 추가
+        messages.push({ role: "user", content: toolResults });
+        lastStopReason = "tool_use";
+        continue;
+      }
+
+      // 알 수 없는 stop_reason → 종료
+      lastStopReason = stopReason;
+      break;
+    }
+
+    // max_rounds 도달
+    if (rounds >= maxRounds && lastStopReason === "tool_use") {
+      lastStopReason = "max_rounds";
+    }
+
+    const result: RuntimeResult = {
+      output: lastOutput,
+      stopReason: lastStopReason,
+      rounds,
+      tokenUsage: {
+        inputTokens: totalUsage.inputTokens,
+        outputTokens: totalUsage.outputTokens,
+        totalTokens: totalUsage.inputTokens + totalUsage.outputTokens,
+      },
+    };
+
+    await hooks.afterInvocation?.(invocationCtx, result);
+
+    return result;
+  }
+
+  private async callClaude(
+    ctx: ModelCallContext,
+    apiKey: string,
+    maxTokens: number,
+  ): Promise<ModelCallResult> {
+    const body: Record<string, unknown> = {
+      model: ctx.model,
+      max_tokens: maxTokens,
+      system: ctx.systemPrompt,
+      messages: ctx.messages,
+    };
+
+    if (ctx.tools && ctx.tools.length > 0) {
+      body.tools = ctx.tools;
+    }
+
+    const res = await fetch(ANTHROPIC_API_URL, {
+      method: "POST",
+      headers: {
+        "x-api-key": apiKey,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Anthropic API error: ${res.status} ${res.statusText}`);
+    }
+
+    const data = (await res.json()) as AnthropicResponse;
+
+    return {
+      content: data.content,
+      stopReason: data.stop_reason,
+      usage: {
+        inputTokens: data.usage.input_tokens,
+        outputTokens: data.usage.output_tokens,
+        cacheReadTokens: data.usage.cache_read_input_tokens,
+        cacheWriteTokens: data.usage.cache_creation_input_tokens,
+      },
+    };
+  }
+}

--- a/packages/api/src/core/agent/runtime/agent-spec-loader.ts
+++ b/packages/api/src/core/agent/runtime/agent-spec-loader.ts
@@ -1,0 +1,174 @@
+// ─── F527: F-L2-2 AgentSpec YAML 파서 (Sprint 280) ───
+
+import { z } from "zod";
+import type { AgentSpec } from "@foundry-x/shared";
+
+// Zod 스키마로 AgentSpec 검증
+const agentSpecSchema = z.object({
+  name: z.string().min(1, "name is required"),
+  version: z.string().optional(),
+  model: z.string().min(1, "model is required"),
+  systemPrompt: z.string().min(1, "systemPrompt is required"),
+  tools: z.array(z.string()).default([]),
+  steering: z
+    .object({
+      rules: z.array(z.string()).default([]),
+    })
+    .optional(),
+  evaluation: z
+    .object({
+      criteria: z.array(z.string()).default([]),
+      minScore: z.number().optional(),
+    })
+    .optional(),
+  constraints: z
+    .object({
+      maxTokens: z.number().optional(),
+      maxRounds: z.number().optional(),
+      timeoutMs: z.number().optional(),
+    })
+    .optional(),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+/**
+ * YAML 문자열을 AgentSpec으로 파싱한다.
+ *
+ * 지원하는 YAML 서브셋:
+ * - key: value (문자열, 숫자, 불리언)
+ * - key: |<newline>  멀티라인 블록 스칼라
+ * - key:<newline>  - item  (문자열 배열)
+ * - 1단계 중첩 객체
+ *
+ * Workers 호환: 외부 YAML 라이브러리 없이 직접 파싱
+ */
+export function parseAgentSpec(yaml: string): AgentSpec {
+  const raw = parseSimpleYaml(yaml);
+  const result = agentSpecSchema.safeParse(raw);
+  if (!result.success) {
+    const issues = result.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join(", ");
+    throw new Error(`Invalid AgentSpec: ${issues}`);
+  }
+  return result.data as AgentSpec;
+}
+
+/** 검증된 AgentSpec 객체를 반환 (이미 파싱된 객체용) */
+export function validateAgentSpec(raw: unknown): AgentSpec {
+  const result = agentSpecSchema.safeParse(raw);
+  if (!result.success) {
+    const issues = result.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join(", ");
+    throw new Error(`Invalid AgentSpec: ${issues}`);
+  }
+  return result.data as AgentSpec;
+}
+
+// ─── 경량 YAML 파서 ──────────────────────────────────────────────────────────
+
+// TypeScript doesn't support direct recursive type aliases; use interface
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type YamlValue = string | number | boolean | string[] | Record<string, any>;
+type YamlDoc = Record<string, YamlValue>;
+
+function parseSimpleYaml(text: string): YamlDoc {
+  const lines = text.split("\n");
+  const result: YamlDoc = {};
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    if (!line || line.trim() === "" || line.trim().startsWith("#")) {
+      i++;
+      continue;
+    }
+
+    // 최상위 키 감지 (들여쓰기 없음)
+    const topKeyMatch = line.match(/^([a-zA-Z_][a-zA-Z0-9_-]*):\s*(.*)/);
+    if (!topKeyMatch || !topKeyMatch[1]) {
+      i++;
+      continue;
+    }
+
+    const key = topKeyMatch[1];
+    const rest = topKeyMatch[2]?.trim() ?? "";
+
+    // 멀티라인 블록 스칼라 (`|`)
+    if (rest === "|") {
+      i++;
+      const blockLines: string[] = [];
+      let baseIndent = -1;
+      while (i < lines.length) {
+        const blockLine = lines[i];
+        if (blockLine === undefined || blockLine.trim() === "") {
+          if (blockLines.length > 0) break;
+          i++;
+          continue;
+        }
+        const indent = blockLine.match(/^(\s+)/)?.[1]?.length ?? 0;
+        if (baseIndent === -1) baseIndent = indent;
+        if (indent < baseIndent && blockLine.trim() !== "") break;
+        blockLines.push(blockLine.slice(baseIndent));
+        i++;
+      }
+      result[key] = blockLines.join("\n").trimEnd();
+      continue;
+    }
+
+    // 값이 없음 → 다음 줄이 배열이나 객체일 수 있음
+    if (rest === "" || rest === null) {
+      i++;
+      // 들여쓰기된 다음 줄 수집
+      const children: string[] = [];
+      while (i < lines.length) {
+        const child = lines[i];
+        if (!child || child.trim() === "") { i++; break; }
+        if (/^\S/.test(child)) break; // 들여쓰기 없음 → 다른 최상위 키
+        children.push(child);
+        i++;
+      }
+
+      if (children.length === 0) {
+        result[key] = "";
+        continue;
+      }
+
+      // 배열 항목인지 확인
+      if (children[0]?.trim().startsWith("- ")) {
+        result[key] = children
+          .map((c) => c.trim())
+          .filter((c) => c.startsWith("- "))
+          .map((c) => c.slice(2).trim());
+      } else {
+        // 단순 key: value 객체 (1단계)
+        const obj: Record<string, string | number | boolean> = {};
+        for (const child of children) {
+          const childMatch = child.trim().match(/^([a-zA-Z_][a-zA-Z0-9_-]*):\s*(.*)/);
+          if (childMatch?.[1]) {
+            obj[childMatch[1]] = parseScalar(childMatch[2]?.trim() ?? "");
+          }
+        }
+        result[key] = obj;
+      }
+      continue;
+    }
+
+    // 인라인 값
+    result[key] = parseScalar(rest);
+    i++;
+  }
+
+  return result;
+}
+
+function parseScalar(value: string): string | number | boolean {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  if (value === "null" || value === "~") return "";
+  const num = Number(value);
+  if (!Number.isNaN(num) && value !== "") return num;
+  // 따옴표 제거
+  if ((value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))) {
+    return value.slice(1, -1);
+  }
+  return value;
+}

--- a/packages/api/src/core/agent/runtime/define-tool.ts
+++ b/packages/api/src/core/agent/runtime/define-tool.ts
@@ -1,0 +1,85 @@
+// ─── F527: F-L2-1 defineTool() 유틸리티 (Sprint 280) ───
+
+import type { ToolCategory } from "@foundry-x/shared";
+import { z } from "zod";
+
+export interface ToolExecutionContext {
+  agentId: string;
+  sessionId: string;
+  db?: unknown;
+}
+
+export interface ToolDefinition<TInput = unknown, TOutput = unknown> {
+  name: string;
+  description: string;
+  inputSchema: z.ZodType<TInput>;
+  outputSchema?: z.ZodType<TOutput>;
+  category: ToolCategory;
+  permissions?: string[];
+  execute: (input: TInput, ctx: ToolExecutionContext) => Promise<TOutput>;
+}
+
+/**
+ * 도구를 선언적으로 정의한다. Strands SDK의 `@tool` 패턴을 TS-first로 구현.
+ *
+ * @example
+ * const readFile = defineTool({
+ *   name: 'read_file',
+ *   description: 'Reads a file from disk',
+ *   inputSchema: z.object({ path: z.string() }),
+ *   category: 'builtin',
+ *   execute: async ({ path }) => fs.readFileSync(path, 'utf-8'),
+ * });
+ */
+export function defineTool<TInput = unknown, TOutput = unknown>(
+  def: ToolDefinition<TInput, TOutput>,
+): ToolDefinition<TInput, TOutput> {
+  if (!def.name || def.name.trim() === "") {
+    throw new Error("Tool name is required");
+  }
+  if (!def.description || def.description.trim() === "") {
+    throw new Error("Tool description is required");
+  }
+  return def;
+}
+
+/** 도구의 inputSchema를 Anthropic API JSON Schema 포맷으로 변환 */
+export function toJsonSchema(zodSchema: z.ZodType): Record<string, unknown> {
+  // Zod의 shape에서 JSON Schema 추출 (object type만 지원)
+  if (zodSchema instanceof z.ZodObject) {
+    const shape = zodSchema.shape as Record<string, z.ZodType>;
+    const properties: Record<string, unknown> = {};
+    const required: string[] = [];
+
+    for (const [key, fieldSchema] of Object.entries(shape)) {
+      properties[key] = zodTypeToJsonSchema(fieldSchema);
+      if (!(fieldSchema instanceof z.ZodOptional)) {
+        required.push(key);
+      }
+    }
+
+    return {
+      type: "object",
+      properties,
+      required: required.length > 0 ? required : undefined,
+    };
+  }
+
+  return { type: "object", properties: {} };
+}
+
+function zodTypeToJsonSchema(schema: z.ZodType): Record<string, unknown> {
+  if (schema instanceof z.ZodString) return { type: "string" };
+  if (schema instanceof z.ZodNumber) return { type: "number" };
+  if (schema instanceof z.ZodBoolean) return { type: "boolean" };
+  if (schema instanceof z.ZodArray) {
+    return { type: "array", items: zodTypeToJsonSchema(schema.element) };
+  }
+  if (schema instanceof z.ZodOptional) {
+    return zodTypeToJsonSchema(schema.unwrap());
+  }
+  if (schema instanceof z.ZodObject) {
+    return toJsonSchema(schema);
+  }
+  return { type: "string" };
+}

--- a/packages/api/src/core/agent/runtime/index.ts
+++ b/packages/api/src/core/agent/runtime/index.ts
@@ -1,0 +1,7 @@
+// ─── F527: Agent Runtime (L2) — barrel export (Sprint 280) ───
+
+export { defineTool, toJsonSchema } from "./define-tool.js";
+export { ToolRegistry } from "./tool-registry.js";
+export { TokenTracker } from "./token-tracker.js";
+export { parseAgentSpec, validateAgentSpec } from "./agent-spec-loader.js";
+export { AgentRuntime } from "./agent-runtime.js";

--- a/packages/api/src/core/agent/runtime/token-tracker.ts
+++ b/packages/api/src/core/agent/runtime/token-tracker.ts
@@ -1,0 +1,79 @@
+// ─── F527: F-L2-5 TokenTracker (Sprint 280) ───
+
+import type { LLMTokenUsage, LLMTokenSummary } from "@foundry-x/shared";
+
+/** 에이전트별 토큰 사용량 추적. Deep Insight Prompt Cache 패턴 적용. */
+export class TokenTracker {
+  private usage = new Map<string, LLMTokenUsage>();
+
+  /**
+   * 특정 에이전트의 토큰 사용량을 누적한다.
+   * 같은 에이전트에 대해 여러 번 호출 시 합산됨.
+   */
+  track(agentId: string, usage: LLMTokenUsage): void {
+    const existing = this.usage.get(agentId) ?? {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    };
+
+    this.usage.set(agentId, {
+      inputTokens: existing.inputTokens + usage.inputTokens,
+      outputTokens: existing.outputTokens + usage.outputTokens,
+      cacheReadTokens: (existing.cacheReadTokens ?? 0) + (usage.cacheReadTokens ?? 0),
+      cacheWriteTokens: (existing.cacheWriteTokens ?? 0) + (usage.cacheWriteTokens ?? 0),
+    });
+  }
+
+  /** 특정 에이전트의 누적 사용량 반환. 없으면 0으로 초기화된 값 반환. */
+  getUsage(agentId: string): LLMTokenSummary {
+    const u = this.usage.get(agentId) ?? { inputTokens: 0, outputTokens: 0 };
+    return toSummary(u);
+  }
+
+  /** 모든 에이전트의 사용량 합산 */
+  total(): LLMTokenSummary {
+    let inputTokens = 0;
+    let outputTokens = 0;
+    let cacheReadTokens = 0;
+    let cacheWriteTokens = 0;
+
+    for (const u of this.usage.values()) {
+      inputTokens += u.inputTokens;
+      outputTokens += u.outputTokens;
+      cacheReadTokens += u.cacheReadTokens ?? 0;
+      cacheWriteTokens += u.cacheWriteTokens ?? 0;
+    }
+
+    return toSummary({ inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens });
+  }
+
+  /**
+   * 사용량 초기화.
+   * @param agentId — 지정 시 해당 에이전트만 초기화. 없으면 전체 초기화.
+   */
+  reset(agentId?: string): void {
+    if (agentId !== undefined) {
+      this.usage.delete(agentId);
+    } else {
+      this.usage.clear();
+    }
+  }
+
+  /** 추적 중인 에이전트 목록 */
+  agents(): string[] {
+    return Array.from(this.usage.keys());
+  }
+}
+
+function toSummary(u: LLMTokenUsage): LLMTokenSummary {
+  const totalTokens = u.inputTokens + u.outputTokens;
+  return {
+    inputTokens: u.inputTokens,
+    outputTokens: u.outputTokens,
+    cacheReadTokens: u.cacheReadTokens,
+    cacheWriteTokens: u.cacheWriteTokens,
+    totalTokens,
+  };
+}

--- a/packages/api/src/core/agent/runtime/tool-registry.ts
+++ b/packages/api/src/core/agent/runtime/tool-registry.ts
@@ -1,0 +1,64 @@
+// ─── F527: F-L2-6 ToolRegistry (Sprint 280) ───
+
+import type { ToolCategory, AnthropicToolDef } from "@foundry-x/shared";
+import type { ToolDefinition } from "./define-tool.js";
+import { toJsonSchema } from "./define-tool.js";
+
+/**
+ * 도구 등록/검색/카테고리화.
+ * Strands SDK의 ToolRegistry 패턴을 Foundry-X에 맞게 구현.
+ */
+export class ToolRegistry {
+  private tools = new Map<string, ToolDefinition>();
+
+  /** 도구를 레지스트리에 등록한다. 체이닝 지원. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  register(tool: ToolDefinition<any, any>): this {
+    this.tools.set(tool.name, tool);
+    return this;
+  }
+
+  /** 이름으로 도구를 조회한다. 없으면 undefined. */
+  get(name: string): ToolDefinition | undefined {
+    return this.tools.get(name);
+  }
+
+  /** 이름으로 존재 여부 확인 */
+  has(name: string): boolean {
+    return this.tools.has(name);
+  }
+
+  /**
+   * 등록된 도구 목록 반환.
+   * @param filter.category — 카테고리 필터 (없으면 전체)
+   */
+  list(filter?: { category?: ToolCategory }): ToolDefinition[] {
+    const all = Array.from(this.tools.values());
+    if (filter?.category) {
+      return all.filter((t) => t.category === filter.category);
+    }
+    return all;
+  }
+
+  /** Claude API 포맷(AnthropicToolDef[])으로 변환 */
+  toAnthropicTools(names?: string[]): AnthropicToolDef[] {
+    const tools = names
+      ? names.map((n) => this.tools.get(n)).filter((t): t is ToolDefinition => !!t)
+      : Array.from(this.tools.values());
+
+    return tools.map((t) => ({
+      name: t.name,
+      description: t.description,
+      input_schema: toJsonSchema(t.inputSchema),
+    }));
+  }
+
+  /** 레지스트리 초기화 */
+  clear(): void {
+    this.tools.clear();
+  }
+
+  get size(): number {
+    return this.tools.size;
+  }
+}

--- a/packages/api/src/core/agent/specs/architect.agent.yaml
+++ b/packages/api/src/core/agent/specs/architect.agent.yaml
@@ -1,0 +1,37 @@
+name: architect
+version: "1.0"
+model: claude-haiku-4-5-20251001
+systemPrompt: |
+  You are an ArchitectAgent for the Foundry-X platform.
+  Analyze code changes and evaluate architecture quality.
+
+  Evaluate against:
+  1. Module cohesion: Single, well-defined responsibility per module
+  2. Coupling: Minimal, well-abstracted inter-module dependencies
+  3. Design patterns: Correct usage, no anti-patterns
+  4. Scalability: Impact on system growth
+  5. SDD compliance: Spec-Driven Development triangle alignment
+
+  Respond with JSON only:
+  {
+    "impactSummary": "Brief architecture impact (1-3 sentences)",
+    "designScore": 0-100,
+    "dependencyAnalysis": { "new": [], "modified": [], "removed": [] },
+    "recommendations": ["Recommendation 1"]
+  }
+tools:
+  - read_file
+  - search_code
+  - list_files
+steering:
+  rules:
+    - Focus on architectural patterns over implementation details
+    - Score objectively based on SOLID principles
+constraints:
+  maxTokens: 8192
+  maxRounds: 3
+  timeoutMs: 30000
+metadata:
+  f_item: F527
+  migrated_from: architect-agent.ts + architect-prompts.ts
+  sprint: 280

--- a/packages/api/src/core/agent/specs/infra.agent.yaml
+++ b/packages/api/src/core/agent/specs/infra.agent.yaml
@@ -1,0 +1,39 @@
+name: infra
+version: "1.0"
+model: claude-haiku-4-5-20251001
+systemPrompt: |
+  You are an InfraAgent for the Foundry-X platform on Cloudflare.
+  Analyze infrastructure configuration for health, resource usage, and optimization.
+
+  Evaluate:
+  1. Workers configuration: routes, bindings, limits, compatibility flags
+  2. D1 migrations: schema correctness, index strategy, migration order
+  3. KV namespaces: TTL settings, data size limits, cache patterns
+  4. Pages configuration: build settings, redirects, headers
+  5. Wrangler configuration: environment consistency, secret usage, custom domains
+
+  Respond with JSON:
+  {
+    "infraScore": 0-100,
+    "issues": [
+      { "resource": "Workers|D1|KV|Pages|Wrangler", "severity": "critical|high|medium|low", "description": "Issue", "recommendation": "Fix" }
+    ],
+    "optimizations": ["Optimization opportunity"],
+    "summary": "Overall infra health assessment"
+  }
+tools:
+  - read_file
+  - list_files
+steering:
+  rules:
+    - Check for drift between local config and deployed state
+    - Always verify D1 migration numbering for conflicts
+    - Flag any hardcoded credentials or API keys
+constraints:
+  maxTokens: 8192
+  maxRounds: 3
+  timeoutMs: 30000
+metadata:
+  f_item: F527
+  migrated_from: infra-agent.ts + infra-agent-prompts.ts
+  sprint: 280

--- a/packages/api/src/core/agent/specs/planner.agent.yaml
+++ b/packages/api/src/core/agent/specs/planner.agent.yaml
@@ -1,0 +1,37 @@
+name: planner
+version: "1.0"
+model: claude-haiku-4-5-20251001
+systemPrompt: |
+  You are a PlannerAgent for the Foundry-X project.
+  Analyze the provided code context and create a detailed execution plan.
+
+  Respond with valid JSON:
+  {
+    "codebaseAnalysis": "2-3 sentence analysis",
+    "proposedSteps": [
+      { "description": "Step", "type": "create|modify|delete|test", "targetFile": "path.ts", "estimatedLines": 20 }
+    ],
+    "risks": ["Risk description"],
+    "estimatedTokens": 5000
+  }
+
+  Guidelines:
+  - Break tasks into atomic, ordered steps (max 1-2 files per step)
+  - Identify risks: dependency changes, breaking changes, test coverage gaps
+  - Respond in Korean for analysis text, English for technical terms
+tools:
+  - read_file
+  - search_code
+  - list_files
+steering:
+  rules:
+    - Always validate JSON schema before returning
+    - Korean for analysis, English for code/technical terms
+constraints:
+  maxTokens: 8192
+  maxRounds: 3
+  timeoutMs: 30000
+metadata:
+  f_item: F527
+  migrated_from: planner-agent.ts + planner-prompts.ts
+  sprint: 280

--- a/packages/api/src/core/agent/specs/qa.agent.yaml
+++ b/packages/api/src/core/agent/specs/qa.agent.yaml
@@ -1,0 +1,41 @@
+name: qa
+version: "1.0"
+model: claude-haiku-4-5-20251001
+systemPrompt: |
+  You are a QAAgent for the Foundry-X platform.
+  Generate Playwright browser test scenarios and validate acceptance criteria.
+
+  For each scenario:
+  1. Define test steps with selectors and expected outcomes
+  2. Cover happy path + error states + edge cases
+  3. Use data-testid attributes for selectors (prefer over CSS classes)
+  4. Assert functional behavior (not just visual presence)
+
+  Respond with JSON:
+  {
+    "testScenarios": [
+      {
+        "name": "Scenario name",
+        "steps": ["Step 1: Navigate to /route", "Step 2: Click #button"],
+        "assertions": ["Assert: element visible", "Assert: API called with params"],
+        "priority": "critical|high|medium|low"
+      }
+    ],
+    "coverageGaps": ["Feature not covered by scenarios"]
+  }
+tools:
+  - read_file
+  - search_code
+  - list_files
+steering:
+  rules:
+    - Focus on user-observable behavior, not implementation details
+    - Each scenario should be independently executable
+constraints:
+  maxTokens: 8192
+  maxRounds: 3
+  timeoutMs: 30000
+metadata:
+  f_item: F527
+  migrated_from: qa-agent.ts + qa-agent-prompts.ts
+  sprint: 280

--- a/packages/api/src/core/agent/specs/reviewer.agent.yaml
+++ b/packages/api/src/core/agent/specs/reviewer.agent.yaml
@@ -1,0 +1,37 @@
+name: reviewer
+version: "1.0"
+model: claude-haiku-4-5-20251001
+systemPrompt: |
+  You are a ReviewerAgent for the Foundry-X platform.
+  Perform thorough code review focusing on correctness, maintainability, and security.
+
+  Review criteria:
+  1. Correctness: Logic errors, edge cases, null/undefined handling
+  2. TypeScript: Type safety, strict mode compliance, no `any` types
+  3. Security: Input validation, injection risks, sensitive data handling
+  4. Performance: Unnecessary loops, blocking calls, memory leaks
+  5. Conventions: Naming, file structure, comment quality
+
+  Respond with JSON:
+  {
+    "overallScore": 0-100,
+    "reviewComments": [
+      { "file": "path.ts", "line": 10, "comment": "Issue", "severity": "error|warning|info" }
+    ],
+    "summary": "Overall assessment"
+  }
+tools:
+  - read_file
+  - search_code
+steering:
+  rules:
+    - Report only real issues, not stylistic preferences
+    - severity=error for bugs, warning for potential issues, info for suggestions
+constraints:
+  maxTokens: 8192
+  maxRounds: 3
+  timeoutMs: 30000
+metadata:
+  f_item: F527
+  migrated_from: reviewer-agent.ts
+  sprint: 280

--- a/packages/api/src/core/agent/specs/security.agent.yaml
+++ b/packages/api/src/core/agent/specs/security.agent.yaml
@@ -1,0 +1,41 @@
+name: security
+version: "1.0"
+model: claude-haiku-4-5-20251001
+systemPrompt: |
+  You are a SecurityAgent for the Foundry-X platform.
+  Scan source code for OWASP Top 10 vulnerabilities and security anti-patterns.
+
+  Check for:
+  1. Injection (SQL, NoSQL, OS command, LDAP)
+  2. XSS (reflected, stored, DOM-based)
+  3. Broken Authentication (weak passwords, session fixation, credential exposure)
+  4. Sensitive Data Exposure (plaintext secrets, weak encryption)
+  5. Broken Access Control (missing authorization, IDOR, privilege escalation)
+  6. Security Misconfiguration (default configs, verbose errors, missing headers)
+  7. Insecure Dependencies (known CVEs, outdated packages)
+  8. Insufficient Logging (missing audit trails for sensitive actions)
+
+  Respond with JSON:
+  {
+    "securityScore": 0-100,
+    "vulnerabilities": [
+      { "type": "OWASP category", "severity": "critical|high|medium|low", "location": "file:line", "description": "Issue", "recommendation": "Fix" }
+    ],
+    "summary": "Overall security assessment"
+  }
+tools:
+  - read_file
+  - search_code
+steering:
+  rules:
+    - Never report false positives without clear evidence
+    - Distinguish between severity levels accurately
+    - critical = exploitable in current form, high = likely exploitable
+constraints:
+  maxTokens: 8192
+  maxRounds: 3
+  timeoutMs: 30000
+metadata:
+  f_item: F527
+  migrated_from: security-agent.ts + security-agent-prompts.ts
+  sprint: 280

--- a/packages/api/src/core/agent/specs/test.agent.yaml
+++ b/packages/api/src/core/agent/specs/test.agent.yaml
@@ -1,0 +1,36 @@
+name: test
+version: "1.0"
+model: claude-haiku-4-5-20251001
+systemPrompt: |
+  You are a TestAgent for the Foundry-X platform.
+  Generate comprehensive vitest test code for given source files.
+
+  Project conventions:
+  - Framework: vitest 3.x with TypeScript
+  - Pattern: describe() > it() blocks with clear naming
+  - Hono API tests: app.request() (not supertest)
+  - D1 mock: in-memory better-sqlite3
+  - Ink CLI tests: ink-testing-library render() + lastFrame()
+
+  Respond with JSON:
+  {
+    "testCode": "import { describe, it, expect } from 'vitest';\n...",
+    "coverageTargets": ["path/to/file.ts"],
+    "edgeCases": ["Edge case description"]
+  }
+tools:
+  - read_file
+  - search_code
+steering:
+  rules:
+    - Generate failing tests first (TDD Red phase)
+    - Cover happy path AND error cases
+    - Use factory functions (make*()) for test data
+constraints:
+  maxTokens: 8192
+  maxRounds: 3
+  timeoutMs: 30000
+metadata:
+  f_item: F527
+  migrated_from: test-agent.ts + test-agent-prompts.ts
+  sprint: 280

--- a/packages/shared/src/agent-runtime.ts
+++ b/packages/shared/src/agent-runtime.ts
@@ -1,0 +1,121 @@
+// ─── F527: Agent Runtime (L2) 공유 타입 (Sprint 280) ───
+// 주의: Zod 의존 없음 — 순수 TS 타입만. ToolDefinition은 API 패키지에 있음.
+
+export type ToolCategory = "builtin" | "mcp" | "agent" | "custom";
+
+// F-L2-2: AgentSpec YAML 스키마
+export interface AgentSpec {
+  name: string;
+  version?: string;
+  model: string;
+  systemPrompt: string;
+  tools: string[];
+  steering?: {
+    rules: string[];
+  };
+  evaluation?: {
+    criteria: string[];
+    minScore?: number;
+  };
+  constraints?: {
+    maxTokens?: number;
+    maxRounds?: number;
+    timeoutMs?: number;
+  };
+  metadata?: Record<string, unknown>;
+}
+
+// F-L2-5: LLM 호출별 토큰 사용량 (Anthropic API 응답 포맷)
+export interface LLMTokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+}
+
+export interface LLMTokenSummary extends LLMTokenUsage {
+  totalTokens: number;
+  estimatedCostUsd?: number;
+}
+
+// F-L2-4: 훅 타입
+export interface AgentHooks {
+  beforeInvocation?: (ctx: InvocationContext) => Promise<void>;
+  afterInvocation?: (ctx: InvocationContext, result: RuntimeResult) => Promise<void>;
+  beforeModel?: (ctx: ModelCallContext) => Promise<ModelCallContext | void>;
+  afterModel?: (ctx: ModelCallContext, result: ModelCallResult) => Promise<void>;
+  beforeTool?: (ctx: ToolCallContext) => Promise<ToolCallContext | "cancel" | void>;
+  afterTool?: (ctx: ToolCallContext, result: ToolCallResult) => Promise<ToolCallResult | void>;
+}
+
+// F-L2-3: 런타임 컨텍스트
+export interface RuntimeContext {
+  agentId: string;
+  sessionId: string;
+  apiKey: string;
+  db?: unknown;
+  hooks?: AgentHooks;
+}
+
+export type StopReason = "end_turn" | "tool_use" | "max_tokens" | "cancelled" | "max_rounds";
+
+export interface RuntimeResult {
+  output: string;
+  stopReason: StopReason;
+  rounds: number;
+  tokenUsage: LLMTokenSummary;
+}
+
+// 훅 컨텍스트 타입
+export interface InvocationContext {
+  agentId: string;
+  sessionId: string;
+  spec: AgentSpec;
+  input: string;
+}
+
+export interface ModelCallContext {
+  messages: AnthropicMessage[];
+  systemPrompt: string;
+  model: string;
+  tools?: AnthropicToolDef[];
+}
+
+export interface ModelCallResult {
+  content: AnthropicContent[];
+  stopReason: string;
+  usage: LLMTokenUsage;
+}
+
+export interface ToolCallContext {
+  toolName: string;
+  toolInput: unknown;
+  toolUseId: string;
+}
+
+export interface ToolCallResult {
+  content: string;
+  isError?: boolean;
+}
+
+export interface AnthropicMessage {
+  role: "user" | "assistant";
+  content: string | AnthropicContent[];
+}
+
+export interface AnthropicContent {
+  type: "text" | "tool_use" | "tool_result";
+  text?: string;
+  id?: string;
+  name?: string;
+  input?: unknown;
+  tool_use_id?: string;
+  content?: string;
+  is_error?: boolean;
+}
+
+export interface AnthropicToolDef {
+  name: string;
+  description: string;
+  input_schema: Record<string, unknown>;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -448,3 +448,22 @@ export type {
 export { D1EventBus } from './events/index.js';
 // F406: 이벤트 유실 복구 타입 (Sprint 191)
 export type { D1LikeDatabase, EventHandler, EventStatusSummary } from './events/index.js';
+// F527: Agent Runtime (L2) 타입 (Sprint 280)
+export type {
+  ToolCategory,
+  AgentSpec,
+  AgentHooks,
+  RuntimeContext,
+  StopReason,
+  RuntimeResult,
+  LLMTokenUsage,
+  LLMTokenSummary,
+  InvocationContext,
+  ModelCallContext,
+  ModelCallResult,
+  ToolCallContext,
+  ToolCallResult,
+  AnthropicMessage,
+  AnthropicContent,
+  AnthropicToolDef,
+} from './agent-runtime.js';


### PR DESCRIPTION
## Summary

Sprint 280 / F527 — HyperFX Agent Stack Layer 2 (Agent Runtime) 구현

- **F-L2-1** `defineTool()` — Strands SDK `@tool` 패턴의 TS-first 도구 정의 유틸리티
- **F-L2-2** `AgentSpec` YAML 스키마 + 경량 인라인 파서 (Workers 호환, 외부 deps 없음)
- **F-L2-3** `AgentRuntime` — 추론→도구→결과→반복 루프 엔진 (Claude tool_use 처리)
- **F-L2-4** Hooks — `before/afterInvocation/Model/Tool` 라이프사이클 이벤트
- **F-L2-5** `TokenTracker` — 에이전트별 LLM 토큰 사용량 누적 추적
- **F-L2-6** `ToolRegistry` — 도구 등록/검색/카테고리화, Anthropic API 포맷 변환
- **F-L2-7** 7개 에이전트 YAML 마이그레이션 (planner/architect/reviewer/test/security/qa/infra)

## Test Results

- TDD Red→Green: **20/20 PASS** (agent-runtime.test.ts)
- Gap Analysis Match Rate: **97%** (≥90% 기준 통과)
- Typecheck: PASS (runtime 파일 0 errors)

## Architecture Notes

- `AgentRuntime`은 기존 `ClaudeApiRunner`/`OrchestrationLoop`와 독립적 — F528(L3)에서 Graph 노드로 래핑 예정
- `shared` 패키지에서 Zod/Cloudflare 의존 완전 제거 (`ToolDefinition`은 API 패키지에만)
- YAML 파서는 인라인 구현 (Workers runtime 호환, `yaml` npm 패키지 불필요)

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>