### PR TITLE
fix(velocity): C67 — record-sprint.sh signal 파일 fallback 추가

### DIFF
--- a/docs/metrics/velocity/sprint-293.json
+++ b/docs/metrics/velocity/sprint-293.json
@@ -1,11 +1,11 @@
 {
   "sprint": 293,
   "phase": 44,
-  "f_items": "",
-  "f_count": 0,
-  "match_rate": null,
+  "f_items": "F538",
+  "f_count": 1,
+  "match_rate": 95,
   "duration_minutes": 0,
-  "test_result": "unknown",
-  "created": "2026-04-15T07:52:57+09:00",
-  "recorded_at": "2026-04-15T07:52:57+09:00"
+  "test_result": "pass",
+  "created": "2026-04-15T07:52:49+09:00",
+  "recorded_at": "2026-04-15T10:55:15+09:00"
 }

--- a/scripts/test-velocity-signal-fallback.sh
+++ b/scripts/test-velocity-signal-fallback.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# C67 — record-sprint.sh signal fallback 테스트
+# TDD Red→Green: 3가지 케이스 검증
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RECORD="$SCRIPT_DIR/velocity/record-sprint.sh"
+PASS=0
+FAIL=0
+
+ok()   { echo "  ✅ $*"; PASS=$((PASS+1)); }
+fail() { echo "  ❌ FAIL: $*"; FAIL=$((FAIL+1)); }
+
+assert_eq() {
+  local label="$1" got="$2" want="$3"
+  if [ "$got" = "$want" ]; then ok "$label = $want"
+  else fail "$label: got='$got' want='$want'"; fi
+}
+
+assert_ne() {
+  local label="$1" got="$2" unwant="$3"
+  if [ "$got" != "$unwant" ]; then ok "$label != '$unwant' (got '$got')"
+  else fail "$label: should not be '$unwant'"; fi
+}
+
+# --- 공통 임시 환경 설정 ---
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+SIG_DIR="$TMP_DIR/sprint-signals"
+mkdir -p "$SIG_DIR"
+OUT_DIR="$TMP_DIR/docs/metrics/velocity"
+mkdir -p "$OUT_DIR"
+
+# 테스트용 git repo (duration_minutes 계산용)
+git -C "$TMP_DIR" init -q
+git -C "$TMP_DIR" config user.email "test@test.com"
+git -C "$TMP_DIR" config user.name "Test"
+touch "$TMP_DIR/README.md"
+git -C "$TMP_DIR" add README.md
+git -C "$TMP_DIR" commit -q -m "init"
+
+run_record() {
+  local sprint_num="$1"
+  cd "$TMP_DIR"
+  SIGNAL_DIR="$SIG_DIR" bash "$RECORD" "$sprint_num" 2>&1 || true
+}
+
+read_json() {
+  local file="$1" key="$2"
+  (grep -oP "\"${key}\"\\s*:\\s*\\K(\"[^\"]*\"|null|[0-9]+)" "$file" 2>/dev/null || echo "") | head -1 | tr -d '"'
+}
+
+# ========================================================
+# Case 1: .sprint-context 없고 signal만 있을 때
+# ========================================================
+echo ""
+echo "Case 1: signal 파일만 있을 때 → signal 값 반영"
+
+cat > "$SIG_DIR/Foundry-X-900.signal" <<SIG
+STATUS=MERGED
+SPRINT_NUM=900
+PROJECT=Foundry-X
+F_ITEMS=F900
+BRANCH=sprint/900
+MATCH_RATE=92
+TEST_RESULT=pass
+TIMESTAMP=2026-04-01T10:00:00+09:00
+MERGED_AT=2026-04-01T01:00:00Z
+SIG
+
+run_record 900 >/dev/null
+
+JSON900="$OUT_DIR/sprint-900.json"
+assert_eq "f_items"    "$(read_json "$JSON900" f_items)"    "F900"
+assert_eq "match_rate" "$(read_json "$JSON900" match_rate)" "92"
+assert_eq "test_result" "$(read_json "$JSON900" test_result)" "pass"
+assert_ne "created"    "$(read_json "$JSON900" created)"    ""
+
+# ========================================================
+# Case 2: .sprint-context 우선 (.sprint-context + signal 둘 다)
+# ========================================================
+echo ""
+echo "Case 2: .sprint-context 있으면 우선 적용"
+
+cat > "$SIG_DIR/Foundry-X-901.signal" <<SIG
+STATUS=MERGED
+SPRINT_NUM=901
+F_ITEMS=F_SIGNAL
+MATCH_RATE=50
+TEST_RESULT=fail
+TIMESTAMP=2026-04-02T10:00:00+09:00
+SIG
+
+cat > "$TMP_DIR/.sprint-context" <<CTX
+SPRINT_NUM=901
+F_ITEMS=F_CTX
+MATCH_RATE=99
+TEST_RESULT=pass
+CREATED=2026-04-02T08:00:00+09:00
+CTX
+
+run_record 901 >/dev/null
+
+JSON901="$OUT_DIR/sprint-901.json"
+assert_eq "f_items (ctx wins)"    "$(read_json "$JSON901" f_items)"    "F_CTX"
+assert_eq "match_rate (ctx wins)" "$(read_json "$JSON901" match_rate)" "99"
+assert_eq "test_result (ctx wins)" "$(read_json "$JSON901" test_result)" "pass"
+
+rm "$TMP_DIR/.sprint-context"
+
+# ========================================================
+# Case 3: 둘 다 없으면 empty/unknown (기존 동작 보존)
+# ========================================================
+echo ""
+echo "Case 3: .sprint-context도 signal도 없으면 empty/unknown"
+
+run_record 902 >/dev/null
+
+JSON902="$OUT_DIR/sprint-902.json"
+assert_eq "f_items empty"      "$(read_json "$JSON902" f_items)"    ""
+assert_eq "test_result unknown" "$(read_json "$JSON902" test_result)" "unknown"
+
+# ========================================================
+# 결과 요약
+# ========================================================
+echo ""
+echo "========================================"
+echo "결과: PASS=$PASS  FAIL=$FAIL"
+echo "========================================"
+[ "$FAIL" -eq 0 ]

