### PR TITLE
fix(f537): MetaAgent auto-trigger session_id 불일치 해소

### DIFF
--- a/packages/api/src/core/agent/services/diagnostic-collector.ts
+++ b/packages/api/src/core/agent/services/diagnostic-collector.ts
@@ -90,6 +90,38 @@ export class DiagnosticCollector {
     };
   }
 
+  /**
+   * F537: biz_item_id 기반 집계 진단 — Graph 실행 전체를 하나로 묶어 조회.
+   * stage-runner가 기록하는 session_id 패턴: `stage-{stage}-{bizItemId}`
+   * autoTriggerMetaAgent에서 graph sessionId가 아닌 bizItemId로 수집.
+   */
+  async collectByBizItem(bizItemId: string, reportSessionId: string): Promise<DiagnosticReport> {
+    const rows = await this.db
+      .prepare(
+        `SELECT rounds, stop_reason, input_tokens, output_tokens, duration_ms
+         FROM agent_run_metrics
+         WHERE session_id LIKE ? AND agent_id = 'discovery-stage-runner'
+         ORDER BY created_at DESC
+         LIMIT 20`,
+      )
+      .bind(`stage-%-${bizItemId}`)
+      .all<AgentRunRow>();
+
+    const fetched = rows.results ?? [];
+    const scores = this.computeScores(fetched);
+    const overallScore = Math.round(
+      scores.reduce((s, a) => s + a.score, 0) / scores.length,
+    );
+
+    return {
+      sessionId: reportSessionId,
+      agentId: "discovery-stage-runner",
+      collectedAt: new Date().toISOString(),
+      scores,
+      overallScore,
+    };
+  }
+
   private async fetchRows(sessionId: string, agentId: string): Promise<AgentRunRow[]> {
     const result = await this.db
       .prepare(

--- a/packages/api/src/core/discovery/routes/discovery-stage-runner.ts
+++ b/packages/api/src/core/discovery/routes/discovery-stage-runner.ts
@@ -25,9 +25,13 @@ export async function autoTriggerMetaAgent(
   db: D1Database,
   sessionId: string,
   apiKey: string,
+  bizItemId?: string,
 ): Promise<void> {
   const collector = new DiagnosticCollector(db);
-  const report = await collector.collect(sessionId, "discovery-graph");
+  // F537: bizItemId 제공 시 biz_item 기반 집계. 아니면 legacy collect.
+  const report = bizItemId
+    ? await collector.collectByBizItem(bizItemId, sessionId)
+    : await collector.collect(sessionId, "discovery-graph");
 
   const metaAgent = new MetaAgent({ apiKey });
   let proposals;
@@ -256,8 +260,8 @@ discoveryStageRunnerRoute.post("/biz-items/:id/discovery-graph/run-all", async (
       feedback: parsed.data.feedback,
     });
     await sessionService.updateStatus(sessionId, "completed");
-    // F536: MetaAgent 자동 진단 훅 — fire-and-forget (응답 블로킹 없음)
-    void autoTriggerMetaAgent(c.env.DB, sessionId, apiKey).catch((e) =>
+    // F536+F537: MetaAgent 자동 진단 훅 — bizItemId 기반 집계 (fire-and-forget)
+    void autoTriggerMetaAgent(c.env.DB, sessionId, apiKey, bizItemId).catch((e) =>
       console.error("[F536] MetaAgent auto-trigger failed:", e)
     );
     return c.json({ sessionId, status: "completed", result });


### PR DESCRIPTION
## Summary
F536(PR #571) \`autoTriggerMetaAgent\`가 graph sessionId로 collect하지만 stage-runner는 \`stage-{stage}-{bizItemId}\` 패턴으로 기록하여 매칭 실패.

## Dogfood 3차 검증 확증
Session: \`graph-bi-koami-001-1776130774847\`
- \`agent_run_metrics\`: **9 → 18건** (F534 정상 동작)
- \`agent_improvement_proposals\`: **여전히 0건** (F536 session_id 불일치)

## 수정
- \`DiagnosticCollector.collectByBizItem()\` 추가 — LIKE \`stage-%-{bizItemId}\` 패턴으로 집계
- \`autoTriggerMetaAgent(db, sessionId, apiKey, bizItemId?)\` — bizItemId 받아 새 메서드 사용
- 기존 \`collect()\`는 backward compat 유지

## Test plan
- [x] typecheck PASS
- [x] meta-agent-auto-trigger.test.ts: 4/4 PASS
- [x] diagnostic-collector-record.test.ts: 6/6 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)