### PR TITLE
fix(f534): DiagnosticCollector 훅 실제 호출 사이트 활성화

### DIFF
--- a/packages/api/src/core/agent/orchestration/graphs/discovery-graph.ts
+++ b/packages/api/src/core/agent/orchestration/graphs/discovery-graph.ts
@@ -4,6 +4,7 @@ import { GraphEngine } from "../graph-engine.js";
 import type { GraphDefinition, GraphNodeInput, GraphNodeOutput, GraphExecutionContext } from "@foundry-x/shared";
 import type { AgentRunner } from "../../services/agent-runner.js";
 import { StageRunnerService } from "../../../discovery/services/stage-runner-service.js";
+import { DiagnosticCollector } from "../../services/diagnostic-collector.js";
 import type { DiscoveryType } from "../../../discovery/services/analysis-path-v82.js";
 
 /** F528 backward compat: runner/db 없을 때 stub 핸들러 */
@@ -35,7 +36,8 @@ function makeStageHandler(
 ) {
   return async (input: GraphNodeInput, _ctx: GraphExecutionContext): Promise<GraphNodeOutput> => {
     const stageInput = input.data as GraphStageInput;
-    const svc = new StageRunnerService(db, runner);
+    const collector = new DiagnosticCollector(db);
+    const svc = new StageRunnerService(db, runner, collector);
 
     const result = await svc.runStage(
       stageInput.bizItemId,

--- a/packages/api/src/core/discovery/routes/discovery-stage-runner.ts
+++ b/packages/api/src/core/discovery/routes/discovery-stage-runner.ts
@@ -10,6 +10,7 @@ import type { TenantVariables } from "../../../middleware/tenant.js";
 import { createAgentRunner, createRoutedRunner } from "../../agent/services/agent-runner.js";
 import { StageRunnerService } from "../services/stage-runner-service.js";
 import { DiscoveryGraphService } from "../services/discovery-graph-service.js";
+import { DiagnosticCollector } from "../../agent/services/diagnostic-collector.js";
 import type { DiscoveryType } from "../services/analysis-path-v82.js";
 
 const StageRunSchema = z.object({
@@ -47,7 +48,7 @@ discoveryStageRunnerRoute.get("/biz-items/:id/discovery-stage/:stage/result", as
   }
 
   const runner = createAgentRunner(c.env);
-  const service = new StageRunnerService(c.env.DB, runner);
+  const service = new StageRunnerService(c.env.DB, runner, new DiagnosticCollector(c.env.DB));
 
   const result = await service.getStageResult(bizItemId, orgId, stage);
   if (!result) {
@@ -79,7 +80,7 @@ discoveryStageRunnerRoute.patch("/biz-items/:id/discovery-stage/:stage/result", 
   }
 
   const runner = createAgentRunner(c.env);
-  const service = new StageRunnerService(c.env.DB, runner);
+  const service = new StageRunnerService(c.env.DB, runner, new DiagnosticCollector(c.env.DB));
 
   const updated = await service.updateStageResult(bizItemId, orgId, stage, parsed.data);
   if (!updated) {
@@ -110,7 +111,7 @@ discoveryStageRunnerRoute.post("/biz-items/:id/discovery-stage/:stage/run", asyn
   const feedback = parsed.success ? parsed.data.feedback : undefined;
 
   const runner = await createRoutedRunner(c.env, "discovery-analysis", c.env.DB);
-  const service = new StageRunnerService(c.env.DB, runner);
+  const service = new StageRunnerService(c.env.DB, runner, new DiagnosticCollector(c.env.DB));
 
   try {
     const result = await service.runStage(
@@ -153,7 +154,7 @@ discoveryStageRunnerRoute.post("/biz-items/:id/discovery-stage/:stage/confirm", 
   }
 
   const runner = createAgentRunner(c.env);
-  const service = new StageRunnerService(c.env.DB, runner);
+  const service = new StageRunnerService(c.env.DB, runner, new DiagnosticCollector(c.env.DB));
 
   try {
     const result = await service.confirmStage(


### PR DESCRIPTION
## Summary
F534(PR #564)가 \`StageRunnerService\`에 optional \`diagnostics\` 파라미터를 추가했지만 실제 호출 사이트는 diagnostics 없이 생성되어 \`agent_run_metrics\` 0건 상태였어요.

## Dogfood 재검증 확증
- Session: \`graph-dogfood-bi-koami-001-1776127590892\` (F534 배포 후 재실행)
- Graph 9-stage 성공, 213초
- \`agent_run_metrics\`: **여전히 0건** 🚨

## 수정
5 호출 사이트에서 \`new DiagnosticCollector(db)\` 주입:
- \`discovery-graph.ts::makeStageHandler\` (GraphEngine 노드 실행)
- \`discovery-stage-runner.ts\` 4 routes (GET result, PATCH result, POST run, POST confirm)

## Test plan
- [x] typecheck PASS
- [x] \`discovery-graph-integration.test.ts\` 6 PASS
- [x] \`discovery-graph-service.test.ts\` 6 PASS
- [x] \`stage-runner-metrics.test.ts\` 8 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)