### PR TITLE
feat(cli): Sprint 279 — F526 autopilot Verify E2E 통합

### DIFF
--- a/docs/01-plan/features/sprint-279.plan.md
+++ b/docs/01-plan/features/sprint-279.plan.md
@@ -1,0 +1,45 @@
+---
+id: FX-PLAN-279
+title: Sprint 279 Plan — F526 autopilot Verify E2E 통합
+sprint: 279
+status: done
+date: 2026-04-13
+req: FX-REQ-554
+---
+
+# Sprint 279 Plan — F526
+
+## 목표
+
+Sprint autopilot의 Step 5~6(Verify/Report)에 E2E 자동 생성 + 실행 + Composite Score 산출을 통합한다.
+F524(e2e-extractor), F525(gap-scorer)를 오케스트레이션하는 파이프라인 레이어를 구현한다.
+
+## 범위 (F526 M3)
+
+| # | 산출물 | 설명 |
+|---|--------|------|
+| 1 | `e2e-runner.ts` | Design doc → 생성 → 실행 → Composite Score 파이프라인 서비스 |
+| 2 | `e2e-verify` CLI command | `foundry-x e2e-verify <N> --gap-rate <R>` |
+| 3 | `index.ts` 등록 | 기존 CLI에 커맨드 추가 |
+| 4 | sprint-autopilot SKILL.md | Step 5b를 F526 통합 버전으로 교체 |
+
+## 제외
+
+- E2E flaky 관리 자동화 (PRD S1/S2 — 별도 Sprint)
+- 크로스 서비스 E2E (Out of Scope)
+
+## Sprint 배정
+
+- Sprint: 279
+- Branch: `sprint/279`
+- Worktree: `~/work/worktrees/Foundry-X/sprint-279`
+
+## TDD 계획
+
+- `e2e-runner.test.ts` — 6개 시나리오 (Red → Green)
+  - Design doc 없음 → error VerifyResult
+  - Playwright 전체 PASS → Composite 97%
+  - Playwright 일부 FAIL → Composite < 90
+  - Playwright 실행 불가 → Gap fallback
+  - spec 파일 경로 반환 확인
+  - 시나리오 수 반영 확인

