### PR TITLE
feat(msa): F539c — 7 routes to fx-discovery via Service Binding (FX-REQ-578)

### DIFF
--- a/docs/01-plan/features/sprint-296.plan.md
+++ b/docs/01-plan/features/sprint-296.plan.md
@@ -1,0 +1,101 @@
+---
+id: FX-PLAN-sprint-296
+feature: F539c — 7 라우트 Service Binding 이전 + CLI URL 전환 흡수
+sprint: 296
+date: 2026-04-15
+status: active
+req: FX-REQ-578
+prd: docs/specs/fx-gateway-cutover/prd-final.md
+---
+
+# Sprint 296 Plan — F539c
+
+## 목표
+
+F538 이월 7 라우트를 fx-discovery Service Binding 호출로 이전하고,
+F539b 이월 2건(CLI URL 전환 + KOAMI Smoke Reality)을 흡수한다.
+
+## 전제 조건
+
+- F539a ✅ (k6 GO 판정, Sprint 294)
+- F539b ✅ 부분 (fx-gateway 프로덕션 배포 + VITE_API_URL 전환, Sprint 295 PR #596)
+- VITE_API_URL = `https://fx-gateway.ktds-axbd.workers.dev/api` (이미 완료)
+- fx-gateway 라우팅: discovery/ax-bd/discovery-report → fx-discovery, 나머지 → MAIN_API
+
+## 현재 상태 (as-is)
+
+| 항목 | 상태 |
+|------|------|
+| fx-gateway 프로덕션 배포 | ✅ |
+| VITE_API_URL (web) | ✅ fx-gateway |
+| CLI URL 전환 | ❌ packages/cli에 API URL 없음 (조사 완료 — CLI는 REST API 미호출) |
+| scripts/*.sh 기본 URL | ❌ foundry-x-api.ktds-axbd.workers.dev 하드코딩 |
+| smoke.spec.ts PROD_API_URL | ❌ 구 URL 하드코딩 |
+| biz-items 3 라우트 → fx-discovery | ❌ fx-gateway 미등록 |
+| discovery-stages 2 라우트 → fx-discovery | ❌ fx-gateway 미등록 |
+| discovery-pipeline GET 2 라우트 → fx-discovery | ❌ fx-gateway 미등록 |
+| F539b KOAMI Smoke Reality | ❌ 미실행 |
+
+## 작업 목록
+
+### CLI URL 전환 (F539b 이월 — T0)
+
+| # | 작업 | 파일 |
+|---|------|------|
+| T0a | scripts/*.sh 기본 URL 전환 (foundry-x-api → fx-gateway) | scripts/seed-discovery-reports.sh, session-collector.sh, skill-demo-seed.sh, sf-scan-register.sh, usage-tracker-hook.sh, task-daemon.sh, feedback-consumer.sh |
+| T0b | e2e/prod/smoke.spec.ts API_URL 기본값 전환 | packages/web/e2e/prod/smoke.spec.ts |
+| T0c | packages/cli URL 전환 → N/A 결론 (CLI는 REST API 미호출) | docs/04-report에 기록 |
+
+### Group A (PR1: bizItems 3 라우트)
+
+| # | 작업 | 파일 | TDD |
+|---|------|------|-----|
+| T1 | fx-discovery에 BizItemService CRUD 서브셋 추가 | fx-discovery/src/services/biz-item-full.service.ts | N/A |
+| T2 | fx-discovery에 CreateBizItemSchema 추가 | fx-discovery/src/schemas/biz-item.ts | N/A |
+| T3 | fx-discovery에 biz-items 3 라우트 추가 (GET list, POST create, GET :id) | fx-discovery/src/routes/biz-items.ts | Red→Green |
+| T4 | fx-discovery app.ts에 biz-items 라우트 마운트 | fx-discovery/src/app.ts | N/A |
+| T5 | fx-gateway: 3개 특정 패턴 → DISCOVERY 라우팅 추가 | fx-gateway/src/app.ts | 기존 게이트웨이 테스트 보완 |
+| T6 | packages/api biz-items.ts에서 3 라우트 정의 제거 | packages/api/src/core/discovery/routes/biz-items.ts | N/A |
+| T7 | KOAMI Smoke Reality PR1 검증 | — | 수동 |
+
+### Group B (PR2: discoveryPipeline/stages 4 라우트)
+
+| # | 작업 | 파일 | TDD |
+|---|------|------|-----|
+| T8 | fx-discovery에 DiscoveryStageService 이전 | fx-discovery/src/services/discovery-stage.service.ts | N/A |
+| T9 | fx-discovery에 discovery-stage 스키마 추가 | fx-discovery/src/schemas/discovery-stage.ts | N/A |
+| T10 | fx-discovery에 discovery-stages 2 라우트 추가 | fx-discovery/src/routes/discovery-stages.ts | Red→Green |
+| T11 | fx-discovery에 DiscoveryPipelineReadService 추가 (listRuns, getRun - read-only) | fx-discovery/src/services/discovery-pipeline-read.service.ts | N/A |
+| T12 | fx-discovery에 discovery-pipeline 2 GET 라우트 추가 | fx-discovery/src/routes/discovery-pipeline.ts | Red→Green |
+| T13 | fx-discovery app.ts에 2 라우트 파일 마운트 | fx-discovery/src/app.ts | N/A |
+| T14 | fx-gateway: 4개 패턴 → DISCOVERY 라우팅 추가 | fx-gateway/src/app.ts | 기존 테스트 보완 |
+| T15 | packages/api에서 4 라우트 정의 제거 (stages.ts 2개, pipeline.ts 2개) | packages/api/src/core/discovery/routes/discovery-stages.ts, discovery-pipeline.ts | N/A |
+| T16 | KOAMI Smoke Reality PR2 + 통합 검증 (F539b 이월 흡수) | — | 수동 |
+
+### 마무리
+
+| # | 작업 | 파일 |
+|---|------|------|
+| T17 | ESLint no-cross-domain-import 룰 확장 (bizItems → discovery 도메인 고정) | packages/api/src/eslint-rules/index.ts |
+| T18 | Phase 44 f539 회고 작성 (Smoke Reality P1~P4) | docs/04-report/phase-44-f539-retrospective.md |
+
+## 7 라우트 목록 (패턴)
+
+| 그룹 | HTTP | 패턴 | 현재 | 목표 |
+|------|------|------|------|------|
+| A | GET | /api/biz-items | packages/api | fx-discovery |
+| A | POST | /api/biz-items | packages/api | fx-discovery |
+| A | GET | /api/biz-items/:id | packages/api | fx-discovery |
+| B | GET | /api/biz-items/:id/discovery-progress | packages/api | fx-discovery |
+| B | POST | /api/biz-items/:id/discovery-stage | packages/api | fx-discovery |
+| B | GET | /api/discovery-pipeline/runs | packages/api | fx-discovery |
+| B | GET | /api/discovery-pipeline/runs/:id | packages/api | fx-discovery |
+
+## 성공 기준
+
+- fx-gateway에서 7 라우트 모두 DISCOVERY로 라우팅 확인
+- packages/api에서 7 라우트 정의 삭제 완료
+- `grep /api/biz-items.*GET.*POST packages/api/src` = 0
+- `pnpm test` PASS (all packages)
+- KOAMI Smoke Reality: bi-koami-001 Graph 실행 → proposals ≥ 1건
+- Phase 44 F539 회고 완성

--- a/docs/02-design/features/sprint-296.design.md
+++ b/docs/02-design/features/sprint-296.design.md
@@ -1,0 +1,228 @@
+---
+id: FX-DESIGN-sprint-296
+feature: F539c — 7 라우트 Service Binding 이전
+sprint: 296
+date: 2026-04-15
+status: active
+req: FX-REQ-578
+---
+
+# Sprint 296 Design — F539c
+
+## §1 목표
+
+fx-gateway → fx-discovery Service Binding 경로에 7개 라우트 추가.
+biz-items CRUD 3개 + discovery-stages 2개 + discovery-pipeline GET 2개.
+
+## §2 아키텍처 변화 (F539c After)
+
+```
+Browser → fx-gateway (https://fx-gateway.ktds-axbd.workers.dev)
+  ├─ GET  /api/biz-items           → [SB] → fx-discovery  ★신규
+  ├─ POST /api/biz-items           → [SB] → fx-discovery  ★신규
+  ├─ GET  /api/biz-items/:id       → [SB] → fx-discovery  ★신규
+  ├─ GET  /api/biz-items/:id/discovery-progress → [SB] → fx-discovery ★신규
+  ├─ POST /api/biz-items/:id/discovery-stage    → [SB] → fx-discovery ★신규
+  ├─ GET  /api/discovery-pipeline/runs          → [SB] → fx-discovery ★신규
+  ├─ GET  /api/discovery-pipeline/runs/:id      → [SB] → fx-discovery ★신규
+  ├─ /api/discovery/*              → [SB] → fx-discovery  (기존)
+  ├─ /api/ax-bd/discovery-report*  → [SB] → fx-discovery  (기존)
+  └─ /api/* (나머지)               → [SB] → MAIN_API
+```
+
+**핵심 설계 결정**: Hono의 `:id` 파라미터는 단일 경로 세그먼트만 매칭.
+- `GET /api/biz-items/:id` → `/api/biz-items/abc123` ✓, `/api/biz-items/abc123/classify` ✗
+- classify/evaluate 등 나머지 biz-items 서브 라우트는 catch-all → MAIN_API로 자연 fall-through
+
+## §3 D1~D3 체크리스트 (Stage 3 Exit)
+
+### D1: 주입 사이트 전수 검증
+
+| 신규 라우트 | 등록 위치 | 라우팅 위치 |
+|------------|----------|------------|
+| biz-items 3 라우트 | fx-discovery/src/app.ts | fx-gateway/src/app.ts (3 lines) |
+| discovery-stages 2 라우트 | fx-discovery/src/app.ts | fx-gateway/src/app.ts (2 lines) |
+| discovery-pipeline GET 2 라우트 | fx-discovery/src/app.ts | fx-gateway/src/app.ts (2 lines) |
+
+확인 방법: `grep -n "DISCOVERY.fetch" packages/fx-gateway/src/app.ts` = 기존 3 + 신규 7 = 10줄
+
+### D2: 식별자 계약
+
+- **bizItemId 포맷**: 32자 hex (crypto.getRandomValues, biz-item-service.ts 동일 함수)
+  - packages/api `generateId()` = `Uint8Array(16).map(b=>b.toString(16).padStart(2,"0")).join("")`
+  - fx-discovery에 동일 함수 복사 → 포맷 일치 보장
+- **orgId**: JWT tenantGuard가 이미 `c.get("orgId")` 설정 — Service Binding 전파 자동
+- **discovery-stage ID**: 동일 hex 포맷
+
+### D3: Breaking change 영향도
+
+| 변경 | 영향 파일 | 마이그레이션 |
+|------|----------|------------|
+| biz-items 3 라우트 packages/api 제거 | biz-items.ts (나머지 유지) | 없음 — 동일 D1 DB |
+| discovery-stages packages/api 제거 | discovery-stages.ts (전체 제거 가능) | 없음 — 동일 D1 DB |
+| discovery-pipeline GET 2개 제거 | discovery-pipeline.ts (나머지 유지) | 없음 — 동일 D1 DB |
+
+### D4: TDD Red 파일
+
+- `packages/fx-discovery/src/__tests__/biz-items.test.ts` — 3 라우트 Red 커밋
+- `packages/fx-discovery/src/__tests__/discovery-stages.test.ts` — 2 라우트 Red 커밋
+- `packages/fx-discovery/src/__tests__/discovery-pipeline.test.ts` — 2 라우트 Red 커밋
+
+## §4 TDD 테스트 계약
+
+### Group A — biz-items 3 라우트
+
+```typescript
+// packages/fx-discovery/src/__tests__/biz-items.test.ts
+describe("F539c Group A: biz-items 3 라우트", () => {
+  it("GET /api/biz-items → 401 (인증 미적용 시)", async () => {
+    const res = await app.request("/api/biz-items", {}, env);
+    expect([200, 401]).toContain(res.status);
+  });
+  it("POST /api/biz-items → 201 or 401", async () => {
+    const res = await app.request("/api/biz-items", { method: "POST", body: JSON.stringify({ title: "test" }) }, env);
+    expect([201, 400, 401]).toContain(res.status);
+  });
+  it("GET /api/biz-items/:id → 404 or 401 (미존재 ID)", async () => {
+    const res = await app.request("/api/biz-items/nonexistent-id", {}, env);
+    expect([404, 401]).toContain(res.status);
+  });
+  it("GET /api/biz-items/:id/classify → 404 (fx-discovery 미구현 — MAIN_API로 fall-through)", async () => {
+    // fx-discovery에 없는 라우트는 404 응답 (게이트웨이 레이어 검증)
+    const res = await app.request("/api/biz-items/abc/classify", {}, env);
+    expect(res.status).toBe(404);
+  });
+});
+```
+
+### Group B — discovery-stages + pipeline
+
+```typescript
+// packages/fx-discovery/src/__tests__/discovery-stages.test.ts
+describe("F539c Group B: discovery-stages", () => {
+  it("GET /api/biz-items/:id/discovery-progress → 401 or 200", async () => {});
+  it("POST /api/biz-items/:id/discovery-stage → 401 or 400", async () => {});
+});
+
+// packages/fx-discovery/src/__tests__/discovery-pipeline.test.ts
+describe("F539c Group B: discovery-pipeline GET", () => {
+  it("GET /api/discovery-pipeline/runs → 401 or 200", async () => {});
+  it("GET /api/discovery-pipeline/runs/:id → 401 or 404", async () => {});
+});
+```
+
+## §5 파일 매핑 (Worker 매핑)
+
+### A. packages/fx-discovery — 신규/수정 파일
+
+| 파일 | 변경 | 내용 |
+|------|------|------|
+| `src/services/biz-item-full.service.ts` | 신규 | BizItemService.create/list/getById 이전 (순수 D1, cross-domain 의존 없음) |
+| `src/schemas/biz-item.ts` | 신규 | CreateBizItemSchema (z.object title/description/source) |
+| `src/routes/biz-items.ts` | 신규 | 3 라우트 — GET /api/biz-items, POST /api/biz-items, GET /api/biz-items/:id |
+| `src/services/discovery-stage.service.ts` | 신규 | DiscoveryStageService.getProgress/updateStage (순수 D1) |
+| `src/schemas/discovery-stage.ts` | 신규 | DISCOVERY_STAGES 상수 + UpdateDiscoveryStageSchema |
+| `src/routes/discovery-stages.ts` | 신규 | 2 라우트 — GET :id/discovery-progress, POST :id/discovery-stage |
+| `src/services/discovery-pipeline-read.service.ts` | 신규 | listRuns/getRun read-only (FSM 의존 제거, validEvents 단순화) |
+| `src/schemas/discovery-pipeline.ts` | 신규 | listPipelineRunsSchema (status/bizItemId/limit/offset) |
+| `src/routes/discovery-pipeline.ts` | 신규 | 2 GET 라우트 — /runs, /runs/:id |
+| `src/app.ts` | 수정 | 3개 신규 라우트 파일 마운트 (authenticated 그룹에 추가) |
+| `src/__tests__/biz-items.test.ts` | 신규 | TDD Red → Green |
+| `src/__tests__/discovery-stages.test.ts` | 신규 | TDD Red → Green |
+| `src/__tests__/discovery-pipeline.test.ts` | 신규 | TDD Red → Green |
+
+### B. packages/fx-gateway — 수정 파일
+
+| 파일 | 변경 | 내용 |
+|------|------|------|
+| `src/app.ts` | 수정 | 7개 특정 패턴 → DISCOVERY 라우팅 추가 (catch-all 전) |
+| `src/__tests__/gateway.test.ts` | 수정 | 7 라우트 → DISCOVERY 전달 테스트 추가 |
+
+**fx-gateway app.ts 추가 순서** (중요: 특정 패턴이 먼저, catch-all 마지막 유지):
+```typescript
+// F539c Group A: biz-items 3 라우트
+app.get("/api/biz-items", (c) => c.env.DISCOVERY.fetch(c.req.raw));
+app.post("/api/biz-items", (c) => c.env.DISCOVERY.fetch(c.req.raw));
+app.get("/api/biz-items/:id", (c) => c.env.DISCOVERY.fetch(c.req.raw));
+
+// F539c Group B: discovery-stages + pipeline GET
+app.get("/api/biz-items/:id/discovery-progress", (c) => c.env.DISCOVERY.fetch(c.req.raw));
+app.post("/api/biz-items/:id/discovery-stage", (c) => c.env.DISCOVERY.fetch(c.req.raw));
+app.get("/api/discovery-pipeline/runs", (c) => c.env.DISCOVERY.fetch(c.req.raw));
+app.get("/api/discovery-pipeline/runs/:id", (c) => c.env.DISCOVERY.fetch(c.req.raw));
+
+// 기존 catch-all (변경 없음)
+app.all("/api/*", (c) => c.env.MAIN_API.fetch(c.req.raw));
+```
+
+**주의**: `GET /api/biz-items/:id` 와 `GET /api/biz-items/:id/discovery-progress`
+- Hono는 등록 순서 기반이므로 특정 패턴(`/:id/discovery-progress`)을 `:id` 앞에 등록
+- 실제 매칭: `/api/biz-items/abc/discovery-progress` → 4세그먼트이므로 `:id` (3세그먼트)와 불일치 → 자동 올바른 라우팅
+
+### C. packages/api — 수정 파일
+
+| 파일 | 변경 | 내용 |
+|------|------|------|
+| `src/core/discovery/routes/biz-items.ts` | 수정 | `bizItemsRoute.get("/biz-items")`, `bizItemsRoute.post("/biz-items")`, `bizItemsRoute.get("/biz-items/:id")` 3개 handler 제거 |
+| `src/core/discovery/routes/discovery-stages.ts` | 수정 or 삭제 | 2개 handler 제거 (파일 비게 되면 삭제 후 app.ts에서 import 제거) |
+| `src/core/discovery/routes/discovery-pipeline.ts` | 수정 | GET runs, GET runs/:id 2개 handler 제거 |
+| `src/app.ts` | 수정 | discoveryStagesRoute import/mount 제거 (stages 전체 제거 시) |
+
+### D. scripts + web e2e — URL 전환 (F539b 이월)
+
+| 파일 | 변경 |
+|------|------|
+| `scripts/seed-discovery-reports.sh` | 기본 URL: foundry-x-api → fx-gateway |
+| `scripts/session-collector.sh` | 기본 URL 전환 |
+| `scripts/skill-demo-seed.sh` | 기본 URL 전환 |
+| `scripts/sf-scan-register.sh` | 기본 URL 전환 |
+| `scripts/usage-tracker-hook.sh` | 기본 URL 전환 |
+| `scripts/task/task-daemon.sh` | 기본 URL 전환 |
+| `scripts/feedback-consumer.sh` | 기본 URL 전환 |
+| `packages/web/e2e/prod/smoke.spec.ts` | API_URL 기본값 전환 |
+
+### E. ESLint 룰 확장
+
+| 파일 | 변경 |
+|------|------|
+| `packages/api/src/eslint-rules/index.ts` | no-cross-domain-import 룰에 bizItems/biz-items → discovery 도메인 mapping 추가 |
+
+## §6 DiscoveryPipelineReadService 설계 (FSM 의존 제거)
+
+packages/api의 DiscoveryPipelineService는 생성자에서 PipelineStateMachine을 초기화.
+fx-discovery용 Read-Only 서비스는 이 의존을 제거:
+
+```typescript
+// fx-discovery/src/services/discovery-pipeline-read.service.ts
+export class DiscoveryPipelineReadService {
+  constructor(private db: D1Database) {}
+
+  async listRuns(orgId: string, filters: { status?: string; bizItemId?: string; limit: number; offset: number }) {
+    // 순수 D1 SELECT — FSM 불필요
+  }
+
+  async getRun(id: string, orgId: string) {
+    // validEvents 제외 (FSM 불필요) — 클라이언트가 현재 UI에서 미사용
+    // 필요 시 후속 sprint에서 PipelineStateMachine 이전 후 추가
+  }
+}
+```
+
+**tradeoff**: `validEvents` 필드가 getRun 응답에서 누락됨.
+- 현재 Web UI에서 `validEvents`를 UI에 표시하지 않음 (미사용 확인 필요)
+- 확인 필요: `grep -rn "validEvents" packages/web/src/` 결과
+
+## §7 KOAMI Smoke Reality (F539b 이월 + F539c PR1/PR2)
+
+각 PR merge 후 실행:
+```bash
+curl -H "Authorization: Bearer $JWT" \
+  https://fx-gateway.ktds-axbd.workers.dev/api/biz-items
+# → 200 {"items":[...]}
+
+curl -H "Authorization: Bearer $JWT" \
+  https://fx-gateway.ktds-axbd.workers.dev/api/biz-items/bi-koami-001/discovery-progress
+# → 200 {"stages":[...]}
+```
+
+KOAMI Graph 1회 실행 후 proposals ≥ 1건 확인 (Phase 43 P3 Dogfood 재현).

--- a/packages/api/src/__tests__/biz-items.test.ts
+++ b/packages/api/src/__tests__/biz-items.test.ts
@@ -79,6 +79,11 @@ function seedDb(sql: string) {
   (env.DB as any).prepare(sql).run();
 }
 
+// F539c: POST /api/biz-items가 fx-discovery로 이전됨 → 직접 DB 삽입으로 대체
+function seedBizItem(id: string, title: string) {
+  seedDb(`INSERT OR IGNORE INTO biz_items (id, org_id, title, source, status, created_by, created_at, updated_at) VALUES ('${id}', 'org_test', '${title}', 'field', 'draft', 'test-user', datetime('now'), datetime('now'))`);
+}
+
 const BIZ_TABLES_SQL = `
   CREATE TABLE IF NOT EXISTS biz_items (
     id TEXT PRIMARY KEY,
@@ -138,32 +143,12 @@ describe("BizItems Routes", () => {
     authHeader = await createAuthHeaders();
   });
 
-  // ─── POST /api/biz-items ───
-
-  it("POST /api/biz-items: creates a new biz item", async () => {
-    const res = await req("POST", "/api/biz-items", {
-      headers: authHeader,
-      body: { title: "AI 프로세스 마이닝", description: "업무 자동 분석", source: "field" },
-    });
-
-    expect(res.status).toBe(201);
-    const data = (await res.json()) as any;
-    expect(data.title).toBe("AI 프로세스 마이닝");
-    expect(data.status).toBe("draft");
-    expect(data.orgId).toBe("org_test");
-    expect(data.classification).toBeNull();
-  });
-
-  it("POST /api/biz-items: validates required fields", async () => {
-    const res = await req("POST", "/api/biz-items", {
-      headers: authHeader,
-      body: { description: "no title" },
-    });
-
-    expect(res.status).toBe(400);
-  });
+  // ─── POST /api/biz-items: F539c 이전 (fx-discovery에서 테스트) ───
+  // POST /api/biz-items, GET /api/biz-items, GET /api/biz-items/:id 는
+  // fx-discovery로 이전됨 (FX-REQ-578) — packages/fx-discovery/src/__tests__/biz-items.test.ts 참조
 
   it("POST /api/biz-items: unauthorized returns 401", async () => {
+    // auth middleware는 라우트 핸들러 이전에 실행 → 404가 아닌 401 반환
     const res = await req("POST", "/api/biz-items", {
       body: { title: "Unauthorized Item" },
     });
@@ -171,64 +156,12 @@ describe("BizItems Routes", () => {
     expect(res.status).toBe(401);
   });
 
-  // ─── GET /api/biz-items ───
-
-  it("GET /api/biz-items: returns item list for org", async () => {
-    // Create 2 items
-    await req("POST", "/api/biz-items", { headers: authHeader, body: { title: "Item 1" } });
-    await req("POST", "/api/biz-items", { headers: authHeader, body: { title: "Item 2" } });
-
-    const res = await req("GET", "/api/biz-items", { headers: authHeader });
-
-    expect(res.status).toBe(200);
-    const data = (await res.json()) as any;
-    expect(data.items).toHaveLength(2);
-  });
-
-  it("GET /api/biz-items: filters by status", async () => {
-    await req("POST", "/api/biz-items", { headers: authHeader, body: { title: "Draft Item" } });
-
-    const res = await req("GET", "/api/biz-items?status=draft", { headers: authHeader });
-
-    expect(res.status).toBe(200);
-    const data = (await res.json()) as any;
-    expect(data.items.length).toBeGreaterThanOrEqual(1);
-    expect(data.items.every((i: any) => i.status === "draft")).toBe(true);
-  });
-
-  // ─── GET /api/biz-items/:id ───
-
-  it("GET /api/biz-items/:id: returns item detail", async () => {
-    const createRes = await req("POST", "/api/biz-items", {
-      headers: authHeader,
-      body: { title: "Detail Item" },
-    });
-    const { id } = (await createRes.json()) as any;
-
-    const res = await req("GET", `/api/biz-items/${id}`, { headers: authHeader });
-
-    expect(res.status).toBe(200);
-    const data = (await res.json()) as any;
-    expect(data.id).toBe(id);
-    expect(data.title).toBe("Detail Item");
-  });
-
-  it("GET /api/biz-items/:id: returns 404 for non-existent", async () => {
-    const res = await req("GET", "/api/biz-items/nonexistent", { headers: authHeader });
-
-    expect(res.status).toBe(404);
-    const data = (await res.json()) as any;
-    expect(data.error).toBe("BIZ_ITEM_NOT_FOUND");
-  });
-
   // ─── POST /api/biz-items/:id/classify ───
 
   it("POST /api/biz-items/:id/classify: classifies item", async () => {
-    const createRes = await req("POST", "/api/biz-items", {
-      headers: authHeader,
-      body: { title: "XX사 플랫폼 전환" },
-    });
-    const { id } = (await createRes.json()) as any;
+    // F539c: POST /api/biz-items 이전됨 → 직접 DB 삽입
+    const id = "classify-test-1";
+    seedBizItem(id, "XX사 플랫폼 전환");
 
     const res = await req("POST", `/api/biz-items/${id}/classify`, {
       headers: authHeader,
@@ -253,11 +186,9 @@ describe("BizItems Routes", () => {
   });
 
   it("POST /api/biz-items/:id/classify: idempotent — returns cached result on re-classify", async () => {
-    const createRes = await req("POST", "/api/biz-items", {
-      headers: authHeader,
-      body: { title: "Already Classified" },
-    });
-    const { id } = (await createRes.json()) as any;
+    // F539c: POST /api/biz-items 이전됨 → 직접 DB 삽입
+    const id = "classify-idempotent-1";
+    seedBizItem(id, "Already Classified");
 
     // First classify
     const first = await req("POST", `/api/biz-items/${id}/classify`, { headers: authHeader, body: {} });
@@ -275,12 +206,9 @@ describe("BizItems Routes", () => {
   // ─── POST /api/biz-items/:id/evaluate ───
 
   it("POST /api/biz-items/:id/evaluate: evaluates classified item", async () => {
-    // Create + classify
-    const createRes = await req("POST", "/api/biz-items", {
-      headers: authHeader,
-      body: { title: "Evaluate Me" },
-    });
-    const { id } = (await createRes.json()) as any;
+    // F539c: POST /api/biz-items 이전됨 → 직접 DB 삽입 후 classify
+    const id = "evaluate-test-1";
+    seedBizItem(id, "Evaluate Me");
     await req("POST", `/api/biz-items/${id}/classify`, { headers: authHeader, body: {} });
 
     // Evaluate
@@ -297,11 +225,9 @@ describe("BizItems Routes", () => {
   });
 
   it("POST /api/biz-items/:id/evaluate: returns 400 if not classified", async () => {
-    const createRes = await req("POST", "/api/biz-items", {
-      headers: authHeader,
-      body: { title: "Not Classified" },
-    });
-    const { id } = (await createRes.json()) as any;
+    // F539c: POST /api/biz-items 이전됨 → 직접 DB 삽입
+    const id = "evaluate-unclassified-1";
+    seedBizItem(id, "Not Classified");
 
     const res = await req("POST", `/api/biz-items/${id}/evaluate`, {
       headers: authHeader,
@@ -316,12 +242,9 @@ describe("BizItems Routes", () => {
   // ─── GET /api/biz-items/:id/evaluation ───
 
   it("GET /api/biz-items/:id/evaluation: returns evaluation result", async () => {
-    // Create + classify + evaluate
-    const createRes = await req("POST", "/api/biz-items", {
-      headers: authHeader,
-      body: { title: "Full Flow" },
-    });
-    const { id } = (await createRes.json()) as any;
+    // F539c: POST /api/biz-items 이전됨 → 직접 DB 삽입 후 classify+evaluate
+    const id = "evaluation-full-1";
+    seedBizItem(id, "Full Flow");
     await req("POST", `/api/biz-items/${id}/classify`, { headers: authHeader, body: {} });
     await req("POST", `/api/biz-items/${id}/evaluate`, { headers: authHeader, body: {} });
 
@@ -335,11 +258,9 @@ describe("BizItems Routes", () => {
   });
 
   it("GET /api/biz-items/:id/evaluation: returns 404 if no evaluation", async () => {
-    const createRes = await req("POST", "/api/biz-items", {
-      headers: authHeader,
-      body: { title: "No Eval" },
-    });
-    const { id } = (await createRes.json()) as any;
+    // F539c: POST /api/biz-items 이전됨 → 직접 DB 삽입
+    const id = "evaluation-empty-1";
+    seedBizItem(id, "No Eval");
 
     const res = await req("GET", `/api/biz-items/${id}/evaluation`, { headers: authHeader });
 

--- a/packages/api/src/__tests__/discovery-pipeline-route.test.ts
+++ b/packages/api/src/__tests__/discovery-pipeline-route.test.ts
@@ -59,40 +59,8 @@ describe("discovery-pipeline routes (F312+F313)", () => {
     expect(res.status).toBe(400);
   });
 
-  it("GET /discovery-pipeline/runs lists runs", async () => {
-    await post(app, "/api/discovery-pipeline/runs", {
-      bizItemId: "biz-1",
-      triggerMode: "manual",
-    });
-
-    const res = await app.request("/api/discovery-pipeline/runs");
-    expect(res.status).toBe(200);
-
-    const body = await json(res);
-    expect(body.items).toHaveLength(1);
-    expect(body.total).toBe(1);
-  });
-
-  it("GET /discovery-pipeline/runs/:id returns detail", async () => {
-    const createRes = await post(app, "/api/discovery-pipeline/runs", {
-      bizItemId: "biz-1",
-      triggerMode: "manual",
-    });
-    const created = await json(createRes);
-
-    const res = await app.request(`/api/discovery-pipeline/runs/${created.id}`);
-    expect(res.status).toBe(200);
-
-    const body = await json(res);
-    expect(body.id).toBe(created.id);
-    expect(body.events).toBeDefined();
-    expect(body.validEvents).toBeDefined();
-  });
-
-  it("GET /discovery-pipeline/runs/:id returns 404 for unknown", async () => {
-    const res = await app.request("/api/discovery-pipeline/runs/nonexistent");
-    expect(res.status).toBe(404);
-  });
+  // F539c: GET /discovery-pipeline/runs, GET /discovery-pipeline/runs/:id 는
+  // fx-discovery로 이전됨 (FX-REQ-578) — packages/fx-discovery/src/__tests__/discovery-pipeline.test.ts 참조
 
   it("POST /runs/:id/step-complete reports step", async () => {
     const createRes = await post(app, "/api/discovery-pipeline/runs", {

--- a/packages/api/src/core/discovery/routes/biz-items.ts
+++ b/packages/api/src/core/discovery/routes/biz-items.ts
@@ -93,35 +93,8 @@ bizItemsRoute.get("/biz-items/summary", async (c) => {
   return c.json({ items });
 });
 
-// ─── POST /biz-items — 사업 아이템 등록 ───
-
-bizItemsRoute.post("/biz-items", async (c) => {
-  const body = await c.req.json();
-  const parsed = CreateBizItemSchema.safeParse(body);
-  if (!parsed.success) {
-    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
-  }
-
-  const orgId = c.get("orgId");
-  const userId = (c.get("jwtPayload") as Record<string, string> | undefined)?.sub ?? "";
-  const service = new BizItemService(c.env.DB);
-  const item = await service.create(orgId, userId, parsed.data);
-
-  return c.json(item, 201);
-});
-
-// ─── GET /biz-items — 목록 조회 (org 필터) ───
-
-bizItemsRoute.get("/biz-items", async (c) => {
-  const orgId = c.get("orgId");
-  const status = c.req.query("status") || undefined;
-  const source = c.req.query("source") || undefined;
-
-  const service = new BizItemService(c.env.DB);
-  const items = await service.list(orgId, { status, source });
-
-  return c.json({ items });
-});
+// ─── POST /biz-items — 사업 아이템 등록 (F539c: fx-gateway → fx-discovery로 이전) ───
+// ─── GET /biz-items — 목록 조회 (F539c: fx-gateway → fx-discovery로 이전) ───
 
 // ─── GET /biz-items/portfolio-list — 전체 포트폴리오 목록 + coverage (F459, Sprint 224) ───
 // 주의: /biz-items/:id 라우트보다 먼저 등록 필수 (정적 경로 우선)
@@ -162,21 +135,7 @@ bizItemsRoute.get("/biz-items/by-artifact", async (c) => {
   }
 });
 
-// ─── GET /biz-items/:id — 상세 조회 ───
-
-bizItemsRoute.get("/biz-items/:id", async (c) => {
-  const orgId = c.get("orgId");
-  const id = c.req.param("id");
-
-  const service = new BizItemService(c.env.DB);
-  const item = await service.getById(orgId, id);
-
-  if (!item) {
-    return c.json({ error: "BIZ_ITEM_NOT_FOUND" }, 404);
-  }
-
-  return c.json(item);
-});
+// ─── GET /biz-items/:id — 상세 조회 (F539c: fx-gateway → fx-discovery로 이전) ───
 
 // ─── GET /biz-items/:id/shaping-artifacts — 형상화 아티팩트 존재 여부 (S229 P1) ───
 

--- a/packages/api/src/core/discovery/routes/discovery-pipeline.ts
+++ b/packages/api/src/core/discovery/routes/discovery-pipeline.ts
@@ -9,7 +9,6 @@ import { DiscoveryPipelineService } from "../services/discovery-pipeline-service
 import { ShapingOrchestratorService } from "../../shaping/services/shaping-orchestrator-service.js";
 import {
   createPipelineRunSchema,
-  listPipelineRunsSchema,
   stepCompleteSchema,
   stepFailedSchema,
   stepActionSchema,
@@ -48,28 +47,8 @@ discoveryPipelineRoute.post("/discovery-pipeline/runs", async (c) => {
   return c.json(detail, 201);
 });
 
-// 2) GET /discovery-pipeline/runs — 목록 조회
-discoveryPipelineRoute.get("/discovery-pipeline/runs", async (c) => {
-  const parsed = listPipelineRunsSchema.safeParse(c.req.query());
-  if (!parsed.success) {
-    return c.json({ error: "Invalid query", details: parsed.error.flatten() }, 400);
-  }
-
-  const svc = new DiscoveryPipelineService(c.env.DB);
-  const result = await svc.listRuns(c.get("orgId"), parsed.data);
-  return c.json(result);
-});
-
-// 3) GET /discovery-pipeline/runs/:id — 상세 조회
-discoveryPipelineRoute.get("/discovery-pipeline/runs/:id", async (c) => {
-  const svc = new DiscoveryPipelineService(c.env.DB);
-  const detail = await svc.getRun(c.req.param("id"), c.get("orgId"));
-
-  if (!detail) {
-    return c.json({ error: "Pipeline run not found" }, 404);
-  }
-  return c.json(detail);
-});
+// 2) GET /discovery-pipeline/runs — F539c: fx-gateway → fx-discovery로 이전
+// GET /discovery-pipeline/runs/:id — F539c: fx-gateway → fx-discovery로 이전
 
 // 4) POST /discovery-pipeline/runs/:id/step-complete — 단계 완료 보고
 discoveryPipelineRoute.post("/discovery-pipeline/runs/:id/step-complete", async (c) => {

--- a/packages/api/src/core/discovery/routes/discovery-stages.ts
+++ b/packages/api/src/core/discovery/routes/discovery-stages.ts
@@ -1,56 +1,15 @@
 /**
  * Sprint 94: F263 Discovery Stage 라우트 — biz-item별 단계 진행 추적
+ * F539c: 2개 라우트 전부 fx-discovery로 이전 (FX-REQ-578)
+ * 라우팅: fx-gateway /api/biz-items/:id/discovery-progress → fx-discovery
+ *         fx-gateway /api/biz-items/:id/discovery-stage → fx-discovery
  */
 import { Hono } from "hono";
 import type { Env } from "../../../env.js";
 import type { TenantVariables } from "../../../middleware/tenant.js";
-import { DiscoveryStageService } from "../services/discovery-stage-service.js";
-import { UpdateDiscoveryStageSchema } from "../schemas/discovery-stage.js";
 
 export const discoveryStagesRoute = new Hono<{ Bindings: Env; Variables: TenantVariables }>();
 
-// ─── GET /biz-items/:id/discovery-progress ───
-discoveryStagesRoute.get("/biz-items/:id/discovery-progress", async (c) => {
-  const bizItemId = c.req.param("id");
-  const orgId = c.get("orgId");
-  const svc = new DiscoveryStageService(c.env.DB);
-
-  // biz-item 존재 확인
-  const item = await c.env.DB
-    .prepare("SELECT id FROM biz_items WHERE id = ? AND org_id = ?")
-    .bind(bizItemId, orgId)
-    .first();
-
-  if (!item) {
-    return c.json({ error: "BizItem not found" }, 404);
-  }
-
-  const progress = await svc.getProgress(bizItemId, orgId);
-  return c.json(progress);
-});
-
-// ─── POST /biz-items/:id/discovery-stage ───
-discoveryStagesRoute.post("/biz-items/:id/discovery-stage", async (c) => {
-  const bizItemId = c.req.param("id");
-  const orgId = c.get("orgId");
-  const body = await c.req.json();
-
-  const parsed = UpdateDiscoveryStageSchema.safeParse(body);
-  if (!parsed.success) {
-    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
-  }
-
-  // biz-item 존재 확인
-  const item = await c.env.DB
-    .prepare("SELECT id FROM biz_items WHERE id = ? AND org_id = ?")
-    .bind(bizItemId, orgId)
-    .first();
-
-  if (!item) {
-    return c.json({ error: "BizItem not found" }, 404);
-  }
-
-  const svc = new DiscoveryStageService(c.env.DB);
-  await svc.updateStage(bizItemId, orgId, parsed.data.stage, parsed.data.status);
-  return c.json({ ok: true, stage: parsed.data.stage, status: parsed.data.status });
-});
+// F539c: 두 라우트 모두 fx-discovery로 이전됨
+// GET /biz-items/:id/discovery-progress → fx-discovery (Service Binding)
+// POST /biz-items/:id/discovery-stage   → fx-discovery (Service Binding)

--- a/packages/fx-discovery/src/__tests__/biz-items.test.ts
+++ b/packages/fx-discovery/src/__tests__/biz-items.test.ts
@@ -1,0 +1,151 @@
+/**
+ * F539c Group A: biz-items 3 라우트 TDD Red Phase
+ * FX-REQ-578 — GET /api/biz-items, POST /api/biz-items, GET /api/biz-items/:id
+ */
+import { describe, it, expect, vi } from "vitest";
+import { sign } from "hono/jwt";
+import app from "../app.js";
+import type { DiscoveryEnv } from "../env.js";
+
+const TEST_SECRET = "test-secret-f539c";
+
+const makeD1Mock = (rows: Record<string, unknown>[] = [], singleRow?: Record<string, unknown> | null) =>
+  ({
+    prepare: vi.fn().mockReturnValue({
+      bind: vi.fn().mockReturnValue({
+        all: vi.fn().mockResolvedValue({ results: rows }),
+        first: vi.fn().mockResolvedValue(singleRow ?? rows[0] ?? null),
+        run: vi.fn().mockResolvedValue({ success: true }),
+      }),
+      all: vi.fn().mockResolvedValue({ results: rows }),
+      first: vi.fn().mockResolvedValue(singleRow ?? rows[0] ?? null),
+      run: vi.fn().mockResolvedValue({ success: true }),
+    }),
+  }) as unknown as D1Database;
+
+const makeEnv = (db?: D1Database): DiscoveryEnv => ({
+  DB: db ?? makeD1Mock(),
+  JWT_SECRET: TEST_SECRET,
+  ANTHROPIC_API_KEY: "test-api-key",
+});
+
+async function makeAuthHeader(payload: Record<string, unknown> = {}) {
+  const token = await sign(
+    { sub: "user-1", orgId: "org-1", orgRole: "admin", exp: Math.floor(Date.now() / 1000) + 3600, ...payload },
+    TEST_SECRET,
+    "HS256",
+  );
+  return { Authorization: `Bearer ${token}` };
+}
+
+// org_members mock: tenantGuard가 통과하도록
+const makeOrgMemberDb = (bizItemRows: Record<string, unknown>[] = []) =>
+  ({
+    prepare: vi.fn((sql: string) => {
+      const isOrgMemberQuery = sql.includes("org_members");
+      const isBizItemsQuery = sql.includes("biz_items");
+      const isClassificationQuery = sql.includes("biz_item_classifications");
+      const isPipelineStagesQuery = sql.includes("pipeline_stages");
+
+      return {
+        bind: vi.fn().mockReturnValue({
+          all: vi.fn().mockResolvedValue({ results: bizItemRows }),
+          first: vi.fn().mockImplementation(async () => {
+            if (isOrgMemberQuery) return { role: "admin" };
+            if (isBizItemsQuery) return bizItemRows[0] ?? null;
+            if (isClassificationQuery) return null;
+            return null;
+          }),
+          run: vi.fn().mockResolvedValue({ success: true, meta: { last_row_id: 1 } }),
+        }),
+        all: vi.fn().mockResolvedValue({ results: bizItemRows }),
+        first: vi.fn().mockImplementation(async () => {
+          if (isOrgMemberQuery) return { role: "admin" };
+          return bizItemRows[0] ?? null;
+        }),
+        run: vi.fn().mockResolvedValue({ success: true }),
+      };
+    }),
+  }) as unknown as D1Database;
+
+describe("F539c Group A: biz-items 3 라우트", () => {
+  // Red: 이 테스트들은 구현 전 FAIL (404) → 구현 후 PASS
+
+  it("GET /api/biz-items → 200 with items array", async () => {
+    const bizItemRow = {
+      id: "item-001",
+      org_id: "org-1",
+      title: "Test Item",
+      description: null,
+      source: "field",
+      status: "draft",
+      created_by: "user-1",
+      created_at: "2026-04-15T00:00:00Z",
+      updated_at: "2026-04-15T00:00:00Z",
+    };
+    const db = makeOrgMemberDb([bizItemRow]);
+    const headers = await makeAuthHeader();
+
+    const res = await app.request("/api/biz-items", { headers }, makeEnv(db));
+    expect(res.status).toBe(200);
+    const body = await res.json() as { items: unknown[] };
+    expect(Array.isArray(body.items)).toBe(true);
+  });
+
+  it("POST /api/biz-items → 201 with created item", async () => {
+    const db = makeOrgMemberDb([]);
+    const headers = await makeAuthHeader();
+
+    const res = await app.request("/api/biz-items", {
+      method: "POST",
+      headers: { ...headers, "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "새 사업 아이템" }),
+    }, makeEnv(db));
+    expect(res.status).toBe(201);
+    const body = await res.json() as { id: string; title: string };
+    expect(body.title).toBe("새 사업 아이템");
+    expect(typeof body.id).toBe("string");
+  });
+
+  it("GET /api/biz-items/:id → 200 with biz item", async () => {
+    const bizItemRow = {
+      id: "item-001",
+      org_id: "org-1",
+      title: "Test Item",
+      description: null,
+      source: "field",
+      status: "draft",
+      created_by: "user-1",
+      created_at: "2026-04-15T00:00:00Z",
+      updated_at: "2026-04-15T00:00:00Z",
+    };
+    const db = makeOrgMemberDb([bizItemRow]);
+    const headers = await makeAuthHeader();
+
+    const res = await app.request("/api/biz-items/item-001", { headers }, makeEnv(db));
+    expect(res.status).toBe(200);
+    const body = await res.json() as { id: string; title: string };
+    expect(body.id).toBe("item-001");
+    expect(body.title).toBe("Test Item");
+  });
+
+  it("GET /api/biz-items/:id → 404 for missing item", async () => {
+    const db = makeOrgMemberDb([]);
+    const headers = await makeAuthHeader();
+
+    const res = await app.request("/api/biz-items/nonexistent-id", { headers }, makeEnv(db));
+    expect(res.status).toBe(404);
+  });
+
+  it("POST /api/biz-items → 400 without title", async () => {
+    const db = makeOrgMemberDb([]);
+    const headers = await makeAuthHeader();
+
+    const res = await app.request("/api/biz-items", {
+      method: "POST",
+      headers: { ...headers, "Content-Type": "application/json" },
+      body: JSON.stringify({ description: "no title" }),
+    }, makeEnv(db));
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/fx-discovery/src/__tests__/discovery-pipeline.test.ts
+++ b/packages/fx-discovery/src/__tests__/discovery-pipeline.test.ts
@@ -1,0 +1,70 @@
+/**
+ * F539c Group B: discovery-pipeline GET 2 라우트 TDD Red Phase
+ * FX-REQ-578 — GET /api/discovery-pipeline/runs, GET /api/discovery-pipeline/runs/:id
+ */
+import { describe, it, expect, vi } from "vitest";
+import { sign } from "hono/jwt";
+import app from "../app.js";
+import type { DiscoveryEnv } from "../env.js";
+
+const TEST_SECRET = "test-secret-f539c";
+
+async function makeAuthHeader() {
+  const token = await sign(
+    { sub: "user-1", orgId: "org-1", orgRole: "admin", exp: Math.floor(Date.now() / 1000) + 3600 },
+    TEST_SECRET,
+    "HS256",
+  );
+  return { Authorization: `Bearer ${token}` };
+}
+
+const makeDb = (runRows: Record<string, unknown>[] = []) =>
+  ({
+    prepare: vi.fn((sql: string) => {
+      const isOrgMember = sql.includes("org_members");
+      const isCount = sql.includes("COUNT(*)");
+      return {
+        bind: vi.fn().mockReturnValue({
+          all: vi.fn().mockResolvedValue({ results: runRows }),
+          first: vi.fn().mockResolvedValue(
+            isOrgMember ? { role: "admin" } : isCount ? { total: runRows.length } : (runRows[0] ?? null),
+          ),
+          run: vi.fn().mockResolvedValue({ success: true }),
+        }),
+        all: vi.fn().mockResolvedValue({ results: runRows }),
+        first: vi.fn().mockResolvedValue(
+          isOrgMember ? { role: "admin" } : isCount ? { total: runRows.length } : (runRows[0] ?? null),
+        ),
+        run: vi.fn().mockResolvedValue({ success: true }),
+      };
+    }),
+  }) as unknown as D1Database;
+
+const makeEnv = (db?: D1Database): DiscoveryEnv => ({
+  DB: db ?? makeDb(),
+  JWT_SECRET: TEST_SECRET,
+  ANTHROPIC_API_KEY: "test-api-key",
+});
+
+describe("F539c Group B: discovery-pipeline GET 2 라우트", () => {
+  it("GET /api/discovery-pipeline/runs → 200 with items/total", async () => {
+    const headers = await makeAuthHeader();
+    const res = await app.request("/api/discovery-pipeline/runs", { headers }, makeEnv());
+    expect(res.status).toBe(200);
+    const body = await res.json() as { items: unknown[]; total: number };
+    expect(Array.isArray(body.items)).toBe(true);
+    expect(typeof body.total).toBe("number");
+  });
+
+  it("GET /api/discovery-pipeline/runs/:id → 404 for missing run", async () => {
+    const headers = await makeAuthHeader();
+    const res = await app.request("/api/discovery-pipeline/runs/nonexistent", { headers }, makeEnv());
+    expect(res.status).toBe(404);
+  });
+
+  it("GET /api/discovery-pipeline/runs → 400 with invalid query", async () => {
+    const headers = await makeAuthHeader();
+    const res = await app.request("/api/discovery-pipeline/runs?limit=abc", { headers }, makeEnv());
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/fx-discovery/src/__tests__/discovery-stages.test.ts
+++ b/packages/fx-discovery/src/__tests__/discovery-stages.test.ts
@@ -1,0 +1,73 @@
+/**
+ * F539c Group B: discovery-stages 2 라우트 TDD Red Phase
+ * FX-REQ-578 — GET /api/biz-items/:id/discovery-progress, POST /api/biz-items/:id/discovery-stage
+ */
+import { describe, it, expect, vi } from "vitest";
+import { sign } from "hono/jwt";
+import app from "../app.js";
+import type { DiscoveryEnv } from "../env.js";
+
+const TEST_SECRET = "test-secret-f539c";
+
+async function makeAuthHeader() {
+  const token = await sign(
+    { sub: "user-1", orgId: "org-1", orgRole: "admin", exp: Math.floor(Date.now() / 1000) + 3600 },
+    TEST_SECRET,
+    "HS256",
+  );
+  return { Authorization: `Bearer ${token}` };
+}
+
+const makeDb = (stageRows: Record<string, unknown>[] = []) =>
+  ({
+    prepare: vi.fn((sql: string) => {
+      const isOrgMember = sql.includes("org_members");
+      return {
+        bind: vi.fn().mockReturnValue({
+          all: vi.fn().mockResolvedValue({ results: stageRows }),
+          first: vi.fn().mockResolvedValue(isOrgMember ? { role: "admin" } : (stageRows[0] ?? null)),
+          run: vi.fn().mockResolvedValue({ success: true }),
+        }),
+        all: vi.fn().mockResolvedValue({ results: stageRows }),
+        first: vi.fn().mockResolvedValue(isOrgMember ? { role: "admin" } : (stageRows[0] ?? null)),
+        run: vi.fn().mockResolvedValue({ success: true }),
+      };
+    }),
+  }) as unknown as D1Database;
+
+const makeEnv = (db?: D1Database): DiscoveryEnv => ({
+  DB: db ?? makeDb(),
+  JWT_SECRET: TEST_SECRET,
+  ANTHROPIC_API_KEY: "test-api-key",
+});
+
+describe("F539c Group B: discovery-stages 2 라우트", () => {
+  it("GET /api/biz-items/:id/discovery-progress → 200", async () => {
+    const headers = await makeAuthHeader();
+    const res = await app.request("/api/biz-items/item-001/discovery-progress", { headers }, makeEnv());
+    expect(res.status).toBe(200);
+    const body = await res.json() as { stages: unknown[]; completedCount: number; totalCount: number };
+    expect(Array.isArray(body.stages)).toBe(true);
+    expect(typeof body.completedCount).toBe("number");
+  });
+
+  it("POST /api/biz-items/:id/discovery-stage → 200 or 400", async () => {
+    const headers = await makeAuthHeader();
+    const res = await app.request("/api/biz-items/item-001/discovery-stage", {
+      method: "POST",
+      headers: { ...headers, "Content-Type": "application/json" },
+      body: JSON.stringify({ stage: "2-1", status: "in_progress" }),
+    }, makeEnv());
+    expect([200, 400]).toContain(res.status);
+  });
+
+  it("POST /api/biz-items/:id/discovery-stage → 400 with invalid body", async () => {
+    const headers = await makeAuthHeader();
+    const res = await app.request("/api/biz-items/item-001/discovery-stage", {
+      method: "POST",
+      headers: { ...headers, "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    }, makeEnv());
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/fx-discovery/src/app.ts
+++ b/packages/fx-discovery/src/app.ts
@@ -1,5 +1,6 @@
 // fx-discovery app (F518: FX-REQ-546, F523: FX-REQ-551)
 // F538: 3개 clean route 추가 (discovery, discovery-report, discovery-reports)
+// F539c: 7 라우트 추가 (biz-items 3 + discovery-stages 2 + discovery-pipeline GET 2)
 import { Hono } from "hono";
 import type { DiscoveryEnv } from "./env.js";
 import { authMiddleware } from "./middleware/auth.js";
@@ -8,6 +9,9 @@ import items from "./routes/items.js";
 import { discoveryRoute } from "./routes/discovery.js";
 import { discoveryReportRoute } from "./routes/discovery-report.js";
 import { discoveryReportsRoute } from "./routes/discovery-reports.js";
+import { bizItemsRoute } from "./routes/biz-items.js";
+import { discoveryStagesRoute } from "./routes/discovery-stages.js";
+import { discoveryPipelineRoute } from "./routes/discovery-pipeline.js";
 
 const app = new Hono<{ Bindings: DiscoveryEnv }>();
 
@@ -22,12 +26,18 @@ app.route("/", items);
 // F538: JWT + tenant 미들웨어 적용 (authenticated routes)
 app.use("/api/*", authMiddleware);
 
-// F538: 3개 clean discovery routes
+// F538+F539c: authenticated routes
 const authenticated = new Hono<{ Bindings: DiscoveryEnv; Variables: TenantVariables }>();
 authenticated.use("*", tenantGuard);
+// F538: 3개 clean discovery routes
 authenticated.route("/api", discoveryRoute);
 authenticated.route("/api", discoveryReportRoute);
 authenticated.route("/api", discoveryReportsRoute);
+// F539c Group A: biz-items 3 라우트
+authenticated.route("/api", bizItemsRoute);
+// F539c Group B: discovery-stages 2 라우트 + pipeline GET 2 라우트
+authenticated.route("/api", discoveryStagesRoute);
+authenticated.route("/api", discoveryPipelineRoute);
 
 app.route("/", authenticated);
 

--- a/packages/fx-discovery/src/routes/biz-items.ts
+++ b/packages/fx-discovery/src/routes/biz-items.ts
@@ -1,0 +1,54 @@
+/**
+ * F539c Group A: biz-items 3 라우트 (FX-REQ-578)
+ * GET /api/biz-items, POST /api/biz-items, GET /api/biz-items/:id
+ */
+import { Hono } from "hono";
+import type { DiscoveryEnv } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import { CreateBizItemSchema } from "../schemas/biz-item.js";
+import { BizItemCrudService } from "../services/biz-item-crud.service.js";
+
+export const bizItemsRoute = new Hono<{ Bindings: DiscoveryEnv; Variables: TenantVariables }>();
+
+// GET /biz-items — 목록 조회
+bizItemsRoute.get("/biz-items", async (c) => {
+  const orgId = c.get("orgId");
+  const status = c.req.query("status") || undefined;
+  const source = c.req.query("source") || undefined;
+
+  const service = new BizItemCrudService(c.env.DB);
+  const items = await service.list(orgId, { status, source });
+
+  return c.json({ items });
+});
+
+// POST /biz-items — 생성
+bizItemsRoute.post("/biz-items", async (c) => {
+  const body = await c.req.json();
+  const parsed = CreateBizItemSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const orgId = c.get("orgId");
+  const userId = (c.get("jwtPayload") as Record<string, string> | undefined)?.sub ?? "";
+  const service = new BizItemCrudService(c.env.DB);
+  const item = await service.create(orgId, userId, parsed.data);
+
+  return c.json(item, 201);
+});
+
+// GET /biz-items/:id — 상세 조회
+bizItemsRoute.get("/biz-items/:id", async (c) => {
+  const orgId = c.get("orgId");
+  const id = c.req.param("id");
+
+  const service = new BizItemCrudService(c.env.DB);
+  const item = await service.getById(orgId, id);
+
+  if (!item) {
+    return c.json({ error: "BIZ_ITEM_NOT_FOUND" }, 404);
+  }
+
+  return c.json(item);
+});

--- a/packages/fx-discovery/src/routes/discovery-pipeline.ts
+++ b/packages/fx-discovery/src/routes/discovery-pipeline.ts
@@ -1,0 +1,35 @@
+/**
+ * F539c Group B: discovery-pipeline GET 2 라우트 (FX-REQ-578)
+ * GET /api/discovery-pipeline/runs
+ * GET /api/discovery-pipeline/runs/:id
+ */
+import { Hono } from "hono";
+import type { DiscoveryEnv } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import { DiscoveryPipelineReadService } from "../services/discovery-pipeline-read.service.js";
+import { listPipelineRunsSchema } from "../schemas/discovery-pipeline.js";
+
+export const discoveryPipelineRoute = new Hono<{ Bindings: DiscoveryEnv; Variables: TenantVariables }>();
+
+// GET /discovery-pipeline/runs
+discoveryPipelineRoute.get("/discovery-pipeline/runs", async (c) => {
+  const parsed = listPipelineRunsSchema.safeParse(c.req.query());
+  if (!parsed.success) {
+    return c.json({ error: "Invalid query", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new DiscoveryPipelineReadService(c.env.DB);
+  const result = await svc.listRuns(c.get("orgId"), parsed.data);
+  return c.json(result);
+});
+
+// GET /discovery-pipeline/runs/:id
+discoveryPipelineRoute.get("/discovery-pipeline/runs/:id", async (c) => {
+  const svc = new DiscoveryPipelineReadService(c.env.DB);
+  const detail = await svc.getRun(c.req.param("id"), c.get("orgId"));
+
+  if (!detail) {
+    return c.json({ error: "Pipeline run not found" }, 404);
+  }
+  return c.json(detail);
+});

--- a/packages/fx-discovery/src/routes/discovery-stages.ts
+++ b/packages/fx-discovery/src/routes/discovery-stages.ts
@@ -1,0 +1,37 @@
+/**
+ * F539c Group B: discovery-stages 2 라우트 (FX-REQ-578)
+ * GET /api/biz-items/:id/discovery-progress
+ * POST /api/biz-items/:id/discovery-stage
+ */
+import { Hono } from "hono";
+import type { DiscoveryEnv } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import { DiscoveryStageService } from "../services/discovery-stage.service.js";
+import { UpdateDiscoveryStageSchema } from "../schemas/discovery-stage.js";
+
+export const discoveryStagesRoute = new Hono<{ Bindings: DiscoveryEnv; Variables: TenantVariables }>();
+
+// GET /biz-items/:id/discovery-progress
+discoveryStagesRoute.get("/biz-items/:id/discovery-progress", async (c) => {
+  const bizItemId = c.req.param("id");
+  const orgId = c.get("orgId");
+  const svc = new DiscoveryStageService(c.env.DB);
+  const progress = await svc.getProgress(bizItemId, orgId);
+  return c.json(progress);
+});
+
+// POST /biz-items/:id/discovery-stage
+discoveryStagesRoute.post("/biz-items/:id/discovery-stage", async (c) => {
+  const bizItemId = c.req.param("id");
+  const orgId = c.get("orgId");
+
+  const body = await c.req.json();
+  const parsed = UpdateDiscoveryStageSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new DiscoveryStageService(c.env.DB);
+  const result = await svc.updateStage(bizItemId, orgId, parsed.data.stage, parsed.data.status);
+  return c.json(result);
+});

--- a/packages/fx-discovery/src/schemas/biz-item.ts
+++ b/packages/fx-discovery/src/schemas/biz-item.ts
@@ -1,0 +1,12 @@
+/**
+ * F539c: biz-item 생성 스키마 (packages/api 이전)
+ */
+import { z } from "zod";
+
+export const CreateBizItemSchema = z.object({
+  title: z.string().min(1, "Title is required"),
+  description: z.string().optional(),
+  source: z.string().optional(),
+});
+
+export type CreateBizItemInput = z.infer<typeof CreateBizItemSchema>;

--- a/packages/fx-discovery/src/schemas/discovery-pipeline.ts
+++ b/packages/fx-discovery/src/schemas/discovery-pipeline.ts
@@ -1,0 +1,13 @@
+/**
+ * F539c: discovery-pipeline 쿼리 스키마 (read-only)
+ */
+import { z } from "zod";
+
+export const listPipelineRunsSchema = z.object({
+  status: z.string().optional(),
+  bizItemId: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+export type ListPipelineRunsQuery = z.infer<typeof listPipelineRunsSchema>;

--- a/packages/fx-discovery/src/schemas/discovery-stage.ts
+++ b/packages/fx-discovery/src/schemas/discovery-stage.ts
@@ -1,0 +1,18 @@
+/**
+ * F539c: discovery-stage 스키마 (packages/api 이전)
+ */
+import { z } from "zod";
+
+export const DISCOVERY_STAGES = [
+  "2-0", "2-1", "2-2", "2-3", "2-4", "2-5", "2-6", "2-7", "2-8", "2-9", "2-10",
+] as const;
+
+export const STAGE_STATUSES = ["pending", "in_progress", "completed", "skipped"] as const;
+
+export const UpdateDiscoveryStageSchema = z.object({
+  stage: z.enum(DISCOVERY_STAGES),
+  status: z.enum(STAGE_STATUSES),
+});
+
+export type StageId = (typeof DISCOVERY_STAGES)[number];
+export type StageStatus = (typeof STAGE_STATUSES)[number];

--- a/packages/fx-discovery/src/services/biz-item-crud.service.ts
+++ b/packages/fx-discovery/src/services/biz-item-crud.service.ts
@@ -1,0 +1,168 @@
+/**
+ * F539c: BizItem CRUD 서비스 (create/list/getById — 순수 D1, cross-domain 의존 없음)
+ * packages/api/src/core/discovery/services/biz-item-service.ts 에서 발췌
+ */
+import type { D1Database } from "@cloudflare/workers-types";
+
+export interface CreateBizItemInput {
+  title: string;
+  description?: string;
+  source?: string;
+}
+
+export interface BizItem {
+  id: string;
+  orgId: string;
+  title: string;
+  description: string | null;
+  source: string;
+  status: string;
+  createdBy: string;
+  createdAt: string;
+  updatedAt: string;
+  classification: {
+    itemType: string;
+    confidence: number;
+    analysisWeights: Record<string, number>;
+    classifiedAt: string;
+  } | null;
+}
+
+interface BizItemRow {
+  id: string;
+  org_id: string;
+  title: string;
+  description: string | null;
+  source: string;
+  status: string;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface ClassificationRow {
+  item_type: string;
+  confidence: number;
+  analysis_weights: string;
+  classified_at: string;
+}
+
+function generateId(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function toCamelCase(row: BizItemRow, cls: ClassificationRow | null): BizItem {
+  return {
+    id: row.id,
+    orgId: row.org_id,
+    title: row.title,
+    description: row.description,
+    source: row.source,
+    status: row.status,
+    createdBy: row.created_by,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    classification: cls
+      ? {
+          itemType: cls.item_type,
+          confidence: cls.confidence,
+          analysisWeights: JSON.parse(cls.analysis_weights || "{}"),
+          classifiedAt: cls.classified_at,
+        }
+      : null,
+  };
+}
+
+export class BizItemCrudService {
+  constructor(private db: D1Database) {}
+
+  async create(orgId: string, userId: string, data: CreateBizItemInput): Promise<BizItem> {
+    const id = generateId();
+    const now = new Date().toISOString();
+
+    await this.db
+      .prepare(
+        `INSERT INTO biz_items (id, org_id, title, description, source, status, created_by, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, 'draft', ?, ?, ?)`,
+      )
+      .bind(id, orgId, data.title, data.description ?? null, data.source ?? "field", userId, now, now)
+      .run();
+
+    try {
+      const pipelineId = crypto.randomUUID().replace(/-/g, "");
+      await this.db
+        .prepare(
+          `INSERT INTO pipeline_stages (id, biz_item_id, org_id, stage, entered_at, entered_by)
+           VALUES (?, ?, ?, 'REGISTERED', ?, ?)`,
+        )
+        .bind(pipelineId, id, orgId, now, userId)
+        .run();
+    } catch {
+      // pipeline_stages 미존재 환경에서는 무시
+    }
+
+    return {
+      id,
+      orgId,
+      title: data.title,
+      description: data.description ?? null,
+      source: data.source ?? "field",
+      status: "draft",
+      createdBy: userId,
+      createdAt: now,
+      updatedAt: now,
+      classification: null,
+    };
+  }
+
+  async list(orgId: string, filters?: { status?: string; source?: string }): Promise<BizItem[]> {
+    let query = "SELECT * FROM biz_items WHERE org_id = ?";
+    const bindings: unknown[] = [orgId];
+
+    if (filters?.status) {
+      query += " AND status = ?";
+      bindings.push(filters.status);
+    }
+    if (filters?.source) {
+      query += " AND source = ?";
+      bindings.push(filters.source);
+    }
+
+    query += " ORDER BY created_at DESC";
+
+    const { results } = await this.db
+      .prepare(query)
+      .bind(...bindings)
+      .all<BizItemRow>();
+
+    const items: BizItem[] = [];
+    for (const row of results) {
+      const cls = await this.db
+        .prepare("SELECT item_type, confidence, analysis_weights, classified_at FROM biz_item_classifications WHERE biz_item_id = ?")
+        .bind(row.id)
+        .first<ClassificationRow>();
+      items.push(toCamelCase(row, cls));
+    }
+    return items;
+  }
+
+  async getById(orgId: string, id: string): Promise<BizItem | null> {
+    const row = await this.db
+      .prepare("SELECT * FROM biz_items WHERE id = ? AND org_id = ?")
+      .bind(id, orgId)
+      .first<BizItemRow>();
+
+    if (!row) return null;
+
+    const cls = await this.db
+      .prepare("SELECT item_type, confidence, analysis_weights, classified_at FROM biz_item_classifications WHERE biz_item_id = ?")
+      .bind(id)
+      .first<ClassificationRow>();
+
+    return toCamelCase(row, cls);
+  }
+}

--- a/packages/fx-discovery/src/services/discovery-pipeline-read.service.ts
+++ b/packages/fx-discovery/src/services/discovery-pipeline-read.service.ts
@@ -1,0 +1,125 @@
+/**
+ * F539c: DiscoveryPipelineReadService — GET-only (FSM 의존 제거)
+ * listRuns/getRun만 구현. validEvents 필드 제외 (Web UI 미사용).
+ * packages/api/src/core/discovery/services/discovery-pipeline-service.ts 발췌
+ */
+import type { D1Database } from "@cloudflare/workers-types";
+import type { ListPipelineRunsQuery } from "../schemas/discovery-pipeline.js";
+
+interface PipelineRunRow {
+  id: string;
+  tenant_id: string;
+  biz_item_id: string;
+  status: string;
+  current_step: string | null;
+  discovery_start_at: string | null;
+  discovery_end_at: string | null;
+  shaping_run_id: string | null;
+  trigger_mode: string;
+  retry_count: number;
+  max_retries: number;
+  error_message: string | null;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface PipelineEventRow {
+  id: string;
+  pipeline_run_id: string;
+  event_type: string;
+  from_status: string | null;
+  to_status: string | null;
+  step_id: string | null;
+  payload: string | null;
+  error_code: string | null;
+  error_message: string | null;
+  created_by: string | null;
+  created_at: string;
+}
+
+function mapRun(row: PipelineRunRow) {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    bizItemId: row.biz_item_id,
+    status: row.status,
+    currentStep: row.current_step,
+    discoveryStartAt: row.discovery_start_at,
+    discoveryEndAt: row.discovery_end_at,
+    shapingRunId: row.shaping_run_id,
+    triggerMode: row.trigger_mode,
+    retryCount: row.retry_count,
+    maxRetries: row.max_retries,
+    errorMessage: row.error_message,
+    createdBy: row.created_by,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export class DiscoveryPipelineReadService {
+  constructor(private db: D1Database) {}
+
+  async listRuns(orgId: string, filters: ListPipelineRunsQuery) {
+    let where = "tenant_id = ?";
+    const params: unknown[] = [orgId];
+
+    if (filters.status) {
+      where += " AND status = ?";
+      params.push(filters.status);
+    }
+    if (filters.bizItemId) {
+      where += " AND biz_item_id = ?";
+      params.push(filters.bizItemId);
+    }
+
+    const countResult = await this.db
+      .prepare(`SELECT COUNT(*) as total FROM discovery_pipeline_runs WHERE ${where}`)
+      .bind(...params)
+      .first<{ total: number }>();
+
+    const rows = await this.db
+      .prepare(
+        `SELECT * FROM discovery_pipeline_runs WHERE ${where}
+         ORDER BY created_at DESC LIMIT ? OFFSET ?`,
+      )
+      .bind(...params, filters.limit, filters.offset)
+      .all<PipelineRunRow>();
+
+    return {
+      items: (rows.results ?? []).map(mapRun),
+      total: countResult?.total ?? 0,
+    };
+  }
+
+  async getRun(id: string, orgId: string) {
+    const row = await this.db
+      .prepare("SELECT * FROM discovery_pipeline_runs WHERE id = ? AND tenant_id = ?")
+      .bind(id, orgId)
+      .first<PipelineRunRow>();
+
+    if (!row) return null;
+
+    const events = await this.db
+      .prepare("SELECT * FROM discovery_pipeline_events WHERE pipeline_run_id = ? ORDER BY created_at ASC")
+      .bind(id)
+      .all<PipelineEventRow>();
+
+    return {
+      ...mapRun(row),
+      events: (events.results ?? []).map((e) => ({
+        id: e.id,
+        eventType: e.event_type,
+        fromStatus: e.from_status,
+        toStatus: e.to_status,
+        stepId: e.step_id,
+        payload: e.payload ? JSON.parse(e.payload) : null,
+        errorCode: e.error_code,
+        errorMessage: e.error_message,
+        createdBy: e.created_by,
+        createdAt: e.created_at,
+      })),
+    };
+  }
+}

--- a/packages/fx-discovery/src/services/discovery-stage.service.ts
+++ b/packages/fx-discovery/src/services/discovery-stage.service.ts
@@ -1,0 +1,165 @@
+/**
+ * F539c: DiscoveryStageService (packages/api 이전 — 순수 D1, cross-domain 의존 없음)
+ */
+import type { D1Database } from "@cloudflare/workers-types";
+import { DISCOVERY_STAGES, type StageId, type StageStatus } from "../schemas/discovery-stage.js";
+
+const FULL_STAGE_NAMES: Record<string, string> = {
+  "2-0": "사업 아이템 분류",
+  "2-1": "레퍼런스 분석",
+  "2-2": "수요 시장 검증",
+  "2-3": "경쟁·자사 분석",
+  "2-4": "사업 아이템 도출",
+  "2-5": "핵심 아이템 선정",
+  "2-6": "타겟 고객 정의",
+  "2-7": "비즈니스 모델 정의",
+  "2-8": "패키징",
+  "2-9": "AI 멀티페르소나 평가",
+  "2-10": "최종 보고서",
+};
+
+export interface StageProgress {
+  stage: string;
+  stageName: string;
+  status: string;
+  startedAt: string | null;
+  completedAt: string | null;
+}
+
+export interface DiscoveryProgress {
+  stages: StageProgress[];
+  currentStage: string | null;
+  completedCount: number;
+  totalCount: number;
+}
+
+interface StageRow {
+  id: string;
+  biz_item_id: string;
+  org_id: string;
+  stage: string;
+  status: string;
+  started_at: string | null;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+function generateId(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export class DiscoveryStageService {
+  constructor(private db: D1Database) {}
+
+  async initStages(bizItemId: string, orgId: string): Promise<void> {
+    for (const stage of DISCOVERY_STAGES) {
+      const id = generateId();
+      await this.db
+        .prepare(
+          `INSERT OR IGNORE INTO biz_item_discovery_stages (id, biz_item_id, org_id, stage, status)
+           VALUES (?, ?, ?, ?, 'pending')`,
+        )
+        .bind(id, bizItemId, orgId, stage)
+        .run();
+    }
+  }
+
+  async getProgress(bizItemId: string, orgId: string): Promise<DiscoveryProgress> {
+    const { results } = await this.db
+      .prepare(
+        "SELECT * FROM biz_item_discovery_stages WHERE biz_item_id = ? AND org_id = ? ORDER BY stage",
+      )
+      .bind(bizItemId, orgId)
+      .all<StageRow>();
+
+    // 기록이 없으면 초기화
+    if (results.length === 0) {
+      await this.initStages(bizItemId, orgId);
+      return {
+        stages: DISCOVERY_STAGES.map((stage) => ({
+          stage,
+          stageName: FULL_STAGE_NAMES[stage] ?? stage,
+          status: "pending",
+          startedAt: null,
+          completedAt: null,
+        })),
+        currentStage: null,
+        completedCount: 0,
+        totalCount: DISCOVERY_STAGES.length,
+      };
+    }
+
+    const stages: StageProgress[] = results.map((row) => ({
+      stage: row.stage,
+      stageName: FULL_STAGE_NAMES[row.stage] ?? row.stage,
+      status: row.status,
+      startedAt: row.started_at,
+      completedAt: row.completed_at,
+    }));
+
+    const completedCount = stages.filter((s) => s.status === "completed").length;
+    const currentStage =
+      stages.find((s) => s.status === "in_progress")?.stage ??
+      stages.find((s) => s.status === "pending")?.stage ??
+      null;
+
+    return {
+      stages,
+      currentStage,
+      completedCount,
+      totalCount: stages.length,
+    };
+  }
+
+  async updateStage(
+    bizItemId: string,
+    orgId: string,
+    stage: StageId,
+    status: StageStatus,
+  ): Promise<{ stage: string; status: string }> {
+    const now = new Date().toISOString();
+
+    const existing = await this.db
+      .prepare("SELECT id FROM biz_item_discovery_stages WHERE biz_item_id = ? AND org_id = ? AND stage = ?")
+      .bind(bizItemId, orgId, stage)
+      .first<{ id: string }>();
+
+    if (existing) {
+      const startedAt = status === "in_progress" ? now : undefined;
+      const completedAt = status === "completed" ? now : undefined;
+
+      if (startedAt !== undefined) {
+        await this.db
+          .prepare("UPDATE biz_item_discovery_stages SET status = ?, started_at = ?, updated_at = ? WHERE id = ?")
+          .bind(status, startedAt, now, existing.id)
+          .run();
+      } else if (completedAt !== undefined) {
+        await this.db
+          .prepare("UPDATE biz_item_discovery_stages SET status = ?, completed_at = ?, updated_at = ? WHERE id = ?")
+          .bind(status, completedAt, now, existing.id)
+          .run();
+      } else {
+        await this.db
+          .prepare("UPDATE biz_item_discovery_stages SET status = ?, updated_at = ? WHERE id = ?")
+          .bind(status, now, existing.id)
+          .run();
+      }
+    } else {
+      const id = generateId();
+      await this.db
+        .prepare(
+          `INSERT INTO biz_item_discovery_stages (id, biz_item_id, org_id, stage, status, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .bind(id, bizItemId, orgId, stage, status, now, now)
+        .run();
+    }
+
+    return { stage, status };
+  }
+}

--- a/packages/fx-gateway/src/__tests__/gateway.test.ts
+++ b/packages/fx-gateway/src/__tests__/gateway.test.ts
@@ -45,15 +45,16 @@ describe("F523: Gateway DISCOVERY routing (hardwired)", () => {
     expect(mainApi.fetch).not.toHaveBeenCalled();
   });
 
-  it("/api/biz-items → MAIN_API로 전달한다", async () => {
+  // F539c: /api/biz-items → DISCOVERY로 변경됨
+  it("/api/biz-items → DISCOVERY Service Binding으로 전달한다", async () => {
     const discovery = makeDiscoveryMock();
     const mainApi = makeMainApiMock();
     const env: GatewayEnv = { MAIN_API: mainApi, DISCOVERY: discovery };
 
     const res = await app.request("/api/biz-items", {}, env);
 
-    expect(mainApi.fetch).toHaveBeenCalledTimes(1);
-    expect(discovery.fetch).not.toHaveBeenCalled();
+    expect(discovery.fetch).toHaveBeenCalledTimes(1);
+    expect(mainApi.fetch).not.toHaveBeenCalled();
     expect(res.status).toBe(200);
   });
 

--- a/packages/fx-gateway/src/app.ts
+++ b/packages/fx-gateway/src/app.ts
@@ -29,6 +29,34 @@ app.all("/api/ax-bd/discovery-report/*", async (c) => {
   return c.env.DISCOVERY.fetch(c.req.raw);
 });
 
+// F539c Group B: discovery-stages (/:id/discovery-progress, /:id/discovery-stage)
+// 주의: /:id/discovery-* 패턴을 /:id 단순 패턴보다 먼저 등록
+app.get("/api/biz-items/:id/discovery-progress", async (c) => {
+  return c.env.DISCOVERY.fetch(c.req.raw);
+});
+app.post("/api/biz-items/:id/discovery-stage", async (c) => {
+  return c.env.DISCOVERY.fetch(c.req.raw);
+});
+
+// F539c Group A: biz-items 3 라우트
+app.get("/api/biz-items", async (c) => {
+  return c.env.DISCOVERY.fetch(c.req.raw);
+});
+app.post("/api/biz-items", async (c) => {
+  return c.env.DISCOVERY.fetch(c.req.raw);
+});
+app.get("/api/biz-items/:id", async (c) => {
+  return c.env.DISCOVERY.fetch(c.req.raw);
+});
+
+// F539c Group B: discovery-pipeline GET 2 라우트
+app.get("/api/discovery-pipeline/runs", async (c) => {
+  return c.env.DISCOVERY.fetch(c.req.raw);
+});
+app.get("/api/discovery-pipeline/runs/:id", async (c) => {
+  return c.env.DISCOVERY.fetch(c.req.raw);
+});
+
 // 그 외 모든 /api/* 요청은 MAIN_API로
 app.all("/api/*", async (c) => {
   return c.env.MAIN_API.fetch(c.req.raw);

--- a/packages/web/e2e/prod/smoke.spec.ts
+++ b/packages/web/e2e/prod/smoke.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@playwright/test";
 
 const API_URL =
   process.env.PROD_API_URL ||
-  "https://foundry-x-api.ktds-axbd.workers.dev";
+  "https://fx-gateway.ktds-axbd.workers.dev";
 
 test.describe("Production Smoke", () => {
   /**

--- a/scripts/feedback-consumer.sh
+++ b/scripts/feedback-consumer.sh
@@ -3,7 +3,7 @@
 # Usage: ./scripts/feedback-consumer.sh [--once] [--interval 60]
 #
 # Environment variables:
-#   API_BASE       — Workers API URL (default: https://foundry-x-api.ktds-axbd.workers.dev)
+#   API_BASE       — Workers API URL (default: https://fx-gateway.ktds-axbd.workers.dev)
 #   WEBHOOK_SECRET — X-Webhook-Secret 헤더 인증 (JWT 불필요)
 #   REPO_DIR       — Foundry-X 리포 경로 (default: pwd)
 #
@@ -13,7 +13,7 @@
 set -euo pipefail
 
 INTERVAL="${INTERVAL:-60}"
-API_BASE="${API_BASE:-https://foundry-x-api.ktds-axbd.workers.dev}"
+API_BASE="${API_BASE:-https://fx-gateway.ktds-axbd.workers.dev}"
 REPO_DIR="${REPO_DIR:-$(pwd)}"
 ONCE=false
 

--- a/scripts/seed-discovery-reports.sh
+++ b/scripts/seed-discovery-reports.sh
@@ -12,7 +12,7 @@
 
 set -euo pipefail
 
-API_BASE="${FOUNDRY_X_API:-https://foundry-x-api.ktds-axbd.workers.dev/api}"
+API_BASE="${FOUNDRY_X_API:-https://fx-gateway.ktds-axbd.workers.dev/api}"
 TOKEN="${FOUNDRY_X_TOKEN:-}"
 
 if [ -z "$TOKEN" ]; then

--- a/scripts/session-collector.sh
+++ b/scripts/session-collector.sh
@@ -10,7 +10,7 @@
 
 set -euo pipefail
 
-API_URL="${FOUNDRY_API_URL:-https://foundry-x-api.ktds-axbd.workers.dev}"
+API_URL="${FOUNDRY_API_URL:-https://fx-gateway.ktds-axbd.workers.dev}"
 API_TOKEN="${FOUNDRY_API_TOKEN:-}"
 
 if [ -z "$API_TOKEN" ]; then

--- a/scripts/sf-scan-register.sh
+++ b/scripts/sf-scan-register.sh
@@ -3,12 +3,12 @@
 # Usage: ./scripts/sf-scan-register.sh [--api-url URL] [--token TOKEN]
 #
 # 환경변수:
-#   FOUNDRY_X_API_URL — API 기본 URL (기본: https://foundry-x-api.ktds-axbd.workers.dev/api)
+#   FOUNDRY_X_API_URL — API 기본 URL (기본: https://fx-gateway.ktds-axbd.workers.dev/api)
 #   FOUNDRY_X_TOKEN   — 인증 JWT 토큰
 
 set -euo pipefail
 
-API_URL="${FOUNDRY_X_API_URL:-https://foundry-x-api.ktds-axbd.workers.dev/api}"
+API_URL="${FOUNDRY_X_API_URL:-https://fx-gateway.ktds-axbd.workers.dev/api}"
 TOKEN="${FOUNDRY_X_TOKEN:-}"
 
 # Parse arguments

--- a/scripts/skill-demo-seed.sh
+++ b/scripts/skill-demo-seed.sh
@@ -3,7 +3,7 @@
 # Usage: ./scripts/skill-demo-seed.sh [API_URL] [TOKEN]
 set -euo pipefail
 
-API_URL="${1:-https://foundry-x-api.ktds-axbd.workers.dev/api}"
+API_URL="${1:-https://fx-gateway.ktds-axbd.workers.dev/api}"
 TOKEN="${2:-${FOUNDRY_X_TOKEN:-}}"
 
 if [ -z "$TOKEN" ]; then

--- a/scripts/task/task-daemon.sh
+++ b/scripts/task/task-daemon.sh
@@ -887,7 +887,7 @@ phase_sprint_signals() {
 
     # 7) Post-merge 검증 (구 sprint-merge-monitor.sh 기능 통합, C43)
     # deploy 자체는 CI/CD(deploy.yml on master push)가 자동 처리 — 여기서는 health check만
-    local api_base="https://foundry-x-api.ktds-axbd.workers.dev"
+    local api_base="https://fx-gateway.ktds-axbd.workers.dev"
     local web_base="https://fx.minu.best"
     local api_status web_status
     api_status=$(curl -s -o /dev/null -w "%{http_code}" "${api_base}/api/health" 2>/dev/null || echo "000")

--- a/scripts/usage-tracker-hook.sh
+++ b/scripts/usage-tracker-hook.sh
@@ -6,11 +6,11 @@
 #   { "type": "command", "event": "PostToolUse", "command": "./scripts/usage-tracker-hook.sh", "matcher": { "tool_name": "Skill" } }
 #
 # 환경변수:
-#   FOUNDRY_X_API_URL — API 베이스 URL (기본: https://foundry-x-api.ktds-axbd.workers.dev/api)
+#   FOUNDRY_X_API_URL — API 베이스 URL (기본: https://fx-gateway.ktds-axbd.workers.dev/api)
 #   FOUNDRY_X_TOKEN   — JWT Bearer 토큰 (없으면 조용히 무시)
 set -euo pipefail
 
-API_URL="${FOUNDRY_X_API_URL:-https://foundry-x-api.ktds-axbd.workers.dev/api}"
+API_URL="${FOUNDRY_X_API_URL:-https://fx-gateway.ktds-axbd.workers.dev/api}"
 TOKEN="${FOUNDRY_X_TOKEN:-}"
 
 # stdin에서 hook 데이터 읽기 (JSON)


### PR DESCRIPTION
## Summary

- **Group A (biz-items CRUD)**: `GET /api/biz-items`, `POST /api/biz-items`, `GET /api/biz-items/:id` → fx-discovery
- **Group B (stages+pipeline)**: `GET/POST /biz-items/:id/discovery-{progress,stage}`, `GET /discovery-pipeline/runs{/:id}` → fx-discovery
- **F539b iweol**: CLI URL → `fx-gateway.ktds-axbd.workers.dev` (scripts + E2E smoke)
- `packages/api` route stubs replaced with migration comments

## Implementation

| Component | Changes |
|-----------|---------|
| fx-gateway | 7 routing rules added before MAIN_API catch-all |
| fx-discovery | 3 route files + 3 service files + 3 schema files |
| packages/api | 7 handlers removed (biz-items CRUD + stages + pipeline GET) |
| tests | 11 new tests in fx-discovery GREEN, gateway test updated, api test fixtures fixed |

## Test plan

- [x] `turbo typecheck` — 13 packages all pass
- [x] `turbo test` — 12 tasks successful (3721+ tests)
- [x] fx-discovery: 11 new tests (5 biz-items + 3 stages + 3 pipeline) GREEN
- [x] fx-gateway: 8 tests GREEN (routing updated)
- [x] packages/api: migrated route tests removed, classify/evaluate fixed with DB seeding

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- fx-pr-enrich -->
### Sprint Metadata
- Sprint: 296
- F-items: F539c
- Match Rate: 95%
<!-- /fx-pr-enrich -->