### PR TITLE
feat(meta-agent): F544 — autoTriggerMetaAgent 저장 경로 복구

### DIFF
--- a/docs/01-plan/features/sprint-292.plan.md
+++ b/docs/01-plan/features/sprint-292.plan.md
@@ -1,0 +1,56 @@
+---
+id: sprint-292-plan
+type: plan
+sprint: 292
+features: [F544]
+status: active
+created: 2026-04-14
+---
+
+# Sprint 292 Plan — F544: F536 auto-trigger 저장 경로 복구
+
+## 목표
+
+Graph 완료 후 `autoTriggerMetaAgent` hook이 호출되지만 `agent_improvement_proposals`에 저장되지 않는 버그 수정.
+Phase 43 Exit P1~P4 재검증 목적. MVP: K1(auto-trigger proposals ≥ 1건) + K2(manual == auto 경로 동일) PASS.
+
+## 근본 원인 분석
+
+Dogfood 실측 (graph-bi-koami-001-1776147547955): auto-trigger → 0건, manual `/api/meta/diagnose` → 6건.
+
+### 원인 A: Cloudflare Workers `waitUntil` 누락 (P0)
+```typescript
+// 현재 — void fire-and-forget, Workers 응답 후 컨텍스트 종료 위험
+void autoTriggerMetaAgent(c.env.DB, sessionId, apiKey, bizItemId).catch(...)
+return c.json(...)
+```
+Workers는 `return c.json()` 이후 컨텍스트를 종료할 수 있음. `collection.ts` 등 다른 라우트는 `c.executionCtx.waitUntil()`로 안전 처리.
+
+### 원인 B: 저장 경로 분기 (P1)
+- **manual**: `rubric.score(p)` → `approveSvc.save({ ...p, rubricScore })`
+- **auto-trigger**: `approvalService.save({ ...bare fields })` — `rubricScore` 없음, spread 없음
+
+### 원인 C: 모델 미지정 (P2)
+- **manual**: `new MetaAgent({ apiKey, model: META_AGENT_MODEL })`
+- **auto-trigger**: `new MetaAgent({ apiKey })` — default 모델 사용 (일관성 없음)
+
+## 작업 목록
+
+| 항목 | 파일 | 설명 |
+|------|------|------|
+| (a) 구조 로깅 추가 | `discovery-stage-runner.ts` | sessionId, bizItemId, reportRows, proposals.length 로그 |
+| (b) waitUntil 적용 | `discovery-stage-runner.ts` | `autoTriggerMetaAgent`를 route 내부로 이동, `c.executionCtx.waitUntil()` |
+| (c) save 경로 단일화 | `discovery-stage-runner.ts` | `ProposalRubric` 적용 + spread로 manual과 동일화 |
+| (d) 모델 통일 | `discovery-stage-runner.ts` | `MetaAgent({ apiKey, model })` — Env에서 읽기 |
+| (e) integration test | `meta-agent-full-loop.test.ts` | Graph 완료 후 proposals > 0 보장 테스트 |
+
+## 성공 기준
+
+- K1: Dogfood P3에서 auto-trigger만으로 proposals ≥ 1건 실측
+- K2: manual / auto-trigger 저장 경로 코드 단일화 (rubric 포함)
+- K3: integration test GREEN (Graph run → proposals > 0)
+
+## 전제
+
+- F542 ✅ (Sonnet 4.6 + rubric 인프라 활용)
+- D1 migration 없음 (스키마 변경 없음)

