### PR TITLE
[C61] task-daemon post-merge 정리 경로 강화

### DIFF
--- a/scripts/task/lib.sh
+++ b/scripts/task/lib.sh
@@ -235,12 +235,16 @@ write_signal() {
   local task_id="$1" status="$2"
   shift 2
   local project; project=$(_project_name 2>/dev/null || echo "unknown")
+  # Pre-compute timestamp in a variable — avoids $() expansion inside heredoc body,
+  # which can silently store the literal string when called from certain subshell
+  # contexts (C61 A-fix; confirmed in phase_merged_prs / phase_orphan_wts pipe paths).
+  local ts; ts="$(date -Iseconds)"
   mkdir -p "$FX_SIGNAL_DIR"
   local sig_file="${FX_SIGNAL_DIR}/${project}-${task_id}.signal"
   cat > "$sig_file" <<EOF
 TASK_ID=$task_id
 STATUS=$status
-TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+TIMESTAMP=$ts
 PROJECT=$project
 EOF
   # Append any extra key=value pairs

--- a/scripts/task/task-daemon.sh
+++ b/scripts/task/task-daemon.sh
@@ -85,6 +85,22 @@ phase_signals() {
       MERGED=true
     fi
 
+    # B-fix (C61): PR_URL=none + commits 있음 → branch 기반 PR API 재조회
+    # squash merge는 `git branch --merged` 에 안 잡히므로 PR API가 권위 소스.
+    # 재현 사례: C55 — gh pr create 실패로 signal에 PR_URL=none이 기록됐으나
+    # 실제 PR은 세션 재기동 9시간 전에 squash merged 완료 상태였음.
+    if [ "$MERGED" = false ] && [ "${COMMIT_COUNT:-0}" -gt 0 ] && \
+       [ "${PR_URL:-none}" = "none" ] && [ -n "$BRANCH" ] && \
+       command -v gh >/dev/null 2>&1; then
+      local BRANCH_PR_STATE
+      BRANCH_PR_STATE=$(gh pr view "$BRANCH" --repo "KTDS-AXBD/Foundry-X" \
+        --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+      if [ "$BRANCH_PR_STATE" = "MERGED" ]; then
+        log "🔍 ${TASK_ID}: PR_URL=none + COMMIT_COUNT=${COMMIT_COUNT} — branch ${BRANCH} API 재조회 → MERGED (C61)"
+        MERGED=true
+      fi
+    fi
+
     # master pull
     if [ "$MERGED" = true ]; then
       (cd "$REPO_ROOT" && git pull origin master --ff-only 2>/dev/null) || true
@@ -529,11 +545,14 @@ phase_merged_prs() {
         # write_signal은 _project_name()으로 프로젝트명을 결정하는데,
         # daemon은 nohup 백그라운드라 cwd가 달라 "."을 반환할 수 있음.
         # daemon의 $PROJECT 변수를 직접 사용하여 signal 파일 작성.
+        # A-fix (C61): timestamp를 heredoc 밖에서 pre-compute — pipe subshell 내부의
+        # $() heredoc 치환이 리터럴로 저장되는 엣지 케이스 방어.
         local _sig="${FX_SIGNAL_DIR}/${PROJECT}-${task_id}.signal"
+        local _ts; _ts="$(date -Iseconds)"
         cat > "$_sig" <<SIGEOF
 TASK_ID=$task_id
 STATUS=DONE
-TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+TIMESTAMP=$_ts
 PROJECT=$PROJECT
 BRANCH=${task_branch:-$branch}
 PR_URL=https://github.com/KTDS-AXBD/Foundry-X/pull/${pr_num}
@@ -589,10 +608,12 @@ phase_orphan_wts() {
         local pane_id
         pane_id=$(jq -r --arg id "$task_id" '.tasks[$id].pane // ""' "$FX_CACHE" 2>/dev/null)
         local _sig="${FX_SIGNAL_DIR}/${PROJECT}-${task_id}.signal"
+        # A-fix (C61): pre-compute timestamp (pipe subshell $() heredoc 방어)
+        local _ts; _ts="$(date -Iseconds)"
         cat > "$_sig" <<SIGEOF
 TASK_ID=$task_id
 STATUS=DONE
-TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+TIMESTAMP=$_ts
 PROJECT=$PROJECT
 BRANCH=${branch}
 PR_URL=https://github.com/KTDS-AXBD/Foundry-X/pull/${pr_num}
@@ -1002,6 +1023,10 @@ case "${1:-}" in
   __debug-recover)
     # 단위 테스트 진입점 — phase_recover 직접 호출 (FX-REQ-517 / C23)
     phase_recover "${2:?task_id required}" "${3:?wt_path required}"
+    ;;
+  __debug-phase-signals)
+    # 단위 테스트 진입점 — phase_signals 직접 호출 (C61 B-fix 검증)
+    phase_signals
     ;;
   --enqueue)
     # 편의 기능: 큐 추가

--- a/scripts/task/test-daemon-merge-reconfirm.sh
+++ b/scripts/task/test-daemon-merge-reconfirm.sh
@@ -57,7 +57,12 @@ mkdir -p "$FAKE_BIN"
 cat > "$FAKE_BIN/gh" << 'GHEOF'
 #!/usr/bin/env bash
 if [[ "$*" == *"pr view"* ]] && [[ "$*" == *"--json state"* ]]; then
-  printf '{"state":"MERGED","mergedAt":"2026-04-14T01:21:41Z"}'
+  # Simulate gh pr view --json state --jq '.state'
+  if [[ "$*" == *"--jq"* ]]; then
+    echo "MERGED"
+  else
+    printf '{"state":"MERGED","mergedAt":"2026-04-14T01:21:41Z"}'
+  fi
   exit 0
 fi
 echo "[]"

--- a/scripts/task/test-daemon-merge-reconfirm.sh
+++ b/scripts/task/test-daemon-merge-reconfirm.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# scripts/task/test-daemon-merge-reconfirm.sh — C61 TDD
+#
+# A-fix: write_signal TIMESTAMP 필드가 $() 리터럴이 아닌 실제 날짜로 기록됨 검증
+# B-fix: PR_URL=none + COMMIT_COUNT>0 + branch merged → MERGED=true (FINAL_STATUS=merged)
+#
+# 격리: tmp git repo + 격리 PROJECT 이름 (Foundry-X-reconfirm-PID)
+#
+# 주의:
+#  - lib.sh FX_SIGNAL_DIR = /tmp/task-signals (hardcoded, not env-overridable)
+#  - lib.sh _project_name() main-repo에서 "." 반환 → 파일 = .-{ID}.signal (dotfile)
+#    bash glob *-{ID}.signal 로 매칭 안 됨 — find 사용 필요
+#  - task-daemon.sh: PROJECT=$(basename REPO_ROOT) → 올바른 프로젝트명
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DAEMON="$SCRIPT_DIR/task-daemon.sh"
+LIB="$SCRIPT_DIR/lib.sh"
+[ -x "$DAEMON" ] || chmod +x "$DAEMON" 2>/dev/null || true
+
+TMP=$(mktemp -d)
+PROJECT="Foundry-X-reconfirm-$$"
+REPO="$TMP/$PROJECT"
+SIG_DIR="/tmp/task-signals"
+SIG_T777="${SIG_DIR}/${PROJECT}-T777.signal"   # Scenario 2: daemon PROJECT = basename REPO
+DAEMON_LOG="${SIG_DIR}/daemon-${PROJECT}.log"
+
+cleanup() {
+  rm -rf "$TMP"
+  # Remove any T888 signal written by lib.sh _project_name quirk
+  find "$SIG_DIR" -maxdepth 1 -name "*-T888.signal" -delete 2>/dev/null || true
+  rm -f "$SIG_T777" "$DAEMON_LOG"
+}
+trap cleanup EXIT
+
+export FX_HOME="$TMP/fx-home"
+mkdir -p "$FX_HOME" "$SIG_DIR" /tmp/task-retry
+
+# Isolated git repo so daemon PROJECT = Foundry-X-reconfirm-$$
+mkdir -p "$REPO"
+cd "$REPO"
+git init -q -b master
+git config user.email "test@foundry-x.local"
+git config user.name  "fx-test"
+echo "init" > README.md
+git add README.md
+git commit -qm "init"
+
+pass() { echo "  ✅ $*"; }
+fail() { echo "  ❌ $*" >&2; exit 1; }
+
+# ─── Fake gh CLI ─────────────────────────────────────────────────────────────
+# `gh pr view <anything> --json state ...` → MERGED
+FAKE_BIN="$TMP/fake-bin"
+mkdir -p "$FAKE_BIN"
+cat > "$FAKE_BIN/gh" << 'GHEOF'
+#!/usr/bin/env bash
+if [[ "$*" == *"pr view"* ]] && [[ "$*" == *"--json state"* ]]; then
+  printf '{"state":"MERGED","mergedAt":"2026-04-14T01:21:41Z"}'
+  exit 0
+fi
+echo "[]"
+GHEOF
+chmod +x "$FAKE_BIN/gh"
+export PATH="$FAKE_BIN:$PATH"
+
+# ─── Scenario 1: write_signal TIMESTAMP expansion ────────────────────────────
+echo "[test] scenario 1 — write_signal TIMESTAMP must be expanded date, not literal \$(...)"
+
+# Remove any leftover T888 signal
+find "$SIG_DIR" -maxdepth 1 -name "*-T888.signal" -delete 2>/dev/null || true
+
+(
+  source "$LIB"
+  write_signal "T888" "DONE" "BRANCH=test/branch" "PR_URL=none" "COMMIT_COUNT=0"
+)
+
+# lib.sh _project_name() returns "." in main repo → file is .-T888.signal (dotfile)
+# Use find instead of glob (bash * skips dotfiles)
+SIG_T888_ACTUAL=$(find "$SIG_DIR" -maxdepth 1 -name "*-T888.signal" 2>/dev/null | head -1 || true)
+[ -n "$SIG_T888_ACTUAL" ] || fail "signal 파일 미생성 (in $SIG_DIR)"
+pass "signal 파일 생성: $(basename "$SIG_T888_ACTUAL")"
+
+TIMESTAMP_LINE=$(grep "^TIMESTAMP=" "$SIG_T888_ACTUAL")
+[ -n "$TIMESTAMP_LINE" ] || fail "TIMESTAMP 필드 없음"
+pass "TIMESTAMP 필드 존재"
+
+# Must NOT contain '$(' literal (A-fix 핵심 검증)
+if echo "$TIMESTAMP_LINE" | grep -qF "\$("; then
+  fail "TIMESTAMP에 \$() 리터럴 발견 (A-fix 미적용): $TIMESTAMP_LINE"
+fi
+pass "TIMESTAMP 리터럴 \$() 없음"
+
+# Must look like an ISO-8601 date
+if ! echo "$TIMESTAMP_LINE" | grep -qE "^TIMESTAMP=[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}"; then
+  fail "TIMESTAMP가 날짜 형식 아님: $TIMESTAMP_LINE"
+fi
+pass "TIMESTAMP 날짜 형식 확인 (A-fix)"
+
+# ─── Scenario 2: PR_URL=none + COMMIT_COUNT>0 + branch merged ────────────────
+echo "[test] scenario 2 — PR_URL=none COMMIT_COUNT=9, fake gh MERGED → FINAL_STATUS=merged"
+
+rm -f "$SIG_T777"
+: > "$DAEMON_LOG"
+
+# Initialise FX cache with T777 in_progress
+cat > "$FX_HOME/tasks-cache.json" << 'CACHEEOF'
+{
+  "version": 1,
+  "tasks": {
+    "T777": {
+      "status": "in_progress",
+      "track": "C",
+      "pane": "",
+      "wt": "",
+      "branch": "task/T777-squash-test",
+      "issue_url": "",
+      "updated_at": "2026-04-14T01:00:00Z",
+      "started_at": "2026-04-14T00:00:00Z"
+    }
+  }
+}
+CACHEEOF
+touch "$FX_HOME/task-log.ndjson"
+mkdir -p "$FX_HOME/locks" "$FX_HOME/scripts"
+
+# Write signal: PR_URL=none + COMMIT_COUNT=9 (C55 재현)
+TS_NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+cat > "$SIG_T777" << SIGEOF
+TASK_ID=T777
+STATUS=DONE
+TIMESTAMP=${TS_NOW}
+PROJECT=${PROJECT}
+BRANCH=task/T777-squash-test
+PR_URL=none
+COMMIT_COUNT=9
+WT_PATH=
+PANE_ID=unknown
+SIGEOF
+
+# __debug-phase-signals: debug entry added to task-daemon.sh by B-fix
+bash "$DAEMON" __debug-phase-signals >/tmp/fx-reconfirm-s2.log 2>&1 \
+  || { echo "--- daemon log ---"; cat /tmp/fx-reconfirm-s2.log; fail "__debug-phase-signals 비정상 종료"; }
+pass "__debug-phase-signals 정상 종료"
+
+# Signal must be consumed (deleted)
+[ ! -f "$SIG_T777" ] \
+  || fail "signal 파일 미소비 — MERGED 처리 미완 (B-fix 미적용?)"
+pass "signal 파일 소비"
+
+# Cache: status must be merged
+FINAL=$(jq -r '.tasks.T777.status // "missing"' "$FX_HOME/tasks-cache.json" 2>/dev/null)
+[ "$FINAL" = "merged" ] \
+  || fail "FINAL_STATUS='${FINAL}' — 'merged' 이어야 함 (B-fix 미적용)"
+pass "FINAL_STATUS=merged (B-fix 확인)"
+
+# Daemon log must record branch API recheck
+grep -q "API 재조회" "$DAEMON_LOG" \
+  || { cat "$DAEMON_LOG" 2>/dev/null; fail "daemon log에 'API 재조회' 마커 누락"; }
+pass "daemon log branch API 재조회 기록"
+
+echo "[test] ✅ ALL TESTS PASSED"


### PR DESCRIPTION
Task Orchestrator — C61 task-daemon post-merge cleanup hardening

## A-fix: TIMESTAMP pre-compute (signal TIMESTAMP 리터럴 저장 방어)

- **lib.sh `write_signal()`**: `$(date ...)` 를 heredoc body 내부에서 직접 사용하는 대신 `local ts; ts="$(date -Iseconds)"` 로 pre-compute 후 `$ts` 변수만 heredoc에 참조
- **task-daemon.sh `phase_merged_prs` + `phase_orphan_wts`**: 동일 pre-compute 패턴 적용 (pipe subshell 내부 `<<SIGEOF` heredoc 경로)
- **근거**: C51 관찰 — signal 파일에 `TIMESTAMP=$(date -Iseconds)` 리터럴이 저장되어 daemon parse 실패

## B-fix: MERGED 판정 branch-API fallback

- **`phase_signals()`**: `PR_URL=none + COMMIT_COUNT>0` 조건에서 기존 로직이 `MERGED=false + needs_manual_review` 처리. B-fix로 `BRANCH` 값을 사용해 `gh pr view <branch> --json state` 재조회 추가. `state=MERGED` 이면 정리 경로 진행
- **squash merge 감지**: `git branch --merged` 는 squash merge를 감지 못함 — PR API가 권위 소스
- **근거**: C55 관찰 — `gh pr create` 실패로 `PR_URL=none` 기록됐으나 실제 PR은 9시간 전에 squash merged 완료

## TDD

- **Red**: `test-daemon-merge-reconfirm.sh` — Scenario 1(TIMESTAMP), Scenario 2(B-fix) 2건
- **Green**: lib.sh + task-daemon.sh 수정으로 전체 통과
- **회귀**: `test-daemon-retry.sh`, `test-daemon-restart-hook.sh` 전체 PASS 유지
- `__debug-phase-signals` 테스트 진입점 추가 (기존 `__debug-recover` 패턴 동일)