### PR TITLE
fix(landing): sync to Sprint 290 / Phase 44

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,8 @@ Phase 1~36 완료 (Sprint 1~268). 상세: SPEC.md §5
 - **Phase 40: Agent Autonomy** ✅ (F524~F526, Sprint 278~279)
 - **Phase 41: HyperFX Agent Stack** ✅ (F527~F530, Sprint 280~283). PRD: `docs/specs/fx-hyperfx-agent-stack/prd-final.md`
 - **Phase 42: HyperFX Deep Integration** ✅ (F531~F533, Sprint 284~286). 발굴 Graph 실행 연동 + 스트리밍 E2E + MetaAgent 실전 검증
-- **Phase 43: HyperFX Activation** ✅ (F534~F536, Sprint 287~289). Dogfood(KOAMI, S276)에서 확증된 3개 갭 해소 — DiagnosticCollector 훅 / Graph 정식 API+UI / MetaAgent 자동 진단
+- **Phase 43: HyperFX Activation** ✅ (F534~F537, Sprint 287~289). Dogfood(KOAMI, S276)에서 확증된 3개 갭 해소 — DiagnosticCollector 훅 / Graph 정식 API+UI / MetaAgent 자동 진단
+- **Phase 44: MSA 2차 분리 + Agent 품질 튜닝** 🔧 (F538~F542). F542 ✅ Sprint 290 (MetaAgent 프롬프트 강화 + Sonnet 4.6 + A/B + Rubric, Dogfood P2 PASS 6 proposals), F538~F541 📋 W+6+ 구체화. 관찰: C65 F536 auto-trigger 저장 누락
 - 장기 backlog 2건: F112, F117
 - 수치: `/ax:daily-check` 또는 SPEC.md §2 (하드코딩 금지)
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Foundry-X가 이를 읽고 분석하고 동기화를 강제해요.
 <!-- README_SYNC_START: daily-check가 SPEC.md 실측값 기준으로 자동 동기화 -->
 | 항목 | 수치 |
 |------|------|
-| Phase | 43 (Sprint 289) |
-| Sprints | 289 완료 |
+| Phase | 44 (Sprint 290) |
+| Sprints | 290 완료 |
 | API Routes | ~11 |
-| API Services | ~30 |
+| API Services | ~31 |
 | API Schemas | ~14 |
-| Tests | ~3,452 + E2E 273 |
-| D1 Migrations | 146 (latest: 0135) |
+| Tests | ~3,473 + E2E 273 |
+| D1 Migrations | 148 (latest: 0137) |
 <!-- README_SYNC_END -->
 
 ## 주요 기능

--- a/SPEC.md
+++ b/SPEC.md
@@ -57,7 +57,7 @@ Foundry-X — AX 사업개발 라이프사이클을 AI 에이전트로 자동화
 > ```
 > wc -l SPEC.md && find packages/api/src/db/migrations/*.sql | sort | tail -1
 > ```
-> **마지막 실측** (Sprint 289, 2026-04-14): ~11 routes, ~31 services, ~14 schemas, D1 0135, 10 packages, tests ~3452 (E2E 273) — Phase 43 완료 (F534~F536 HyperFX Activation ✅) + F542 PRD Final 등록 (📋plan)
+> **마지막 실측** (Sprint 290, 2026-04-14): ~11 routes, ~31 services, ~14 schemas, D1 0137, 10 packages, tests ~3473 (E2E 273) — Phase 43 완료 (F534~F537 HyperFX Activation ✅) + Phase 44 착수 (F542 MetaAgent 프롬프트 품질 ✅ Dogfood P2 PASS 6 proposals)
 
 ## §3 Phase 진행 현황
 
@@ -80,7 +80,7 @@ Foundry-X — AX 사업개발 라이프사이클을 AI 에이전트로 자동화
 | **Phase 41 HyperFX Agent Stack** (F527~F530) | ✅ Sprint 280~283 |
 | **Phase 42 HyperFX Deep Integration** (F531~F533) | ✅ Sprint 284~286 |
 | **Phase 43 HyperFX Activation** (F534~F537) | ✅ Sprint 287~289 + F537 hotfix |
-| **Phase 44 MSA 2차 분리 + Agent 품질 튜닝** (F538~F542 Idea) | 📋 W+8+ 예정, W+6+ 구체화 |
+| **Phase 44 MSA 2차 분리 + Agent 품질 튜닝** (F538~F542) | 🔧 착수 — F542 ✅ Sprint 290 (Dogfood P2 PASS), F538~F541 📋 W+6+ 구체화 |
 
 ## §4 성공 지표
 

--- a/packages/web/content/landing/hero.md
+++ b/packages/web/content/landing/hero.md
@@ -3,8 +3,8 @@ title: Foundry-X
 section: hero
 sort_order: 0
 tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼"
-phase: "Phase 43"
-phaseTitle: "HyperFX Activation"
+phase: "Phase 44"
+phaseTitle: "MSA 2차 분리 + Agent 품질 튜닝"
 stats:
   - value: "2"
     label: "BD 파이프라인"
@@ -12,7 +12,7 @@ stats:
     label: "AI 에이전트"
   - value: "63"
     label: "자동화 스킬"
-  - value: "289"
+  - value: "290"
     label: "Sprints"
 ---
 

--- a/packages/web/src/components/landing/footer.tsx
+++ b/packages/web/src/components/landing/footer.tsx
@@ -69,7 +69,7 @@ export function Footer() {
             &copy; {new Date().getFullYear()} KTDS AX BD. All rights reserved.
           </p>
           <p className="font-mono text-xs text-muted-foreground/60">
-            Sprint 289 &middot; Phase 43
+            Sprint 290 &middot; Phase 44
           </p>
         </div>
       </div>

--- a/packages/web/src/routes/landing.tsx
+++ b/packages/web/src/routes/landing.tsx
@@ -69,9 +69,9 @@ function getSectionOrder(section: string): number {
    ═══════════════════════════════════════════════ */
 
 const SITE_META_FALLBACK = {
-  sprint: "Sprint 289",
-  phase: "Phase 43",
-  phaseTitle: "HyperFX Activation",
+  sprint: "Sprint 290",
+  phase: "Phase 44",
+  phaseTitle: "MSA 2차 분리 + Agent 품질 튜닝",
   tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼",
 } as const;
 
@@ -79,7 +79,7 @@ const STATS_FALLBACK = [
   { value: "2", label: "BD 파이프라인" },
   { value: "10+", label: "AI 에이전트" },
   { value: "63", label: "자동화 스킬" },
-  { value: "289", label: "Sprints" },
+  { value: "290", label: "Sprints" },
 ];
 
 // Build-time content from TinaCMS-managed Markdown


### PR DESCRIPTION
## Summary
- `packages/web/content/landing/hero.md`: Phase/Sprint 갱신
- `packages/web/src/routes/landing.tsx` SITE_META_FALLBACK/STATS_FALLBACK 갱신
- `packages/web/src/components/landing/footer.tsx` Sprint/Phase 갱신
- S290 session-end 콘텐츠 동기화. SPEC.md 마지막 실측 기준

## Test plan
- [x] `bash scripts/content-sync-check.sh` → "content sync: OK (Sprint 290, Phase 44)"
- [ ] Preview 빌드 후 랜딩 페이지 수치 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)