--- a/docs/02-design/features/sprint-292.design.md
+++ b/docs/02-design/features/sprint-292.design.md
@@ -1,0 +1,178 @@
+---
+id: sprint-292-design
+type: design
+sprint: 292
+features: [F544]
+status: active
+created: 2026-04-14
+---
+
+# Sprint 292 Design — F544: F536 auto-trigger 저장 경로 복구
+
+## §1 목표
+
+`autoTriggerMetaAgent`의 세 가지 버그를 수정하여 Graph 완료 후 proposals 저장을 보장한다.
+
+## §2 현재 vs 목표 상태
+
+### 현재 상태 (버그)
+
+```typescript
+// discovery-stage-runner.ts — run-all route
+void autoTriggerMetaAgent(c.env.DB, sessionId, apiKey, bizItemId).catch(...)
+return c.json(...)
+
+// autoTriggerMetaAgent 함수 내부
+const approvalService = new MetaApprovalService(db);
+for (const proposal of proposals) {
+  await approvalService.save({
+    id: proposal.id,
+    sessionId: proposal.sessionId,
+    // ... bare fields, rubricScore 없음
+  });
+}
+```
+
+### 목표 상태 (수정)
+
+```typescript
+// discovery-stage-runner.ts — run-all route
+const triggerTask = autoTriggerMetaAgent(c.env.DB, sessionId, apiKey, c.env.ANTHROPIC_API_KEY ?? "", bizItemId, c.env.META_AGENT_MODEL).catch(
+  (e) => console.error("[F544] MetaAgent auto-trigger failed:", e)
+);
+try {
+  c.executionCtx.waitUntil(triggerTask);
+} catch {
+  // non-Worker 환경 (테스트) fallback
+}
+return c.json(...)
+
+// autoTriggerMetaAgent 함수 내부
+const rubric = new ProposalRubric();
+const approvalService = new MetaApprovalService(db);
+for (const proposal of proposals) {
+  const rubricScore = rubric.score(proposal);
+  await approvalService.save({ ...proposal, rubricScore, status: "pending" });
+}
+```
+
+## §3 변경 사항 상세
+
+### 변경 A: `autoTriggerMetaAgent` 함수 시그니처 확장
+
+```typescript
+export async function autoTriggerMetaAgent(
+  db: D1Database,
+  sessionId: string,
+  apiKey: string,
+  bizItemId?: string,
+  metaAgentModel?: string,   // NEW: F542 META_AGENT_MODEL 통일
+): Promise<void>
+```
+
+### 변경 B: MetaAgent 모델 통일
+
+```typescript
+// 변경 전
+const metaAgent = new MetaAgent({ apiKey });
+
+// 변경 후
+const model = metaAgentModel ?? "claude-sonnet-4-6";
+const metaAgent = new MetaAgent({ apiKey, model });
+```
+
+### 변경 C: save 경로 단일화 (rubric 포함)
+
+```typescript
+// 변경 전
+for (const proposal of proposals) {
+  await approvalService.save({
+    id: proposal.id,
+    sessionId: proposal.sessionId,
+    agentId: proposal.agentId,
+    type: proposal.type,
+    title: proposal.title,
+    reasoning: proposal.reasoning,
+    yamlDiff: proposal.yamlDiff,
+    status: "pending",
+  });
+}
+
+// 변경 후
+const rubric = new ProposalRubric();
+for (const proposal of proposals) {
+  const rubricScore = rubric.score(proposal);
+  await approvalService.save({ ...proposal, rubricScore, status: "pending" });
+}
+```
+
+### 변경 D: waitUntil 적용
+
+```typescript
+// discovery-stage-runner.ts route 핸들러 내부
+const triggerTask = autoTriggerMetaAgent(
+  c.env.DB,
+  sessionId,
+  apiKey,
+  bizItemId,
+  c.env.META_AGENT_MODEL,
+).catch((e) => console.error("[F544] auto-trigger failed:", e));
+
+try {
+  c.executionCtx.waitUntil(triggerTask);
+} catch {
+  // non-Worker env fallback (테스트)
+}
+```
+
+### 변경 E: 구조 로깅
+
+```typescript
+// collectByBizItem 후
+console.log("[F544] autoTrigger start", {
+  sessionId,
+  bizItemId: bizItemId ?? "none",
+  reportRows: report.scores.length,  // 항상 6 (6축)
+  overallScore: report.overallScore,
+});
+
+// diagnose 후
+console.log("[F544] autoTrigger diagnose result", {
+  proposalsCount: proposals.length,
+});
+
+// save 완료 후
+console.log("[F544] autoTrigger saved", {
+  saved: proposals.length,
+  sessionId,
+});
+```
+
+## §4 TDD Red Target
+
+| 테스트 | 기대 결과 |
+|--------|----------|
+| `autoTriggerMetaAgent — bizItemId 기반 집계 + rubricScore 포함 저장` | proposals 저장, `rubric_score IS NOT NULL` |
+| `autoTriggerMetaAgent — metaAgentModel 파라미터 전달 시 MetaAgent에 전달` | fetch mock에서 model 검증 |
+| `integration: Graph run → proposals saved` | `agent_improvement_proposals` COUNT > 0 |
+
+## §5 파일 매핑 (D1 체크리스트)
+
+| 파일 | 변경 타입 | 내용 |
+|------|----------|------|
+| `packages/api/src/core/discovery/routes/discovery-stage-runner.ts` | 수정 | A+B+C+D+E |
+| `packages/api/src/__tests__/services/meta-agent-auto-trigger.test.ts` | 수정 | 신규 테스트 케이스 추가 (bizItemId + rubricScore) |
+| `packages/api/src/__tests__/integration/meta-agent-full-loop.test.ts` | 수정 | Graph run → proposals > 0 integration test |
+
+**D1 체크리스트**:
+- [x] D1: 주입 사이트 전수 검증 — `autoTriggerMetaAgent` 호출처: `discovery-stage-runner.ts` 1곳 (run-all route)
+- [x] D2: 식별자 계약 — bizItemId 기반 collectByBizItem은 F537에서 이미 검증됨. 변경 없음
+- [x] D3: Breaking change — 함수 시그니처에 optional 파라미터 추가. 기존 테스트 호환
+- [x] D4: TDD Red 파일 목록 위에 기술됨
+
+## §6 import 추가 필요
+
+```typescript
+// discovery-stage-runner.ts에 추가
+import { ProposalRubric } from "../../agent/services/proposal-rubric.js";
+```

