### PR TITLE
fix(content-sync): Phase 42→43 콘텐츠 동기화

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Foundry-X가 이를 읽고 분석하고 동기화를 강제해요.
 <!-- README_SYNC_START: daily-check가 SPEC.md 실측값 기준으로 자동 동기화 -->
 | 항목 | 수치 |
 |------|------|
-| Phase | 42 (Sprint 286) |
-| Sprints | 286 완료 |
+| Phase | 43 (Sprint 289) |
+| Sprints | 289 완료 |
 | API Routes | ~11 |
 | API Services | ~30 |
 | API Schemas | ~14 |
 | Tests | ~3,452 + E2E 273 |
-| D1 Migrations | 145 (latest: 0134) |
+| D1 Migrations | 146 (latest: 0135) |
 <!-- README_SYNC_END -->
 
 ## 주요 기능

--- a/SPEC.md
+++ b/SPEC.md
@@ -57,7 +57,7 @@ Foundry-X — AX 사업개발 라이프사이클을 AI 에이전트로 자동화
 > ```
 > wc -l SPEC.md && find packages/api/src/db/migrations/*.sql | sort | tail -1
 > ```
-> **마지막 실측** (Sprint 286, 2026-04-14): ~11 routes, ~30 services, ~14 schemas, D1 0134, 10 packages, tests ~3452 (E2E 273) — Phase 42 완료 (F531~F533 HyperFX Deep Integration ✅)
+> **마지막 실측** (Sprint 289, 2026-04-14): ~11 routes, ~30 services, ~14 schemas, D1 0135, 10 packages, tests ~3452 (E2E 273) — Phase 43 완료 (F534~F536 HyperFX Activation ✅)
 
 ## §3 Phase 진행 현황
 

--- a/packages/web/content/landing/hero.md
+++ b/packages/web/content/landing/hero.md
@@ -3,8 +3,8 @@ title: Foundry-X
 section: hero
 sort_order: 0
 tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼"
-phase: "Phase 42"
-phaseTitle: "HyperFX Deep Integration"
+phase: "Phase 43"
+phaseTitle: "HyperFX Activation"
 stats:
   - value: "2"
     label: "BD 파이프라인"
@@ -12,7 +12,7 @@ stats:
     label: "AI 에이전트"
   - value: "63"
     label: "자동화 스킬"
-  - value: "286"
+  - value: "289"
     label: "Sprints"
 ---
 

--- a/packages/web/src/components/landing/footer.tsx
+++ b/packages/web/src/components/landing/footer.tsx
@@ -69,7 +69,7 @@ export function Footer() {
             &copy; {new Date().getFullYear()} KTDS AX BD. All rights reserved.
           </p>
           <p className="font-mono text-xs text-muted-foreground/60">
-            Sprint 286 &middot; Phase 42
+            Sprint 289 &middot; Phase 43
           </p>
         </div>
       </div>

--- a/packages/web/src/routes/landing.tsx
+++ b/packages/web/src/routes/landing.tsx
@@ -69,9 +69,9 @@ function getSectionOrder(section: string): number {
    ═══════════════════════════════════════════════ */
 
 const SITE_META_FALLBACK = {
-  sprint: "Sprint 286",
-  phase: "Phase 42",
-  phaseTitle: "HyperFX Deep Integration",
+  sprint: "Sprint 289",
+  phase: "Phase 43",
+  phaseTitle: "HyperFX Activation",
   tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼",
 } as const;
 
@@ -79,7 +79,7 @@ const STATS_FALLBACK = [
   { value: "2", label: "BD 파이프라인" },
   { value: "10+", label: "AI 에이전트" },
   { value: "63", label: "자동화 스킬" },
-  { value: "286", label: "Sprints" },
+  { value: "289", label: "Sprints" },
 ];
 
 // Build-time content from TinaCMS-managed Markdown


### PR DESCRIPTION
## Summary
- Phase 42→43 + Sprint 286→289 + D1 0134→0135 drift 5파일 일괄 보정
- Phase 43 HyperFX Activation (F534~F536) + MSA 원칙 CI 가드 (C54+C55) 완료 반영

## Changes
- `README.md`: SYNC 블록 Phase/Sprints/D1 수치 갱신
- `SPEC.md`: "마지막 실측" 행 Sprint 289 / D1 0135 / Phase 43 반영
- `packages/web/content/landing/hero.md`: phase/phaseTitle/stats[3]
- `packages/web/src/routes/landing.tsx`: SITE_META_FALLBACK + STATS_FALLBACK
- `packages/web/src/components/landing/footer.tsx`: 문자열 패턴

## Test plan
- [x] /ax:session-end Phase 0c-3 drift 재검증: `content sync: OK (Sprint 289, Phase 43)`
- [x] turbo typecheck --filter=@foundry-x/web PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)