--- a/docs/02-design/features/sprint-279.design.md
+++ b/docs/02-design/features/sprint-279.design.md
@@ -1,0 +1,104 @@
+---
+id: FX-DESIGN-279
+title: Sprint 279 Design — F526 autopilot Verify E2E 통합
+sprint: 279
+status: done
+date: 2026-04-13
+req: FX-REQ-554
+---
+
+# Sprint 279 Design — F526
+
+## §1 요약
+
+Design 문서에서 E2E 시나리오를 자동 추출하고(F524), Playwright로 실행하고, Gap Analysis 결과와 합산하여(F525) Composite Score를 산출하는 파이프라인 레이어(e2e-runner.ts)를 구현한다. CLI 커맨드로 노출하고, sprint-autopilot Step 5b에 통합한다.
+
+## §2 아키텍처
+
+```
+sprint-autopilot Step 5b
+        │
+        ▼
+foundry-x e2e-verify <N> --gap-rate <R>
+        │
+        ├─ runE2EVerify(VerifyInput)
+        │       │
+        │       ├─ parseDesignDocument(docContent)        ← F524
+        │       ├─ generateE2ESpec(scenarios, sprintNum)  ← F524
+        │       ├─ fs.writeFileSync(generatedSpecPath)
+        │       ├─ cp.spawnSync(playwright test --reporter=json)
+        │       ├─ parsePlaywrightJson(stdout)
+        │       └─ computeCompositeScore({gapRate, e2eResults})  ← F525
+        │
+        └─ VerifyResult → stdout JSON / 사람 읽기 포맷
+```
+
+## §3 데이터 모델
+
+```typescript
+// 입력
+interface VerifyInput {
+  sprintNum: number;
+  gapRate: number;       // Step 5에서 산출한 Gap Match Rate
+  projectRoot: string;   // 프로젝트 루트 (default: cwd)
+}
+
+// 출력
+interface VerifyResult {
+  sprintNum: number;
+  designDocPath: string;      // docs/02-design/features/sprint-N.design.md
+  generatedSpecPath: string;  // packages/web/e2e/generated/sprint-N.spec.ts
+  scenarioCount: number;
+  e2eResult: E2EResult | null;  // null = Playwright 실행 불가
+  gapRate: number;
+  compositeScore: CompositeScore;  // F525
+  error?: string;
+}
+```
+
+## §4 기능 명세
+
+| # | 기능 | 설명 |
+|---|------|------|
+| 1 | Design doc 파싱 | §4+§5에서 시나리오 추출 (F524 위임) |
+| 2 | spec 생성 | `packages/web/e2e/generated/sprint-N.spec.ts` 자동 작성 |
+| 3 | Playwright 실행 | `npx playwright test <spec> --reporter=json` (spawnSync) |
+| 4 | JSON 파싱 | `stats.expected`=pass, `stats.unexpected`=fail |
+| 5 | Composite 계산 | F525 `computeCompositeScore` 위임 (Gap×0.6 + E2E×0.4) |
+| 6 | Fallback | Playwright 미설치/오류 시 E2E null → Gap만으로 Composite |
+| 7 | Error 처리 | Design doc 없으면 즉시 FAIL VerifyResult 반환 |
+
+## §5 파일 매핑
+
+| 파일 | 역할 | 변경 |
+|------|------|------|
+| `packages/cli/src/services/e2e-runner.ts` | 파이프라인 서비스 | 신규 |
+| `packages/cli/src/services/e2e-runner.test.ts` | TDD 6개 시나리오 | 신규 |
+| `packages/cli/src/commands/e2e-verify.ts` | CLI 커맨드 | 신규 |
+| `packages/cli/src/index.ts` | CLI 진입점 | 수정 (커맨드 등록) |
+| `~/.claude/plugins/.../sprint-autopilot/SKILL.md` | Step 5b 통합 | 수정 |
+
+## §6 TDD 계약
+
+| 시나리오 | 입력 | 기대 출력 |
+|----------|------|-----------|
+| Design doc 없음 | `existsSync=false` | `error` 포함, `status=FAIL` |
+| Playwright 전체 PASS | 3 expected, 0 unexpected | Composite ≈ 97% (gapRate=95) |
+| Playwright 일부 FAIL | 2 expected, 1 unexpected | Composite < 90, status=FAIL |
+| Playwright 실행 불가 | spawnSync signal=SIGTERM | e2eResult=null, Composite=gapRate |
+| spec 경로 반환 | 정상 실행 | `generatedSpecPath` contains `sprint-279.spec.ts` |
+| 시나리오 수 | 정상 실행 | `scenarioCount >= 1` |
+
+## §7 sprint-autopilot Step 5b 변경 요약
+
+- **변경 전**: `/ax:e2e-audit coverage` 실행 (커버리지 감지만, E2E 생성 없음)
+- **변경 후**: `foundry-x e2e-verify ${SPRINT_NUM} --gap-rate ${MATCH_RATE} --json`
+  - Design doc에서 E2E 자동 생성 + 실행
+  - Composite Score를 `.sprint-context`의 `MATCH_RATE`에 덮어씀
+  - PASS/FAIL 판정을 Report에 전달
+
+## §8 갭/의도적 제외
+
+- **Playwright 미설치**: CLI fallback으로 Gap Score만 사용 — 로컬 환경 다양성 고려
+- **E2E 실패 시 자동 수정 없음**: E2E 실패는 도메인 판단이 필요한 영역 (PRD §4.3)
+- **크로스 서비스 E2E**: Out of Scope (PRD §4.3)