--- a/packages/api/src/__tests__/integration/meta-agent-full-loop.test.ts
+++ b/packages/api/src/__tests__/integration/meta-agent-full-loop.test.ts
@@ -272,3 +272,52 @@ describe("F533 MetaAgent Full Loop Integration", () => {
     expect(applyRes.status).toBe(404);
   });
 });
+
+// ─── F544: auto-trigger 경로 integration ─────────────────────────────────────
+describe("F544: autoTriggerMetaAgent integration — auto 경로 proposals 저장", () => {
+  let db: D1Database;
+
+  beforeEach(async () => {
+    setupFetchMock();
+    const mockDb = createMockD1();
+    await mockDb.exec(DDL_METRICS);
+    await mockDb.exec(DDL_PROPOSALS);
+    await mockDb.exec(DDL_MARKETPLACE);
+    await mockDb.exec(DDL_COMPARISONS);
+    db = mockDb as unknown as D1Database;
+  });
+
+  it("stage-runner 패턴 메트릭 존재 시 autoTriggerMetaAgent → proposals > 0 + rubric_score NOT NULL", async () => {
+    const bizItemId = "biz-item-integration-f544";
+    const sessionId = `graph-${bizItemId}-9999`;
+
+    // stage-runner 패턴으로 메트릭 삽입 (Graph 실행 시뮬레이션)
+    await db.prepare(
+      `INSERT INTO agent_run_metrics
+       (id, session_id, agent_id, status, rounds, stop_reason, input_tokens, output_tokens, started_at, created_at)
+       VALUES (?, ?, 'discovery-stage-runner', 'completed', 12, 'end_turn', 80000, 0, datetime('now'), datetime('now'))`
+    ).bind("int-1", `stage-2-1-${bizItemId}`).run();
+
+    const { autoTriggerMetaAgent } = await import(
+      "../../core/discovery/routes/discovery-stage-runner.js"
+    );
+
+    await autoTriggerMetaAgent(db, sessionId, "test-key", bizItemId, "claude-sonnet-4-6");
+
+    const result = await db
+      .prepare("SELECT COUNT(*) as cnt FROM agent_improvement_proposals WHERE session_id = ?")
+      .bind(sessionId)
+      .first<{ cnt: number }>();
+
+    // K1: proposals ≥ 1건 저장 확인
+    expect(result?.cnt).toBeGreaterThan(0);
+
+    const rubricRow = await db
+      .prepare("SELECT rubric_score FROM agent_improvement_proposals WHERE session_id = ? LIMIT 1")
+      .bind(sessionId)
+      .first<{ rubric_score: number | null }>();
+
+    // K2: rubric_score 저장 확인 (manual 경로와 동일)
+    expect(rubricRow?.rubric_score).not.toBeNull();
+  });
+});

