### PR TITLE
[hotfix] deploy-msa wrangler 미해결 — api의 wrangler 상대 경로 호출

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -157,18 +157,18 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      # wrangler-action v3 default로 npm install 돌려 workspace:* 미지원 오류 발생.
-      # pnpm으로 이미 설치된 node_modules 재사용 위해 raw wrangler deploy.
+      # wrangler는 packages/api에만 devDependency. 다른 패키지에서는 `pnpm exec` 미해결.
+      # → 상대 경로로 packages/api의 wrangler 직접 호출.
       - name: Deploy fx-discovery Worker
         working-directory: packages/fx-discovery
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        run: pnpm exec wrangler deploy
+        run: ../api/node_modules/.bin/wrangler deploy
       - name: Deploy fx-gateway Worker
         working-directory: packages/fx-gateway
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        run: pnpm exec wrangler deploy
+        run: ../api/node_modules/.bin/wrangler deploy
 
   smoke-test:
     if: |


### PR DESCRIPTION
## Summary

PR #590 이후 deploy-msa가 `Command "wrangler" not found` 오류로 실패. wrangler가 packages/api에만 있어 fx-discovery 컨텍스트 pnpm exec 미해결.

## Fix
`pnpm exec wrangler deploy` → `../api/node_modules/.bin/wrangler deploy`

## Test Plan
- [ ] 이 PR merge 후 deploy-msa 성공 확인
- [ ] F538 routes Smoke: /api/discovery/progress/summary 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)