--- a/packages/cli/src/commands/e2e-verify.ts
+++ b/packages/cli/src/commands/e2e-verify.ts
@@ -1,0 +1,59 @@
+// F526: foundry-x e2e-verify <sprintNum> [--gap-rate <N>]
+// Sprint autopilot Step 5~6용 E2E Verify 파이프라인 CLI 진입점
+
+import { Command } from 'commander';
+import path from 'node:path';
+import { runE2EVerify } from '../services/e2e-runner.js';
+
+export function e2eVerifyCommand(): Command {
+  return new Command('e2e-verify')
+    .description('Design 문서에서 E2E를 자동 생성하고 실행하여 Composite Score를 산출한다')
+    .argument('<sprintNum>', 'Sprint 번호 (예: 279)', parseInt)
+    .option('--gap-rate <number>', 'Gap Analysis Match Rate (0~100)', parseFloat, 95)
+    .option('--project-root <path>', '프로젝트 루트 경로', process.cwd())
+    .option('--json', 'JSON 형식으로 결과 출력')
+    .action(async (sprintNum: number, options: { gapRate: number; projectRoot: string; json: boolean }) => {
+      const projectRoot = path.resolve(options.projectRoot);
+
+      if (!options.json) {
+        console.log(`\n🔍 F526 E2E Verify — Sprint ${sprintNum}`);
+        console.log(`   Project: ${projectRoot}`);
+        console.log(`   Gap Rate: ${options.gapRate}%\n`);
+      }
+
+      const result = await runE2EVerify({
+        sprintNum,
+        gapRate: options.gapRate,
+        projectRoot,
+      });
+
+      if (options.json) {
+        console.log(JSON.stringify(result, null, 2));
+        process.exit(result.compositeScore.status === 'PASS' ? 0 : 1);
+        return;
+      }
+
+      // 사람이 읽을 수 있는 출력
+      if (result.error) {
+        console.error(`❌ Error: ${result.error}`);
+      } else {
+        console.log(`📄 Design doc : ${result.designDocPath}`);
+        console.log(`📝 Generated  : ${result.generatedSpecPath}`);
+        console.log(`🧪 Scenarios  : ${result.scenarioCount}`);
+        if (result.e2eResult) {
+          const { pass, fail, skip } = result.e2eResult;
+          console.log(`✅ E2E PASS   : ${pass} / FAIL: ${fail} / SKIP: ${skip}`);
+        } else {
+          console.log(`⚠️  E2E        : 실행 불가 (playwright 미설치 또는 오류)`);
+        }
+      }
+
+      const score = result.compositeScore;
+      console.log(`\n📊 Score`);
+      console.log(`   Formula  : ${score.formula}`);
+      console.log(`   Composite: ${score.compositeRate.toFixed(1)}%`);
+      console.log(`   Status   : ${score.status === 'PASS' ? '✅ PASS' : '❌ FAIL'}\n`);
+
+      process.exit(score.status === 'PASS' ? 0 : 1);
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,6 +3,7 @@ import { Command } from 'commander';
 import { initCommand } from './commands/init.js';
 import { syncCommand } from './commands/sync.js';
 import { statusCommand } from './commands/status.js';
+import { e2eVerifyCommand } from './commands/e2e-verify.js';
 
 const program = new Command();
 
@@ -14,5 +15,6 @@ program
 program.addCommand(initCommand());
 program.addCommand(syncCommand());
 program.addCommand(statusCommand());
+program.addCommand(e2eVerifyCommand());
 
 program.parse();

--- a/packages/cli/src/services/e2e-runner.test.ts
+++ b/packages/cli/src/services/e2e-runner.test.ts
@@ -1,0 +1,197 @@
+// F526: autopilot Verify E2E 통합 — e2e-runner.ts TDD Red
+// Design 문서 → E2E 생성 → Playwright 실행 → Composite Score 산출 파이프라인
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { VerifyResult } from './e2e-runner.js';
+
+vi.mock('node:fs', () => ({
+  default: {
+    readFileSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    mkdirSync: vi.fn(),
+    existsSync: vi.fn(),
+  },
+}));
+
+vi.mock('node:child_process', () => ({
+  default: {
+    spawnSync: vi.fn(),
+  },
+}));
+
+// --- 테스트용 픽스처 ---
+const SAMPLE_DESIGN_DOC = `
+# Sprint 279 Design
+
+## 4 기능 명세
+
+| # | 기능 | 설명 | 우선순위 |
+|---|------|------|----------|
+| 1 | E2E Verify 통합 | autopilot Step 5~6에 E2E 삽입 | P0 |
+
+## 5 파일 매핑
+
+| 파일 | 역할 |
+|------|------|
+| \`src/routes/dashboard.tsx\` | 대시보드 UI |
+| \`src/routes/sprint/index.tsx\` | Sprint 목록 |
+`;
+
+const PLAYWRIGHT_JSON_PASS = JSON.stringify({
+  suites: [],
+  stats: { expected: 3, skipped: 0, unexpected: 0, flaky: 0, duration: 1500 },
+});
+
+const PLAYWRIGHT_JSON_PARTIAL_FAIL = JSON.stringify({
+  suites: [],
+  stats: { expected: 2, skipped: 0, unexpected: 1, flaky: 0, duration: 2000 },
+});
+
+describe('F526: e2e-runner — E2E Verify 파이프라인', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('runE2EVerify', () => {
+    it('디자인 문서가 없으면 error를 포함한 VerifyResult를 반환한다', async () => {
+      const { default: fs } = await import('node:fs');
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      const { runE2EVerify } = await import('./e2e-runner.js');
+      const result = await runE2EVerify({ sprintNum: 279, gapRate: 95, projectRoot: '/repo' });
+
+      expect(result.error).toMatch(/design.*not found/i);
+      expect(result.compositeScore.status).toBe('FAIL');
+    });
+
+    it('Playwright 전체 PASS 시 Composite = Gap×0.6 + 100×0.4', async () => {
+      const { default: fs } = await import('node:fs');
+      const { default: cp } = await import('node:child_process');
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(SAMPLE_DESIGN_DOC);
+      vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
+      vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
+      vi.mocked(cp.spawnSync).mockReturnValue({
+        status: 0,
+        stdout: Buffer.from(PLAYWRIGHT_JSON_PASS),
+        stderr: Buffer.from(''),
+        pid: 1,
+        output: [],
+        signal: null,
+      });
+
+      const { runE2EVerify } = await import('./e2e-runner.js');
+      const result = await runE2EVerify({ sprintNum: 279, gapRate: 95, projectRoot: '/repo' });
+
+      expect(result.error).toBeUndefined();
+      expect(result.e2eResult).not.toBeNull();
+      expect(result.e2eResult?.pass).toBe(3);
+      expect(result.e2eResult?.fail).toBe(0);
+      // Composite = 95×0.6 + 100×0.4 = 57 + 40 = 97
+      expect(result.compositeScore.compositeRate).toBeCloseTo(97, 1);
+      expect(result.compositeScore.status).toBe('PASS');
+    });
+
+    it('Playwright 일부 실패 시 Composite 점수가 낮아진다', async () => {
+      const { default: fs } = await import('node:fs');
+      const { default: cp } = await import('node:child_process');
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(SAMPLE_DESIGN_DOC);
+      vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
+      vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
+      vi.mocked(cp.spawnSync).mockReturnValue({
+        status: 1,
+        stdout: Buffer.from(PLAYWRIGHT_JSON_PARTIAL_FAIL),
+        stderr: Buffer.from(''),
+        pid: 1,
+        output: [],
+        signal: null,
+      });
+
+      const { runE2EVerify } = await import('./e2e-runner.js');
+      const result = await runE2EVerify({ sprintNum: 279, gapRate: 95, projectRoot: '/repo' });
+
+      // E2E: 2pass / 3total = 66.7%
+      // Composite = 95×0.6 + 66.7×0.4 = 57 + 26.7 = 83.7 → FAIL
+      expect(result.compositeScore.status).toBe('FAIL');
+      expect(result.compositeScore.compositeRate).toBeLessThan(90);
+    });
+
+    it('Playwright 실행 실패(spawnSync 오류) 시 Gap만으로 Composite를 계산한다', async () => {
+      const { default: fs } = await import('node:fs');
+      const { default: cp } = await import('node:child_process');
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(SAMPLE_DESIGN_DOC);
+      vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
+      vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
+      vi.mocked(cp.spawnSync).mockReturnValue({
+        status: null,
+        stdout: Buffer.from(''),
+        stderr: Buffer.from('playwright not found'),
+        pid: 0,
+        output: [],
+        signal: 'SIGTERM',
+      });
+
+      const { runE2EVerify } = await import('./e2e-runner.js');
+      const result = await runE2EVerify({ sprintNum: 279, gapRate: 92, projectRoot: '/repo' });
+
+      expect(result.e2eResult).toBeNull();
+      // Gap만으로: Composite = 92
+      expect(result.compositeScore.compositeRate).toBe(92);
+      expect(result.compositeScore.status).toBe('PASS');
+    });
+
+    it('생성된 spec 파일 경로가 VerifyResult에 포함된다', async () => {
+      const { default: fs } = await import('node:fs');
+      const { default: cp } = await import('node:child_process');
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(SAMPLE_DESIGN_DOC);
+      vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
+      vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
+      vi.mocked(cp.spawnSync).mockReturnValue({
+        status: 0,
+        stdout: Buffer.from(PLAYWRIGHT_JSON_PASS),
+        stderr: Buffer.from(''),
+        pid: 1,
+        output: [],
+        signal: null,
+      });
+
+      const { runE2EVerify } = await import('./e2e-runner.js');
+      const result = await runE2EVerify({ sprintNum: 279, gapRate: 95, projectRoot: '/repo' });
+
+      expect(result.generatedSpecPath).toContain('sprint-279.spec.ts');
+      expect(result.sprintNum).toBe(279);
+    });
+
+    it('디자인 문서에서 추출된 시나리오 수가 VerifyResult에 반영된다', async () => {
+      const { default: fs } = await import('node:fs');
+      const { default: cp } = await import('node:child_process');
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(SAMPLE_DESIGN_DOC);
+      vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
+      vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
+      vi.mocked(cp.spawnSync).mockReturnValue({
+        status: 0,
+        stdout: Buffer.from(PLAYWRIGHT_JSON_PASS),
+        stderr: Buffer.from(''),
+        pid: 1,
+        output: [],
+        signal: null,
+      });
+
+      const { runE2EVerify } = await import('./e2e-runner.js');
+      const result = await runE2EVerify({ sprintNum: 279, gapRate: 95, projectRoot: '/repo' });
+
+      // SAMPLE_DESIGN_DOC에 route 파일 2개(§5) + 기능 1개(§4)
+      // smoke 포함하면 scenarioCount >= 1
+      expect(result.scenarioCount).toBeGreaterThan(0);
+    });
+  });
+});

--- a/packages/cli/src/services/e2e-runner.ts
+++ b/packages/cli/src/services/e2e-runner.ts
@@ -1,0 +1,125 @@
+// F526: autopilot Verify E2E 통합
+// Design 문서 → E2E 생성 → Playwright 실행 → Composite Score 산출 파이프라인
+
+import fs from 'node:fs';
+import path from 'node:path';
+import cp from 'node:child_process';
+import { parseDesignDocument, generateE2ESpec } from './e2e-extractor.js';
+import { computeCompositeScore, type E2EResult, type CompositeScore } from './gap-scorer.js';
+
+export interface VerifyInput {
+  sprintNum: number;
+  gapRate: number;
+  projectRoot: string;
+}
+
+export interface VerifyResult {
+  sprintNum: number;
+  designDocPath: string;
+  generatedSpecPath: string;
+  scenarioCount: number;
+  e2eResult: E2EResult | null;
+  gapRate: number;
+  compositeScore: CompositeScore;
+  error?: string;
+}
+
+function resolveDesignDocPath(projectRoot: string, sprintNum: number): string {
+  return path.join(projectRoot, 'docs', '02-design', 'features', `sprint-${sprintNum}.design.md`);
+}
+
+function parsePlaywrightJson(stdout: Buffer | null): E2EResult | null {
+  if (!stdout) return null;
+  const raw = stdout.toString('utf8').trim();
+  if (!raw) return null;
+
+  try {
+    const json = JSON.parse(raw) as {
+      stats?: { expected?: number; unexpected?: number; skipped?: number };
+    };
+    const stats = json.stats ?? {};
+    const pass = stats.expected ?? 0;
+    const fail = stats.unexpected ?? 0;
+    const skip = stats.skipped ?? 0;
+    return { specFile: '', total: pass + fail + skip, pass, fail, skip };
+  } catch {
+    return null;
+  }
+}
+
+function runPlaywright(specFilePath: string, webPackageDir: string): E2EResult | null {
+  const relativeSpec = path.relative(webPackageDir, specFilePath);
+  const result = cp.spawnSync(
+    'npx',
+    ['playwright', 'test', relativeSpec, '--reporter=json'],
+    {
+      cwd: webPackageDir,
+      encoding: 'buffer',
+      timeout: 120_000,
+    }
+  );
+
+  // status=null은 시그널로 종료된 경우 (playwright 미설치 등)
+  // stdout이 없거나 비어있으면 E2E 실행 불가로 처리
+  if (result.status === null && (!result.stdout || result.stdout.length === 0)) return null;
+
+  return parsePlaywrightJson(result.stdout);
+}
+
+export async function runE2EVerify(input: VerifyInput): Promise<VerifyResult> {
+  const { sprintNum, gapRate, projectRoot } = input;
+  const designDocPath = resolveDesignDocPath(projectRoot, sprintNum);
+
+  const failResult = (error: string): VerifyResult => ({
+    sprintNum,
+    designDocPath,
+    generatedSpecPath: '',
+    scenarioCount: 0,
+    e2eResult: null,
+    gapRate,
+    compositeScore: {
+      gapRate,
+      e2ePassRate: null,
+      compositeRate: 0,
+      formula: `Error: ${error}`,
+      status: 'FAIL',
+    },
+    error,
+  });
+
+  // 1. Design 문서 존재 확인
+  if (!fs.existsSync(designDocPath)) {
+    return failResult(`Design doc not found: ${designDocPath}`);
+  }
+
+  // 2. Design 문서 파싱 → E2E 시나리오 추출
+  const docContent = fs.readFileSync(designDocPath, 'utf8');
+  const { scenarios } = parseDesignDocument(docContent);
+  const { filePath: relativeSpecPath, scenarioCount, content } = generateE2ESpec(scenarios, sprintNum);
+
+  // 3. spec 파일 작성
+  const generatedSpecPath = path.join(projectRoot, relativeSpecPath);
+  const specDir = path.dirname(generatedSpecPath);
+  fs.mkdirSync(specDir, { recursive: true });
+  fs.writeFileSync(generatedSpecPath, content, 'utf8');
+
+  // 4. Playwright 실행
+  const webPackageDir = path.join(projectRoot, 'packages', 'web');
+  const e2eResult = runPlaywright(generatedSpecPath, webPackageDir);
+
+  // 5. Composite Score 계산
+  const compositeScore = computeCompositeScore({
+    gapRate,
+    e2eResults: e2eResult ? [{ ...e2eResult, specFile: relativeSpecPath }] : [],
+  });
+
+  return {
+    sprintNum,
+    designDocPath,
+    generatedSpecPath,
+    scenarioCount,
+    e2eResult,
+    gapRate,
+    compositeScore,
+  };
+}


### PR DESCRIPTION
## Summary

- **F526**: `sprint-autopilot` Step 5b에 E2E 자동 생성+실행+Composite Score 통합
- `e2e-runner.ts`: Design doc → F524(E2E 추출) → Playwright 실행 → F525(Composite 계산) 파이프라인
- `foundry-x e2e-verify <N>` CLI 커맨드로 autopilot에서 호출 가능
- sprint-autopilot SKILL.md Step 5b 업데이트 (별도 ax marketplace commit)

## TDD

- 6 Red → 6 Green (전체 173 tests pass)
- 시나리오: Design 없음/Playwright 전체PASS/일부FAIL/실행불가/경로반환/시나리오수

## Test plan

- [ ] `pnpm vitest run` — 173 passed
- [ ] `foundry-x e2e-verify 279 --help` 동작 확인
- [ ] Gap Analysis: Design §5 파일 매핑 vs 구현 90%+

## Related

- F524 (e2e-extractor.ts, Sprint 278 PR #548)
- F525 (gap-scorer.ts, Sprint 278 PR #548)
- PRD: `docs/specs/fx-agent-autonomy/prd-final.md` M3

🤖 Generated with [Claude Code](https://claude.com/claude-code)