--- a/packages/api/src/__tests__/services/meta-agent-auto-trigger.test.ts
+++ b/packages/api/src/__tests__/services/meta-agent-auto-trigger.test.ts
@@ -1,4 +1,5 @@
 // F536: MetaAgent 자동 진단 훅 — TDD Red Phase
+// F544: auto-trigger 저장 경로 복구 — bizItemId + rubricScore 테스트 추가
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { D1Database } from "@cloudflare/workers-types";
 import { createMockD1 } from "../helpers/mock-d1.js";
@@ -186,5 +187,127 @@ describe("F536: MetaAgent 자동 진단 훅", () => {
       { emit: vi.fn(), subscribe: vi.fn() },
       db,
     )).not.toThrow();
+  });
+
+  // ─── F544: bizItemId 기반 집계 + rubricScore 저장 ───────────────────────────
+
+  it("F544: autoTriggerMetaAgent — bizItemId 제공 시 stage-runner 메트릭으로 집계", async () => {
+    const bizItemId = "biz-item-f544-001";
+    const sessionId = `graph-${bizItemId}-123456`;
+
+    // stage-runner 패턴으로 metrics 삽입
+    await (db as unknown as ReturnType<typeof createMockD1>).prepare(
+      `INSERT INTO agent_run_metrics
+       (id, session_id, agent_id, status, rounds, stop_reason, input_tokens, output_tokens, started_at, created_at)
+       VALUES (?, ?, 'discovery-stage-runner', 'completed', 8, 'end_turn', 50000, 0, datetime('now'), datetime('now'))`
+    ).bind("mf1", `stage-2-1-${bizItemId}`).run();
+
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        content: [{ type: "text", text: JSON.stringify([{
+          type: "prompt",
+          title: "F544 test proposal",
+          reasoning: "Cost axis score is 0 due to high tokens",
+          yamlDiff: "- model: claude-opus\n+ model: claude-haiku",
+        }]) }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 100, output_tokens: 50 },
+      }),
+    }));
+
+    const { autoTriggerMetaAgent } = await import(
+      "../../core/discovery/routes/discovery-stage-runner.js"
+    );
+
+    await autoTriggerMetaAgent(db, sessionId, "test-api-key", bizItemId);
+
+    const row = await db
+      .prepare("SELECT * FROM agent_improvement_proposals WHERE session_id = ?")
+      .bind(sessionId)
+      .first<Record<string, unknown>>();
+
+    expect(row).not.toBeNull();
+    expect(row?.status).toBe("pending");
+  });
+
+  it("F544: autoTriggerMetaAgent — 저장 시 rubric_score가 NULL이 아님 (경로 단일화)", async () => {
+    const bizItemId = "biz-item-f544-rubric";
+    const sessionId = `graph-${bizItemId}-rubric`;
+
+    await (db as unknown as ReturnType<typeof createMockD1>).prepare(
+      `INSERT INTO agent_run_metrics
+       (id, session_id, agent_id, status, rounds, stop_reason, input_tokens, output_tokens, started_at, created_at)
+       VALUES (?, ?, 'discovery-stage-runner', 'completed', 10, 'end_turn', 99999, 0, datetime('now'), datetime('now'))`
+    ).bind("mf3", `stage-2-1-${bizItemId}`).run();
+
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        content: [{ type: "text", text: JSON.stringify([{
+          type: "prompt",
+          title: "F544 rubric test",
+          reasoning: "Cost score is very low because input tokens are too high",
+          yamlDiff: "- model: claude-opus-4-6\n+ model: claude-haiku-4-5-20251001",
+        }]) }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 100, output_tokens: 50 },
+      }),
+    }));
+
+    const { autoTriggerMetaAgent } = await import(
+      "../../core/discovery/routes/discovery-stage-runner.js"
+    );
+
+    await autoTriggerMetaAgent(db, sessionId, "test-api-key", bizItemId);
+
+    const row = await db
+      .prepare("SELECT rubric_score FROM agent_improvement_proposals WHERE session_id = ?")
+      .bind(sessionId)
+      .first<{ rubric_score: number | null }>();
+
+    expect(row).not.toBeNull();
+    // F544: rubric_score는 반드시 설정돼야 함 (null이면 저장 경로 불일치)
+    expect(row?.rubric_score).not.toBeNull();
+    expect(typeof row?.rubric_score).toBe("number");
+  });
+
+  it("F544: autoTriggerMetaAgent — metaAgentModel 파라미터가 MetaAgent에 전달됨", async () => {
+    const bizItemId = "biz-item-f544-model";
+    const sessionId = `graph-${bizItemId}-model`;
+
+    await (db as unknown as ReturnType<typeof createMockD1>).prepare(
+      `INSERT INTO agent_run_metrics
+       (id, session_id, agent_id, status, rounds, stop_reason, input_tokens, output_tokens, started_at, created_at)
+       VALUES (?, ?, 'discovery-stage-runner', 'completed', 5, 'end_turn', 60000, 0, datetime('now'), datetime('now'))`
+    ).bind("mf4", `stage-2-1-${bizItemId}`).run();
+
+    let capturedModel: string | undefined;
+    vi.stubGlobal("fetch", vi.fn().mockImplementation(async (_url: string, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(init.body as string) as { model?: string } : {};
+      capturedModel = body.model;
+      return {
+        ok: true,
+        json: async () => ({
+          content: [{ type: "text", text: JSON.stringify([{
+            type: "prompt",
+            title: "model test",
+            reasoning: "test reason because score low",
+            yamlDiff: "- x: a\n+ x: b",
+          }]) }],
+          stop_reason: "end_turn",
+          usage: { input_tokens: 50, output_tokens: 20 },
+        }),
+      };
+    }));
+
+    const { autoTriggerMetaAgent } = await import(
+      "../../core/discovery/routes/discovery-stage-runner.js"
+    );
+
+    await autoTriggerMetaAgent(db, sessionId, "test-api-key", bizItemId, "claude-haiku-4-5-20251001");
+
+    // F544: metaAgentModel 파라미터가 실제 fetch 호출 model에 반영돼야 함
+    expect(capturedModel).toBe("claude-haiku-4-5-20251001");
   });
 });

