### PR TITLE
[hotfix] deploy-msa가 workspace:* 미지원으로 실패 → raw pnpm deploy로 우회

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -157,16 +157,18 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      # wrangler-action v3 default로 npm install 돌려 workspace:* 미지원 오류 발생.
+      # pnpm으로 이미 설치된 node_modules 재사용 위해 raw wrangler deploy.
       - name: Deploy fx-discovery Worker
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          workingDirectory: packages/fx-discovery
+        working-directory: packages/fx-discovery
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: pnpm exec wrangler deploy
       - name: Deploy fx-gateway Worker
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          workingDirectory: packages/fx-gateway
+        working-directory: packages/fx-gateway
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: pnpm exec wrangler deploy
 
   smoke-test:
     if: |


### PR DESCRIPTION
## Summary

F538 merge 후 fx-discovery worker 프로덕션 배포 실패 → `/api/discovery/progress` 등 3 routes **404** 관찰. 원인 규명 및 수정.

## 근본 원인

`cloudflare/wrangler-action@v3`는 default로 `npm install`을 실행하는데, fx-discovery/fx-gateway의 package.json에 `"@foundry-x/shared": "workspace:*"`가 있어 npm이 workspace 프로토콜 해석 실패 (`EUNSUPPORTEDPROTOCOL`).

## 타임라인

1. **F538 PR #588 merge (`49d97259`)** — test FAIL(obsolete test 파편) → deploy 전부 skip
2. **Hotfix PR #589 (`6dc8708f`)** — test FIX → deploy-api/web success, deploy-msa SKIP(path filter 매칭 X)
3. **workflow_dispatch 재실행 (run 24427351190)** — deploy-msa 첫 실행 → **FAIL** (workspace:* 오류)

## 해결

`wrangler-action` 대신 raw `pnpm exec wrangler deploy` 사용. 이미 job 시작 시 `pnpm install --frozen-lockfile`로 workspace deps 설치됨.

## Test Plan
- [ ] 이 PR 머지 → deploy-msa 성공 확인
- [ ] Smoke: `curl /api/discovery/progress/summary` 200 (F538 routes 실제 반영)
- [ ] Smoke: `curl /api/ax-bd/discovery-report/bi-koami-001` 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)