### PR TITLE
fix(e2e): resolve Playwright strict mode violation in trace tab

### DIFF
--- a/packages/web/e2e/work-management.spec.ts
+++ b/packages/web/e2e/work-management.spec.ts
@@ -344,11 +344,11 @@ test.describe("Work Management (F509 Walking Skeleton)", () => {
     // 검색 실행
     await page.getByRole("button", { name: "조회" }).click();
 
-    // 체인 결과 확인 — F-item 정보 표시
-    await expect(page.getByText("F516")).toBeVisible();
-    await expect(page.getByText(/Backlog 인입/)).toBeVisible();
+    // 체인 결과 확인 — F-item ID (PR 제목에도 F516 포함되므로 exact match)
+    await expect(page.getByText("F516", { exact: true })).toBeVisible();
+    await expect(page.getByText("Backlog 인입 파이프라인")).toBeVisible();
     // PR 연결 정보
-    await expect(page.getByText("#538")).toBeVisible();
+    await expect(page.getByText("#538", { exact: true })).toBeVisible();
   });
 
   test("trace tab — 동기화 버튼 동작", async ({ authenticatedPage: page }) => {


### PR DESCRIPTION
## Summary
- Work Management E2E `trace tab — REQ 검색→체인 시각화` 테스트의 Playwright strict mode violation 수정
- `getByText('F516')` → `getByText('F516', { exact: true })`: PR 제목에도 "F516"이 포함되어 2개 요소 매칭
- `getByText(/Backlog 인입/)` → `getByText("Backlog 인입 파이프라인")`: PR 제목과 F-item 타이틀 모두 매칭
- `getByText("#538")` → `getByText("#538", { exact: true })`: 방어적 exact match 추가

## Test plan
- [x] `pnpm e2e --grep "Work Management"` 13/13 PASS 확인
- [x] 리그레션 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)