--- a/packages/api/src/core/discovery/routes/discovery-stage-runner.ts
+++ b/packages/api/src/core/discovery/routes/discovery-stage-runner.ts
@@ -13,19 +13,22 @@ import { DiscoveryGraphService } from "../services/discovery-graph-service.js";
 import { DiagnosticCollector } from "../../agent/services/diagnostic-collector.js";
 import { MetaAgent } from "../../agent/services/meta-agent.js";
 import { MetaApprovalService } from "../../agent/services/meta-approval.js";
+import { ProposalRubric } from "../../agent/services/proposal-rubric.js";
 import type { DiscoveryType } from "../services/analysis-path-v82.js";
 import { GraphSessionService } from "../services/graph-session-service.js";
 
 /**
- * F536: MetaAgent 자동 진단 훅 — Graph 실행 완료 후 자동 호출.
+ * F536/F544: MetaAgent 자동 진단 훅 — Graph 실행 완료 후 자동 호출.
  * DiagnosticReport를 수집하여 score < 70 축에 대한 ImprovementProposal을 저장한다.
- * 에러 발생 시 조용히 처리 (fire-and-forget 호출처에서 .catch 처리).
+ * F544: rubricScore 포함 저장(manual 경로와 동일), metaAgentModel 파라미터 추가.
+ * 에러 발생 시 조용히 처리 (호출처에서 .catch 처리).
  */
 export async function autoTriggerMetaAgent(
   db: D1Database,
   sessionId: string,
   apiKey: string,
   bizItemId?: string,
+  metaAgentModel?: string,
 ): Promise<void> {
   const collector = new DiagnosticCollector(db);
   // F537: bizItemId 제공 시 biz_item 기반 집계. 아니면 legacy collect.
@@ -33,30 +36,36 @@ export async function autoTriggerMetaAgent(
     ? await collector.collectByBizItem(bizItemId, sessionId)
     : await collector.collect(sessionId, "discovery-graph");
 
-  const metaAgent = new MetaAgent({ apiKey });
+  console.log("[F544] autoTrigger start", {
+    sessionId,
+    bizItemId: bizItemId ?? "none",
+    overallScore: report.overallScore,
+  });
+
+  // F544: metaAgentModel 파라미터로 모델 통일 (default: claude-sonnet-4-6)
+  const model = metaAgentModel ?? "claude-sonnet-4-6";
+  const metaAgent = new MetaAgent({ apiKey, model });
   let proposals;
   try {
     proposals = await metaAgent.diagnose(report);
   } catch (e) {
-    console.error("[F536] MetaAgent.diagnose failed:", e);
+    console.error("[F544] MetaAgent.diagnose failed:", e);
     return;
   }
 
+  console.log("[F544] autoTrigger diagnose result", { proposalsCount: proposals.length });
+
   if (proposals.length === 0) return;
 
+  // F544: rubricScore 포함 저장 — manual path(/api/meta/diagnose)와 동일 경로
+  const rubric = new ProposalRubric();
   const approvalService = new MetaApprovalService(db);
   for (const proposal of proposals) {
-    await approvalService.save({
-      id: proposal.id,
-      sessionId: proposal.sessionId,
-      agentId: proposal.agentId,
-      type: proposal.type,
-      title: proposal.title,
-      reasoning: proposal.reasoning,
-      yamlDiff: proposal.yamlDiff,
-      status: "pending",
-    });
+    const rubricScore = rubric.score(proposal);
+    await approvalService.save({ ...proposal, rubricScore, status: "pending" });
   }
+
+  console.log("[F544] autoTrigger saved", { saved: proposals.length, sessionId });
 }
 
 const StageRunSchema = z.object({
@@ -260,10 +269,15 @@ discoveryStageRunnerRoute.post("/biz-items/:id/discovery-graph/run-all", async (
       feedback: parsed.data.feedback,
     });
     await sessionService.updateStatus(sessionId, "completed");
-    // F536+F537: MetaAgent 자동 진단 훅 — bizItemId 기반 집계 (fire-and-forget)
-    void autoTriggerMetaAgent(c.env.DB, sessionId, apiKey, bizItemId).catch((e) =>
-      console.error("[F536] MetaAgent auto-trigger failed:", e)
-    );
+    // F544: waitUntil로 Workers 응답 후에도 완료 보장 (void fire-and-forget → 컨텍스트 종료 위험 해소)
+    const triggerTask = autoTriggerMetaAgent(
+      c.env.DB, sessionId, apiKey, bizItemId, c.env.META_AGENT_MODEL,
+    ).catch((e) => console.error("[F544] MetaAgent auto-trigger failed:", e));
+    try {
+      c.executionCtx.waitUntil(triggerTask);
+    } catch {
+      // non-Worker 환경(테스트 등)에서는 waitUntil 없음 — fire-and-forget fallback
+    }
     return c.json({ sessionId, status: "completed", result });
   } catch (e) {
     const message = e instanceof Error ? e.message : "Graph run failed";


### PR DESCRIPTION
## Summary

- **F544**: Graph 완료 시 `autoTriggerMetaAgent`가 `agent_improvement_proposals`에 저장하지 않는 버그 수정 (C65 승격)
- 근본 원인 3가지 해소: Workers `waitUntil` 누락 / `rubricScore` 미포함 / 모델 미지정

## 변경 내용

### Bug Fixes
- `c.executionCtx.waitUntil()` 적용 — `void` fire-and-forget에서 Workers 응답 후 컨텍스트 종료 위험 해소
- `ProposalRubric.score()` 추가 — manual path(`/api/meta/diagnose`)와 저장 경로 단일화 (rubric_score 포함)
- `metaAgentModel` 파라미터 추가 — `META_AGENT_MODEL` env var 연동 (F542 패턴 통일)
- 구조 로깅 추가 — `[F544]` 태그로 sessionId/bizItemId/proposalsCount 트레이스 가능

### Tests Added
- `meta-agent-auto-trigger.test.ts`: F544 케이스 3개 (bizItemId 집계 / rubric_score NOT NULL / metaAgentModel 전달)
- `meta-agent-full-loop.test.ts`: Integration test — auto-trigger 경로 proposals > 0 + rubric_score 검증

## Gap Analysis
- Match Rate: **93%** (>= 90% PASS)

## Test Plan
- [ ] `pnpm vitest run src/__tests__/services/meta-agent-auto-trigger.test.ts` → 8 PASS
- [ ] `pnpm vitest run src/__tests__/integration/meta-agent-full-loop.test.ts` → 9 PASS
- [ ] CI typecheck PASS
- [ ] Dogfood P3: KOAMI Graph 실행 후 auto-trigger proposals ≥ 1건 실측

🤖 Generated with [Claude Code](https://claude.com/claude-code)