### PR TITLE
[C63] fix(ci): msa-lint에 @foundry-x/shared 선빌드 추가

### DIFF
--- a/.github/workflows/msa-lint.yml
+++ b/.github/workflows/msa-lint.yml
@@ -26,6 +26,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Build shared (dependency of api)
+        run: pnpm --filter @foundry-x/shared build
+
       - name: Build ESLint rules plugin
         run: pnpm --filter @foundry-x/api build
 


### PR DESCRIPTION
## Summary

F536/F537/F542/F543/F544 **5연속** msa-lint 실패 관찰(signal 오염 원인) 해소.

## 근본 원인
`pnpm --filter @foundry-x/api build`가 `@foundry-x/shared` 모듈을 의존하나, workflow가 shared를 먼저 빌드하지 않아 tsc가 `@foundry-x/shared` 경로 해석에 실패.

## 변경
`.github/workflows/msa-lint.yml`에 shared 선빌드 step 1개 추가 (3 lines).

## Test Plan
- [ ] 이 PR 자체의 msa-lint CI가 pass하는지 확인
- [ ] 후속 MSA 관련 PR(F538 등)에서 동일 실패 재발 없는지 관찰

🤖 Generated with [Claude Code](https://claude.com/claude-code)