### PR TITLE
fix(task): C62 task-list stale display — filter terminal tasks + IFS tab-collapse fix

### DIFF
--- a/scripts/task/task-daemon.sh
+++ b/scripts/task/task-daemon.sh
@@ -200,7 +200,11 @@ phase_signals() {
     elif [ "$MERGED" = false ]; then
       FINAL_STATUS="done_pending_merge"
     fi
-    cache_upsert_task "$TASK_ID" "$FINAL_STATUS" "" "" "" "$BRANCH" "${PR_URL:-}"
+    # Preserve track from existing cache entry — daemon updates don't know the track
+    # and passing "" caused IFS tab-collapse field shift in task-list.sh (C62).
+    local existing_track
+    existing_track=$(jq -r --arg id "$TASK_ID" '.tasks[$id].track // ""' "$FX_CACHE" 2>/dev/null || echo "")
+    cache_upsert_task "$TASK_ID" "$FINAL_STATUS" "$existing_track" "" "" "$BRANCH" "${PR_URL:-}"
     log_event "$TASK_ID" "daemon_processed" "$(jq -nc --arg s "$FINAL_STATUS" '{status:$s}')"
     rm -f "$sig_file"
     log "✅ ${TASK_ID} → ${FINAL_STATUS}"

--- a/scripts/task/task-list.sh
+++ b/scripts/task/task-list.sh
@@ -17,7 +17,12 @@ if [ "${1:-}" = "--json" ]; then
   exit 0
 fi
 
-count=$(jq -r '.tasks | length' "$FX_CACHE")
+# Terminal statuses: never show in active table.
+# These accumulate in cache (daemon merge-detection writes them without removing).
+TERMINAL_STATUSES='["done","merged","needs_manual_review","cancelled","aborted","rejected","empty_rejected","failed_setup"]'
+
+count=$(jq -r --argjson ts "$TERMINAL_STATUSES" \
+  '[.tasks[] | select(.status as $s | $ts | index($s) == null)] | length' "$FX_CACHE")
 if [ "$count" -eq 0 ]; then
   echo "[fx-task] no active tasks. /ax:task start <F|B|C|X> \"title\" 으로 시작."
   exit 0
@@ -49,8 +54,15 @@ printf "%-6s %-4s %-4s %-32s %-8s %-6s %s\n" "------" "----" "----" "-----------
 
 now_epoch=$(date +%s)
 
-jq -r '.tasks | to_entries[] | [.key, .value.track, .value.status, .value.branch, .value.started_at, .value.pane, .value.wt] | @tsv' "$FX_CACHE" \
-| while IFS=$'\t' read -r id track status branch started pane wt; do
+# Use \x01 (SOH) as separator — tab is IFS whitespace and collapses consecutive delimiters,
+# causing field shift when track="" (empty string produces \t\t in @tsv).
+jq -r --argjson ts "$TERMINAL_STATUSES" \
+  '.tasks | to_entries[]
+   | select(.value.status as $s | $ts | index($s) == null)
+   | [.key, (.value.track // ""), (.value.status // ""), (.value.branch // ""),
+      (.value.started_at // ""), (.value.pane // ""), (.value.wt // "")]
+   | join("\u0001")' "$FX_CACHE" \
+| while IFS=$'\x01' read -r id track status branch started pane wt; do
   start_epoch=$(date -d "$started" +%s 2>/dev/null || echo "$now_epoch")
   age_sec=$(( now_epoch - start_epoch ))
   age=$(printf "%02d:%02d" $((age_sec/3600)) $(((age_sec%3600)/60)))
@@ -82,6 +94,14 @@ jq -r '.tasks | to_entries[] | [.key, .value.track, .value.status, .value.branch
 
   printf "%-6s %-4s %-4s %-32s %-8s %-6s %s\n" "$id" "$track" "$emoji" "$br_short" "$age" "$hb" "${pane:-—}"
 done
+
+# Show archived (terminal-status) task count — informational, not cluttering main table
+archived_count=$(jq -r --argjson ts "$TERMINAL_STATUSES" \
+  '[.tasks[] | select(.status as $s | $ts | index($s) != null)] | length' "$FX_CACHE")
+if [ "$archived_count" -gt 0 ]; then
+  echo ""
+  echo "[fx-task] 📦 $archived_count archived task(s) (done/merged/cancelled) — hidden from table"
+fi
 
 # Check for pending signals
 sig_count=$(read_signals | wc -l)

--- a/scripts/task/test-task-list-display.sh
+++ b/scripts/task/test-task-list-display.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# scripts/task/test-task-list-display.sh — C62 TDD Red
+#
+# Verifies task-list.sh display correctness:
+#   1. Completed tasks (status=merged/done/etc.) are NOT shown in main table
+#   2. Active tasks (status=in_progress) ARE shown with correct fields
+#   3. Track="" entries don't corrupt column alignment via IFS whitespace collapse
+#
+# Usage: bash test-task-list-display.sh
+#
+# Exit code: 0 = all PASS, non-zero = failures
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TASK_LIST="$SCRIPT_DIR/task-list.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "  ✅ $1"; (( PASS++ )) || true; }
+fail() { echo "  ❌ $1"; (( FAIL++ )) || true; }
+
+# ─── test harness ─────────────────────────────────────────────────────────────
+# Run task-list with a fake cache and return its output.
+# lib.sh overwrites FX_CACHE unconditionally, so we inject via FX_HOME instead.
+run_with_cache() {
+  local cache_json="$1"
+  local tmp_home; tmp_home=$(mktemp -d)
+  mkdir -p "$tmp_home/locks" "$tmp_home/scripts"
+  touch "$tmp_home/task-log.ndjson"
+  echo "$cache_json" > "$tmp_home/tasks-cache.json"
+  local out
+  out=$(FX_HOME="$tmp_home" bash "$TASK_LIST" 2>/dev/null || true)
+  rm -rf "$tmp_home"
+  printf '%s' "$out"
+}
+
+echo "=== test-task-list-display.sh (C62 Red) ==="
+
+# ─── Case 1: completed task (status=merged, track="") must NOT appear in main table ─
+echo ""
+echo "Case 1: merged task with track='' must not appear in main table"
+cache_merged='{
+  "version": 1,
+  "tasks": {
+    "C52": {
+      "status": "merged",
+      "track": "",
+      "pane": "",
+      "wt": "",
+      "branch": "task/C52-example",
+      "issue_url": "https://github.com/example/repo/pull/100",
+      "updated_at": "2026-04-13T14:39:45Z",
+      "started_at": "2026-04-13T14:35:56Z"
+    }
+  }
+}'
+out=$(run_with_cache "$cache_merged")
+if echo "$out" | grep -q "^C52 "; then
+  fail "C52 (merged) appeared in main table — should be hidden or archived"
+else
+  pass "C52 (merged) not in main table"
+fi
+if echo "$out" | grep -qE "(no active tasks|archived|C52)"; then
+  pass "Output acknowledges C52 somehow (no-tasks or archived)"
+else
+  fail "Output gives no indication of C52 status"
+fi
+
+# ─── Case 2: active task (status=in_progress, track=C) must appear in main table ────
+echo ""
+echo "Case 2: in_progress task must appear with correct fields"
+cache_active='{
+  "version": 1,
+  "tasks": {
+    "C62": {
+      "status": "in_progress",
+      "track": "C",
+      "pane": "%27",
+      "wt": "/tmp/fake-wt-c62",
+      "branch": "task/C62-task-list-stale-display",
+      "issue_url": "https://github.com/example/repo/issues/200",
+      "updated_at": "2026-04-14T02:00:00Z",
+      "started_at": "2026-04-14T02:00:00Z"
+    }
+  }
+}'
+out=$(run_with_cache "$cache_active")
+if echo "$out" | grep -qE "^C62 "; then
+  pass "C62 (in_progress) appeared in main table"
+else
+  fail "C62 (in_progress) missing from main table"
+fi
+# Verify TRK column has "C" not some other value (no field shift)
+if echo "$out" | grep -qE "^C62 +C "; then
+  pass "C62 TRK column correctly shows 'C'"
+else
+  fail "C62 TRK column is wrong — likely field shift bug: $(echo "$out" | grep '^C62' | head -1)"
+fi
+
+# ─── Case 3: IFS whitespace collapsing — empty track must not shift other fields ───
+echo ""
+echo "Case 3: track='' must not shift subsequent fields (IFS tab collapse bug)"
+cache_empty_track='{
+  "version": 1,
+  "tasks": {
+    "C99": {
+      "status": "in_progress",
+      "track": "",
+      "pane": "%10",
+      "wt": "/tmp/fake-wt-c99",
+      "branch": "task/C99-test-branch",
+      "issue_url": "",
+      "updated_at": "2026-04-14T02:00:00Z",
+      "started_at": "2026-04-14T02:00:00Z"
+    }
+  }
+}'
+out=$(run_with_cache "$cache_empty_track")
+# C99 has in_progress status — it SHOULD appear (it's active, just missing track)
+# If field shift occurs: TRK shows "in_progress", ST shows emoji_for("task/C99-test-branch") = "•"
+# If fixed: TRK shows "" or "?", ST shows emoji_for("in_progress") = "🔧"
+# The key: "in_progress" must NOT appear in the TRK column
+if echo "$out" | grep -qE "^C99 +in_progress"; then
+  fail "C99 TRK column shows 'in_progress' — IFS whitespace collapse field shift not fixed"
+else
+  pass "C99 TRK column does not show 'in_progress' (no field shift)"
+fi
+
+# ─── Case 4: multiple tasks — only active ones in table ─────────────────────
+echo ""
+echo "Case 4: mixed cache — only active tasks in main table, completed ones omitted"
+cache_mixed='{
+  "version": 1,
+  "tasks": {
+    "C50": {
+      "status": "merged",
+      "track": "C",
+      "pane": "",
+      "wt": "",
+      "branch": "task/C50-old",
+      "issue_url": "",
+      "updated_at": "2026-04-10T10:00:00Z",
+      "started_at": "2026-04-10T09:00:00Z"
+    },
+    "C62": {
+      "status": "in_progress",
+      "track": "C",
+      "pane": "%27",
+      "wt": "/tmp/fake-wt-c62",
+      "branch": "task/C62-task-list-stale-display",
+      "issue_url": "",
+      "updated_at": "2026-04-14T02:00:00Z",
+      "started_at": "2026-04-14T02:00:00Z"
+    }
+  }
+}'
+out=$(run_with_cache "$cache_mixed")
+if echo "$out" | grep -qE "^C50 "; then
+  fail "C50 (merged) appeared in main table — should be filtered"
+else
+  pass "C50 (merged) not in main table"
+fi
+if echo "$out" | grep -qE "^C62 "; then
+  pass "C62 (in_progress) in main table"
+else
+  fail "C62 (in_progress) missing from main table"
+fi
+
+# ─── Case 5: done task (status=done) must not appear in main table ──────────
+echo ""
+echo "Case 5: done task must not appear in main table"
+cache_done='{
+  "version": 1,
+  "tasks": {
+    "C61": {
+      "status": "done",
+      "track": "C",
+      "pane": "",
+      "wt": "",
+      "branch": "task/C61-old-done",
+      "issue_url": "",
+      "updated_at": "2026-04-14T02:00:00Z",
+      "started_at": "2026-04-14T01:00:00Z"
+    }
+  }
+}'
+out=$(run_with_cache "$cache_done")
+if echo "$out" | grep -qE "^C61 "; then
+  fail "C61 (done) appeared in main table"
+else
+  pass "C61 (done) not in main table"
+fi
+
+echo ""
+echo "=== Result: ${PASS} passed, ${FAIL} failed ==="
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

- **IFS tab-collapse field shift** — `IFS=$'\t' read` collapses consecutive tabs (`\t\t` from empty `track` field) → all subsequent fields shift left. Fix: `\x01` (SOH) separator via `jq join("\u0001")` + `IFS=$'\x01'`.
- **Stale terminal-status entries** — `merged`/`done`/`cancelled` tasks never removed from cache, polluting main table with growing-age stale rows. Fix: jq `select()` filters terminal statuses; archived count shown at bottom.
- **`track=""` root cause** — `task-daemon.sh` called `cache_upsert_task` with empty track on merge detection, creating entries that trigger the IFS bug. Fix: preserve existing track from cache.

## Test plan

- [x] `test-task-list-display.sh` (new, 8 cases) — all PASS
- [x] `test-daemon-merge-reconfirm.sh` — no regression
- [x] `test-task-complete-empty.sh` — no regression
- [x] `bash scripts/task/task-list.sh` — only C62 (active) shown, 31 archived count at bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)