--- a/scripts/velocity/record-sprint.sh
+++ b/scripts/velocity/record-sprint.sh
@@ -22,11 +22,29 @@ read_ctx() {
   (grep "^${key}=" "$CTX" 2>/dev/null || true) | cut -d= -f2- | head -1
 }
 
+# Signal 파일에서 key=value 읽기 — .sprint-context 부재 시 fallback
+SIGNAL_DIR="${SIGNAL_DIR:-/tmp/sprint-signals}"
+SIGNAL_FILE=""
+for candidate in "${SIGNAL_DIR}"/*-"${SPRINT_NUM}".signal; do
+  [ -f "$candidate" ] && SIGNAL_FILE="$candidate" && break
+done
+
+read_signal() {
+  local key="$1"
+  [ -f "$SIGNAL_FILE" ] || { echo ""; return; }
+  (grep "^${key}=" "$SIGNAL_FILE" 2>/dev/null || true) | cut -d= -f2- | head -1
+}
+
 F_ITEMS=$(read_ctx F_ITEMS)
+[ -z "$F_ITEMS" ] && F_ITEMS=$(read_signal F_ITEMS)
 MATCH_RATE=$(read_ctx MATCH_RATE)
+[ -z "$MATCH_RATE" ] && MATCH_RATE=$(read_signal MATCH_RATE)
 TEST_RESULT=$(read_ctx TEST_RESULT)
+[ -z "$TEST_RESULT" ] && TEST_RESULT=$(read_signal TEST_RESULT)
 [ -z "$TEST_RESULT" ] && TEST_RESULT="unknown"
 CREATED=$(read_ctx CREATED)
+# Signal의 TIMESTAMP(session-end 실행 시각)을 CREATED fallback으로 사용
+[ -z "$CREATED" ] && CREATED=$(read_signal TIMESTAMP)
 [ -z "$CREATED" ] && CREATED=$(date -Iseconds)
 
 # duration_minutes: Sprint 브랜치 첫 커밋 ~ 마지막 커밋 간 경과


### PR DESCRIPTION
## Summary

- `record-sprint.sh`가 `.sprint-context` 파일만 참조하여 Master 환경에서 호출 시 velocity 메트릭이 전부 empty로 기록되는 문제 수정
- `/tmp/sprint-signals/Foundry-X-NNN.signal`에서 F_ITEMS/MATCH_RATE/TEST_RESULT/TIMESTAMP를 fallback으로 읽는 `read_signal()` 함수 추가
- Sprint 293 소급 갱신: f_items=F538, match_rate=95, test_result=pass

## Test plan
- [x] `bash scripts/test-velocity-signal-fallback.sh` — 9 assertions PASS
  - Case 1: signal만 있으면 signal 값 반영
  - Case 2: .sprint-context + signal 둘 다 있으면 .sprint-context 우선
  - Case 3: 둘 다 없으면 empty/unknown (기존 동작 보존)

🤖 Generated with [Claude Code](https://claude.com/claude-code)