### PR TITLE
feat(msa): F540 — fx-shaping Worker 신규 생성 (FX-REQ-579)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,7 @@ jobs:
             msa:
               - 'packages/fx-gateway/**'
               - 'packages/fx-discovery/**'
+              - 'packages/fx-shaping/**'
 
   # 코드 변경 시에만 test 실행 (SPEC.md, scripts, docs 변경은 skip)
   test:
@@ -161,6 +162,11 @@ jobs:
       # → 상대 경로로 packages/api의 wrangler 직접 호출.
       - name: Deploy fx-discovery Worker
         working-directory: packages/fx-discovery
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: ../api/node_modules/.bin/wrangler deploy
+      - name: Deploy fx-shaping Worker
+        working-directory: packages/fx-shaping
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: ../api/node_modules/.bin/wrangler deploy

--- a/docs/01-plan/features/sprint-297.plan.md
+++ b/docs/01-plan/features/sprint-297.plan.md
@@ -1,0 +1,75 @@
+---
+id: FX-PLAN-297
+feature: F540
+req: FX-REQ-579
+sprint: 297
+status: approved
+created: 2026-04-15
+---
+
+# Sprint 297 Plan — F540: Shaping 도메인 분리
+
+## 목표
+
+packages/api의 core/shaping 도메인을 독립 Cloudflare Worker(fx-shaping)로 분리한다.
+F539(Discovery 분리) 선례를 따라 Service Binding 기반 MSA 패턴 적용.
+
+## 범위
+
+| # | 작업 | 파일 수 |
+|---|------|--------|
+| (a) | packages/fx-shaping Worker 신규 생성 | ~55 (routes 13 + schemas 16 + services 22 + infra 4) |
+| (b) | fx-gateway: SHAPING Service Binding 추가 + 라우트 위임 | 3 |
+| (c) | packages/api: shaping 마운트 제거 | 1 |
+| (d) | deploy.yml: fx-shaping paths-filter + deploy step | 1 |
+| (e) | TDD: health + route smoke tests | 2 |
+| (f) | Smoke Reality: KOAMI bi-koami-001 Shaping 단계 Graph proposals 1건 이상 | — |
+
+## 전제 조건
+
+- F539a/b/c DONE (Sprint 294~296 완료)
+- C69 preflight 초판 완료 (Master pane, 2026-04-15)
+- D1 동일 DB 공유 (foundry-x-db) — Phase 44에서 독립 DB로 전환 예정
+
+## 구현 전략
+
+1. packages/fx-shaping 폴더 생성 (fx-discovery 선례 그대로 복사)
+2. core/shaping/routes/*.ts → fx-shaping 포팅 (Env 타입만 교체)
+3. core/shaping/schemas/*.ts → fx-shaping 복사
+4. core/shaping/services/*.ts → fx-shaping 복사
+5. Gateway app.ts에 /api/shaping/*, /api/ax-bd/* → SHAPING binding 라우팅
+6. packages/api/src/app.ts에서 shaping import/mount 제거
+7. deploy.yml에 packages/fx-shaping/** paths + deploy step 추가
+
+## ShapingEnv 바인딩 요구사항
+
+```typescript
+export interface ShapingEnv {
+  DB: D1Database;
+  JWT_SECRET: string;
+  ANTHROPIC_API_KEY?: string;
+  CACHE: KVNamespace;        // ax-bd-agent(rate limit) + ax-bd-persona-eval(rate limit)
+  FILES_BUCKET: R2Bucket;    // ax-bd-prototypes(HTML 제공)
+  MARKER_PROJECT_ID?: string; // ax-bd-prototypes(Marker.io snippet)
+}
+```
+
+## Gateway 라우팅 패턴
+
+```
+/api/shaping/* → fx-shaping
+/api/ax-bd/* → fx-shaping
+```
+
+## TDD 계획
+
+- Red: health.test.ts + shaping-routes.test.ts (route smoke — 401 응답 확인)
+- Green: fx-shaping Worker 전체 구현
+- 검증: cd packages/fx-shaping && pnpm typecheck && pnpm test
+
+## 완료 기준 (Phase Exit 체크리스트)
+
+- [ ] pnpm typecheck (packages/fx-shaping, fx-gateway, api) PASS
+- [ ] pnpm test (packages/fx-shaping) PASS
+- [ ] msa-lint CI PASS (cross-domain import 0건)
+- [ ] Smoke Reality: KOAMI bi-koami-001 Shaping proposals 1건 이상

--- a/docs/02-design/features/sprint-297.design.md
+++ b/docs/02-design/features/sprint-297.design.md
@@ -58,24 +58,18 @@ packages/fx-shaping/
     │   ├── ax-bd-progress.ts
     │   ├── persona-configs.ts
     │   └── persona-evals.ts
-    ├── schemas/        (16개 — core/shaping/schemas/* 복사)
-    │   ├── shaping.ts
-    │   ├── bmc.schema.ts
-    │   ├── bmc-comment.schema.ts
-    │   ├── bmc-history.schema.ts
-    │   ├── bmc-insight.schema.ts
-    │   ├── bmc-agent.schema.ts
-    │   ├── bd-progress.schema.ts
-    │   ├── commit-gate.schema.ts
-    │   ├── hitl-section.schema.ts
-    │   ├── idea-bmc-link.schema.ts
-    │   ├── persona-config-schema.ts
-    │   ├── persona-config.ts
-    │   ├── persona-eval-schema.ts
-    │   ├── persona-eval.ts
-    │   └── viability-checkpoint.schema.ts
+    ├── schemas/        (15개 — core/shaping/schemas/* 복사)
+    │   └── [모든 schema 파일 동일]
     ├── services/       (22개 — core/shaping/services/* 복사)
     │   └── [모든 service 파일 동일]
+    ├── agent/services/ (6개 — 내재화된 AI 의존 서비스)
+    │   └── agent-runner, claude-api-runner, execution-types, model-router, openrouter-runner, prompt-gateway, prompt-utils, skill-metrics
+    ├── harness/        (7개 — prototype 관련 services/schemas)
+    │   ├── services/: prototype-service, tech-review-service, prototype-review-service, prototype-job-service, audit-logger
+    │   └── schemas/: prototype-ext, prototype-build, prototype-job
+    ├── launch/services/ (2개 — poc-env-service, pipeline-state-machine)
+    ├── collection/services/ (1개 — idea-service, shaping이 BMC 연결에 사용)
+    └── discovery/schemas/ (1개 — discovery-pipeline type contract)
     └── __tests__/
         ├── health.test.ts
         └── shaping-routes.test.ts
@@ -141,9 +135,9 @@ export interface ShapingEnv {
 
 ## §7 Cross-domain Import 검증 (D1 체크리스트)
 
-- shaping → discovery: 없음 (shaping-review-service.ts 주석만)
 - shaping → offering: 없음
 - shaping → shared: BdArtifact, ArtifactListQuery, ExecuteSkillInput, SkillExecutionResult, TriggerShapingInput (허용 — contract)
+- shaping → discovery: `discovery/schemas/discovery-pipeline.ts` 포팅 (pipeline-state-machine이 DiscoveryPipelineStatus 타입 참조 — type contract 허용)
 
 ## §8 msa-lint 확인 사항
 

--- a/docs/02-design/features/sprint-297.design.md
+++ b/docs/02-design/features/sprint-297.design.md
@@ -1,0 +1,178 @@
+---
+id: FX-DESIGN-297
+feature: F540
+req: FX-REQ-579
+sprint: 297
+status: approved
+created: 2026-04-15
+---
+
+# Sprint 297 Design — F540: Shaping 도메인 분리
+
+## §1 아키텍처 개요
+
+```
+Browser / CLI
+    │
+    ▼
+fx-gateway (CORS)
+    ├── /api/shaping/* ──────────► fx-shaping Worker [NEW]
+    ├── /api/ax-bd/* ────────────► fx-shaping Worker [NEW]
+    ├── /api/discovery/* ────────► fx-discovery Worker [기존]
+    └── /api/* ──────────────────► foundry-x-api [잔여]
+
+fx-shaping
+    ├── DB (D1: foundry-x-db, 공유)
+    ├── CACHE (KV: 030b30d47a98485ea3af95b3347163d6)
+    ├── FILES_BUCKET (R2: foundry-x-files)
+    └── ANTHROPIC_API_KEY (Secret)
+```
+
+## §2 신규 패키지 구조 (packages/fx-shaping/)
+
+```
+packages/fx-shaping/
+├── wrangler.toml
+├── package.json
+├── tsconfig.json
+├── vitest.config.ts
+├── eslint.config.js
+└── src/
+    ├── index.ts
+    ├── app.ts
+    ├── env.ts
+    ├── middleware/
+    │   ├── auth.ts
+    │   └── tenant.ts
+    ├── routes/         (13개 — core/shaping/routes/* 포팅)
+    │   ├── shaping.ts
+    │   ├── ax-bd-bmc.ts
+    │   ├── ax-bd-agent.ts
+    │   ├── ax-bd-comments.ts
+    │   ├── ax-bd-history.ts
+    │   ├── ax-bd-links.ts
+    │   ├── ax-bd-viability.ts
+    │   ├── ax-bd-prototypes.ts
+    │   ├── ax-bd-skills.ts
+    │   ├── ax-bd-persona-eval.ts
+    │   ├── ax-bd-progress.ts
+    │   ├── persona-configs.ts
+    │   └── persona-evals.ts
+    ├── schemas/        (16개 — core/shaping/schemas/* 복사)
+    │   ├── shaping.ts
+    │   ├── bmc.schema.ts
+    │   ├── bmc-comment.schema.ts
+    │   ├── bmc-history.schema.ts
+    │   ├── bmc-insight.schema.ts
+    │   ├── bmc-agent.schema.ts
+    │   ├── bd-progress.schema.ts
+    │   ├── commit-gate.schema.ts
+    │   ├── hitl-section.schema.ts
+    │   ├── idea-bmc-link.schema.ts
+    │   ├── persona-config-schema.ts
+    │   ├── persona-config.ts
+    │   ├── persona-eval-schema.ts
+    │   ├── persona-eval.ts
+    │   └── viability-checkpoint.schema.ts
+    ├── services/       (22개 — core/shaping/services/* 복사)
+    │   └── [모든 service 파일 동일]
+    └── __tests__/
+        ├── health.test.ts
+        └── shaping-routes.test.ts
+```
+
+## §3 환경 바인딩 (env.ts)
+
+```typescript
+export interface ShapingEnv {
+  DB: D1Database;
+  JWT_SECRET: string;
+  ANTHROPIC_API_KEY?: string;
+  CACHE: KVNamespace;
+  FILES_BUCKET: R2Bucket;
+  MARKER_PROJECT_ID?: string;
+}
+```
+
+## §4 타입 변환 계약 (TDD Red Target)
+
+모든 route 파일에서:
+- `import type { Env } from "../../../env.js"` → `import type { ShapingEnv } from "../env.js"`
+- `import type { TenantVariables } from "../../../middleware/tenant.js"` → 로컬 경로
+- `Bindings: Env` → `Bindings: ShapingEnv`
+
+## §5 파일 매핑 (D1 체크리스트)
+
+### 신규 생성 파일
+
+| 파일 | 내용 |
+|------|------|
+| packages/fx-shaping/wrangler.toml | D1 + KV(CACHE) + R2(FILES_BUCKET) + Secrets |
+| packages/fx-shaping/package.json | name: @foundry-x/fx-shaping, hono, zod, @anthropic-ai/sdk |
+| packages/fx-shaping/tsconfig.json | fx-discovery와 동일 |
+| packages/fx-shaping/vitest.config.ts | fx-discovery와 동일 |
+| packages/fx-shaping/eslint.config.js | fx-discovery와 동일 |
+| packages/fx-shaping/src/index.ts | ExportedHandler wiring |
+| packages/fx-shaping/src/app.ts | health + auth 미들웨어 + 13개 route 마운트 |
+| packages/fx-shaping/src/env.ts | ShapingEnv interface |
+| packages/fx-shaping/src/middleware/auth.ts | JWT authMiddleware (shaping health 공개) |
+| packages/fx-shaping/src/middleware/tenant.ts | tenantGuard |
+| packages/fx-shaping/src/routes/*.ts | 13개 routes (Env 타입 교체) |
+| packages/fx-shaping/src/schemas/*.ts | 16개 schemas (변경 없음) |
+| packages/fx-shaping/src/services/*.ts | 22개 services (변경 없음) |
+| packages/fx-shaping/src/__tests__/health.test.ts | GET /api/shaping/health → 200 |
+| packages/fx-shaping/src/__tests__/shaping-routes.test.ts | POST /api/shaping/runs → 401 (미인증) |
+
+### 수정 파일
+
+| 파일 | 변경 내용 |
+|------|----------|
+| packages/fx-gateway/wrangler.toml | [[services]] SHAPING 추가 |
+| packages/fx-gateway/src/env.ts | SHAPING: Fetcher 추가 |
+| packages/fx-gateway/src/app.ts | /api/shaping/* + /api/ax-bd/* → SHAPING 라우팅 추가 |
+| packages/api/src/app.ts | shaping 관련 import 13개 + app.route() 14개 제거 |
+| .github/workflows/deploy.yml | msa filter에 fx-shaping 추가, deploy-msa step 추가 |
+
+## §6 D1/Breaking Change 검증
+
+- D1 migration 신규 없음 (테이블 동일 DB 공유, 스키마 변경 없음)
+- Breaking change: packages/api에서 shaping routes 제거 → Gateway를 통해서만 접근
+- 주입 사이트: Gateway가 유일한 진입점
+
+## §7 Cross-domain Import 검증 (D1 체크리스트)
+
+- shaping → discovery: 없음 (shaping-review-service.ts 주석만)
+- shaping → offering: 없음
+- shaping → shared: BdArtifact, ArtifactListQuery, ExecuteSkillInput, SkillExecutionResult, TriggerShapingInput (허용 — contract)
+
+## §8 msa-lint 확인 사항
+
+- foundry-x-api/no-cross-domain-import: packages/api에서 shaping 제거 후 잔여 import 없음 확인
+- foundry-x-api/no-direct-route-register: app.ts에서 shaping app.route() 제거 확인
+
+## §9 Gateway 라우팅 설계
+
+```
+Discovery 패턴 참조:
+  app.all("/api/discovery/*", (c) => c.env.DISCOVERY.fetch(c.req.raw))
+
+Shaping 라우팅:
+  // Shaping runs (BD 형상화 세션)
+  app.all("/api/shaping/*", (c) => c.env.SHAPING.fetch(c.req.raw))
+  // AX-BD 공통 라우트 (BMC, prototypes, skills, viability, persona, etc.)
+  app.all("/api/ax-bd/*", (c) => c.env.SHAPING.fetch(c.req.raw))
+  // ideas/:id/bmc — shaping이 소유
+  app.all("/api/ideas/:id/bmc", (c) => c.env.SHAPING.fetch(c.req.raw))
+  app.all("/api/ideas/:id/bmc/*", (c) => c.env.SHAPING.fetch(c.req.raw))
+
+주의: /api/ax-bd/* 중 discovery-report* 는 DISCOVERY에 이미 라우팅됨(F538)
+  → Gateway에서 /api/ax-bd/discovery-report* 먼저 등록(DISCOVERY) 후 /api/ax-bd/* (SHAPING) 후 등록
+```
+
+## §10 TDD Red Target
+
+```
+test: GET /api/shaping/health → { domain: "shaping", status: "ok" } (public)
+test: POST /api/shaping/runs (no auth) → 401
+test: POST /api/ax-bd/bmc (no auth) → 401
+```

--- a/docs/04-report/sprint-297-f540-report.md
+++ b/docs/04-report/sprint-297-f540-report.md
@@ -1,0 +1,76 @@
+---
+sprint: 297
+feature: F540
+req: FX-REQ-579
+match_rate: 96
+test_result: pass
+date: 2026-04-15
+---
+
+# Sprint 297 Report — F540: Shaping 도메인 분리
+
+## 요약
+
+fx-shaping 독립 Worker 생성 완료. 13 routes, 22 services, 15 schemas를 packages/api에서 분리.
+fx-gateway Service Binding 연동 + CI/CD 파이프라인 통합. Match Rate 96%.
+
+## 구현 통계
+
+| 항목 | 수치 |
+|------|------|
+| 신규 파일 | 89개 (fx-shaping 전체) |
+| 수정 파일 | 5개 (gateway 3 + api 2 + deploy.yml 1) |
+| TDD 테스트 | 4개 (health 1 + auth 3) PASS |
+| Match Rate | 96% |
+| 의존 서비스 내재화 | 17개 (agent 8 + harness 8 + collection 1 + discovery 1) |
+
+## 주요 변경
+
+### packages/fx-shaping (신규)
+- `wrangler.toml`: D1 + KV(CACHE) + R2(FILES_BUCKET) + ANTHROPIC_API_KEY
+- 13 routes: shaping, ax-bd-bmc/agent/comments/history/links/viability/prototypes/skills/persona-eval/progress, persona-configs/evals
+- `ShapingEnv` — Env 타입 분리 (packages/api Env에서 독립)
+- middleware: JWT auth + tenant guard (fx-discovery 패턴 재사용)
+
+### fx-gateway
+- SHAPING Service Binding 추가
+- /api/shaping/* + /api/ax-bd/* → fx-shaping 라우팅
+- /api/ax-bd/discovery-report* 선행 등록으로 DISCOVERY 우선 처리 유지
+- /api/ideas/:id/bmc + bmc/* → fx-shaping (BMC 연동)
+
+### packages/api
+- shaping 13개 app.route() 제거 (주석으로 이전 사유 표시)
+- core/index.ts shaping exports 제거
+
+### deploy.yml
+- msa paths-filter에 `packages/fx-shaping/**` 추가
+- deploy-msa에 fx-shaping deploy step 추가 (fx-gateway 직전 배포)
+
+## 의존 서비스 내재화 관찰
+
+shaping 서비스들이 agent(prompt-gateway 등), harness(prototype-service 등), collection(idea-service) 도메인을 cross-import하고 있었음. 현재 MSA 분리는 이들을 fx-shaping 내부에 복사(내재화)하여 Worker 자기완결성 확보.
+
+후속 검토:
+- C57 shared 슬리밍 (F541 완료 후) 시 이 내재화된 파일들을 fx-shaping 전용 내부 타입으로 정리
+- C56 D1 격리 ESLint 룰은 F541 전에 적용 권장
+
+## Gap Analysis
+
+Match Rate: 96%
+
+미명시 추가 구현:
+- agent/, harness/, launch/, collection/, discovery/ 하위 내재화 모듈 (Design 역동기화 완료)
+- schemas 15개 (Design 텍스트 16개 오기 — 실수정)
+
+## Phase Exit 체크리스트 (F540)
+
+- [x] pnpm typecheck (fx-shaping, fx-gateway) PASS
+- [x] pnpm test (4 tests) PASS
+- [x] msa-lint: cross-domain import 위반 없음
+- [x] deploy.yml fx-shaping paths + deploy step 추가
+- [ ] Smoke Reality: KOAMI bi-koami-001 Shaping 단계 Graph proposals >= 1건 (배포 후 검증 필요)
+
+## 다음 Sprint
+
+- Sprint 298: F541 Offering 도메인 분리 (F540 선례 활용)
+- C56: D1 격리 ESLint 룰 (F541 착수 전 선행 권장)

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -33,11 +33,7 @@ import {
   bizItemsRoute,
   discoveryPipelineRoute,
   discoveryStagesRoute, discoveryShapePipelineRoute, discoveryStageRunnerRoute,
-  // shaping (14 routes)
-  shapingRoute, axBdBmcRoute, axBdAgentRoute, axBdCommentsRoute,
-  axBdHistoryRoute, axBdLinksRoute, axBdViabilityRoute,
-  axBdPrototypesRoute, axBdSkillsRoute, axBdPersonaEvalRoute,
-  axBdProgressRoute, personaConfigsRoute, personaEvalsRoute,
+  // shaping — F540: 전체 fx-shaping Worker로 이전 (routes 제거됨)
   // offering (12 routes — Sprint 216: businessPlanExportRoute 추가)
   offeringsRoute, offeringSectionsRoute, offeringExportRoute,
   offeringValidateRoute, offeringMetricsRoute, offeringPrototypeRoute,
@@ -280,17 +276,13 @@ app.route("/api", collectionRoute);
 // Sprint 59: Methodology registry + router (auth + tenant required)
 app.route("/api", methodologyRoute);
 
-// Sprint 61: AX BD Ideation — BMC + Ideas (auth + tenant required)
-app.route("/api", axBdBmcRoute);
+// Sprint 61: AX BD Ideation — Ideas (auth + tenant required)
+// axBdBmcRoute → F540: fx-shaping
 app.route("/api", axBdIdeasRoute);
 
-// Sprint 62: BMCAgent + Version History (auth + tenant required)
-app.route("/api", axBdAgentRoute);
-app.route("/api", axBdHistoryRoute);
+// Sprint 62: BMCAgent + Version History → F540: fx-shaping으로 이전
 
-// Sprint 64: AX BD — 아이디어-BMC 연결 + BMC 댓글 (auth + tenant required)
-app.route("/api", axBdLinksRoute);
-app.route("/api", axBdCommentsRoute);
+// Sprint 64: AX BD — 아이디어-BMC 연결 + BMC 댓글 → F540: fx-shaping으로 이전
 
 // Sprint 65: AX BD — 인사이트 + 평가관리 (auth + tenant required)
 app.route("/api", axBdInsightsRoute);
@@ -299,11 +291,9 @@ app.route("/api", axBdEvaluationsRoute);
 // Sprint 66: Discovery-X API 인터페이스 계약 (auth + tenant required)
 app.route("/api", axBdDiscoveryRoute);
 
-// Sprint 67: F209 AI Foundry 흡수 — Prototype + PoC + TechReview (auth + tenant required)
-app.route("/api", axBdPrototypesRoute);
+// Sprint 67: F209 AI Foundry 흡수 — Prototype + PoC + TechReview → F540: fx-shaping으로 이전
 
-// Sprint 69: F213 사업성 체크포인트 + Commit Gate (auth + tenant required)
-app.route("/api", axBdViabilityRoute);
+// Sprint 69: F213 사업성 체크포인트 + Commit Gate → F540: fx-shaping으로 이전
 
 // Sprint 76: F221 Agent-as-Code + F223 Doc Sharding (auth + tenant required)
 app.route("/api", agentDefinitionRoute);
@@ -338,11 +328,9 @@ app.route("/api", adminRoute);
 // Sprint 88: Org shared data + NPS (F253, F254)
 app.route("/api", orgSharedRoute);
 app.route("/api", npsRoute);
-// Sprint 90: BD 스킬 실행 + 산출물 (F260, F261)
-app.route("/api", axBdSkillsRoute);
+// Sprint 90: BD 스킬 실행 → F540: fx-shaping 이전 / 산출물 (F261)
 app.route("/api", axBdArtifactsRoute);
-// Sprint 91: BD 프로세스 진행 추적 (F262)
-app.route("/api", axBdProgressRoute);
+// Sprint 91: BD 프로세스 진행 추적 → F540: fx-shaping 이전 / KG (F262)
 app.route("/api", axBdKgRoute);
 // Sprint 95: Help Agent 챗봇 (F264)
 app.route("/api", helpAgentRoute);
@@ -358,8 +346,7 @@ app.route("/api", derivedEngineRoute);
 app.route("/api", capturedEngineRoute);
 // Sprint 107: BD ROI 벤치마크 (F278)
 app.route("/api", roiBenchmarkRoute);
-// Sprint 112: BD 형상화 Phase F (F286, F287)
-app.route("/api", shapingRoute);
+// Sprint 112: BD 형상화 Phase F → F540: fx-shaping으로 이전
 // Sprint 116: 2-tier 검증 + 미팅 관리 (F294, F295)
 app.route("/api", validationTierRoute);
 app.route("/api", validationMeetingsRoute);
@@ -388,13 +375,10 @@ app.route("/api", orchestrationRoute);
 // Sprint 151: Agent Adapter Registry (F336, Phase 14)
 app.route("/api", agentAdaptersRoute);
 
-// Sprint 154: Discovery UI/UX v2 (F342)
-app.route("/api", personaConfigsRoute);
-app.route("/api", personaEvalsRoute);
+// Sprint 154: Discovery UI/UX v2 (F342) — personaConfigsRoute/personaEvalsRoute → F540: fx-shaping
 // discoveryReportsRoute → fx-discovery (F538)
 app.route("/api", teamReviewsRoute);
-// Sprint 155: 멀티 페르소나 평가 (F344, F345, Phase 15)
-app.route("/api", axBdPersonaEvalRoute);
+// Sprint 155: 멀티 페르소나 평가 → F540: fx-shaping으로 이전
 // Sprint 156: discoveryReportRoute → fx-discovery (F538)
 // Sprint 159: Prototype Auto-Gen (F353, F354, Phase 16)
 app.route("/api", prototypeJobsRoute);

--- a/packages/api/src/core/index.ts
+++ b/packages/api/src/core/index.ts
@@ -10,13 +10,7 @@ export {
   discoveryStageRunnerRoute,
 } from "./discovery/index.js";
 
-// Shaping (S3 형상화) — 14 routes
-export {
-  shapingRoute, axBdBmcRoute, axBdAgentRoute, axBdCommentsRoute,
-  axBdHistoryRoute, axBdLinksRoute, axBdViabilityRoute,
-  axBdPrototypesRoute, axBdSkillsRoute, axBdPersonaEvalRoute,
-  axBdProgressRoute, personaConfigsRoute, personaEvalsRoute,
-} from "./shaping/index.js";
+// Shaping — F540: fx-shaping Worker로 이전 (exports 제거됨)
 
 // Offering Pipeline — 12 routes (Sprint 216: businessPlanExportRoute 추가)
 export {

--- a/packages/fx-gateway/src/__tests__/gateway.test.ts
+++ b/packages/fx-gateway/src/__tests__/gateway.test.ts
@@ -25,7 +25,8 @@ describe("F523: Gateway DISCOVERY routing (hardwired)", () => {
   it("/api/discovery/* → DISCOVERY Service Binding으로 전달한다", async () => {
     const discovery = makeDiscoveryMock();
     const mainApi = makeMainApiMock();
-    const env: GatewayEnv = { MAIN_API: mainApi, DISCOVERY: discovery };
+    const shapingMock = { fetch: vi.fn().mockResolvedValue(new Response("{}")) } as unknown as Fetcher;
+    const env: GatewayEnv = { MAIN_API: mainApi, DISCOVERY: discovery, SHAPING: shapingMock };
 
     const res = await app.request("/api/discovery/items", {}, env);
 
@@ -37,7 +38,8 @@ describe("F523: Gateway DISCOVERY routing (hardwired)", () => {
   it("/api/discovery/health → DISCOVERY로 전달한다", async () => {
     const discovery = makeDiscoveryMock();
     const mainApi = makeMainApiMock();
-    const env: GatewayEnv = { MAIN_API: mainApi, DISCOVERY: discovery };
+    const shapingMock = { fetch: vi.fn().mockResolvedValue(new Response("{}")) } as unknown as Fetcher;
+    const env: GatewayEnv = { MAIN_API: mainApi, DISCOVERY: discovery, SHAPING: shapingMock };
 
     await app.request("/api/discovery/health", {}, env);
 
@@ -49,7 +51,8 @@ describe("F523: Gateway DISCOVERY routing (hardwired)", () => {
   it("/api/biz-items → DISCOVERY Service Binding으로 전달한다", async () => {
     const discovery = makeDiscoveryMock();
     const mainApi = makeMainApiMock();
-    const env: GatewayEnv = { MAIN_API: mainApi, DISCOVERY: discovery };
+    const shapingMock = { fetch: vi.fn().mockResolvedValue(new Response("{}")) } as unknown as Fetcher;
+    const env: GatewayEnv = { MAIN_API: mainApi, DISCOVERY: discovery, SHAPING: shapingMock };
 
     const res = await app.request("/api/biz-items", {}, env);
 
@@ -61,7 +64,8 @@ describe("F523: Gateway DISCOVERY routing (hardwired)", () => {
   it("Authorization 헤더가 MAIN_API downstream으로 그대로 전달된다", async () => {
     const mainApi = makeMainApiMock();
     const discovery = makeDiscoveryMock();
-    const env: GatewayEnv = { MAIN_API: mainApi, DISCOVERY: discovery };
+    const shapingMock = { fetch: vi.fn().mockResolvedValue(new Response("{}")) } as unknown as Fetcher;
+    const env: GatewayEnv = { MAIN_API: mainApi, DISCOVERY: discovery, SHAPING: shapingMock };
 
     await app.request(
       "/api/health",
@@ -77,9 +81,11 @@ describe("F523: Gateway DISCOVERY routing (hardwired)", () => {
 
 // F539b: CORS 미들웨어 테스트
 describe("F539b: Gateway CORS (FX-REQ-577)", () => {
+  const makeShapingMock = () => ({ fetch: vi.fn().mockResolvedValue(new Response("{}")) } as unknown as Fetcher);
   const makeEnv = (): GatewayEnv => ({
     MAIN_API: makeMainApiMock(),
     DISCOVERY: makeDiscoveryMock(),
+    SHAPING: makeShapingMock(),
   });
 
   it("OPTIONS preflight 요청에 CORS 헤더를 반환한다", async () => {

--- a/packages/fx-gateway/src/app.ts
+++ b/packages/fx-gateway/src/app.ts
@@ -1,6 +1,7 @@
 // fx-gateway app (F523: FX-REQ-551 — DISCOVERY 하드와이어 활성화)
 // F538: ax-bd/discovery-report* 라우트도 fx-discovery로 이전
 // F539b: CORS 미들웨어 추가 — 브라우저 직접 접점 (FX-REQ-577)
+// F540: ax-bd/*, shaping/* → fx-shaping Worker
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import type { GatewayEnv } from "./env.js";
@@ -55,6 +56,25 @@ app.get("/api/discovery-pipeline/runs", async (c) => {
 });
 app.get("/api/discovery-pipeline/runs/:id", async (c) => {
   return c.env.DISCOVERY.fetch(c.req.raw);
+});
+
+// F540: /api/shaping/* → fx-shaping Worker
+app.all("/api/shaping/*", async (c) => {
+  return c.env.SHAPING.fetch(c.req.raw);
+});
+
+// F540: /api/ax-bd/* → fx-shaping Worker
+// 주의: /api/ax-bd/discovery-report* 는 위에서 DISCOVERY로 먼저 처리됨
+app.all("/api/ax-bd/*", async (c) => {
+  return c.env.SHAPING.fetch(c.req.raw);
+});
+
+// F540: /api/ideas/:id/bmc — shaping이 소유 (BMC 생성 연동)
+app.all("/api/ideas/:id/bmc", async (c) => {
+  return c.env.SHAPING.fetch(c.req.raw);
+});
+app.all("/api/ideas/:id/bmc/*", async (c) => {
+  return c.env.SHAPING.fetch(c.req.raw);
 });
 
 // 그 외 모든 /api/* 요청은 MAIN_API로

--- a/packages/fx-gateway/src/env.ts
+++ b/packages/fx-gateway/src/env.ts
@@ -4,4 +4,6 @@ export interface GatewayEnv {
   MAIN_API: Fetcher;
   /** Service Binding — fx-discovery Worker (F523: 활성화 완료) */
   DISCOVERY: Fetcher;
+  /** Service Binding — fx-shaping Worker (F540: Shaping 도메인 분리) */
+  SHAPING: Fetcher;
 }

--- a/packages/fx-gateway/wrangler.toml
+++ b/packages/fx-gateway/wrangler.toml
@@ -17,6 +17,11 @@ service = "foundry-x-api"
 binding = "DISCOVERY"
 service = "fx-discovery"
 
+# F540: Service Binding — Shaping Worker
+[[services]]
+binding = "SHAPING"
+service = "fx-shaping"
+
 # Local development
 [env.dev]
 name = "fx-gateway-dev"
@@ -28,3 +33,7 @@ service = "foundry-x-api-dev"
 [[env.dev.services]]
 binding = "DISCOVERY"
 service = "fx-discovery-dev"
+
+[[env.dev.services]]
+binding = "SHAPING"
+service = "fx-shaping-dev"

--- a/packages/fx-shaping/eslint.config.js
+++ b/packages/fx-shaping/eslint.config.js
@@ -1,0 +1,22 @@
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    rules: {
+      '@typescript-eslint/no-unused-vars': ['error', {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+      }],
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/consistent-type-imports': 'error',
+      'no-console': 'off',
+    },
+  },
+  {
+    ignores: ['dist/', 'node_modules/', '**/*.test.ts'],
+  },
+);

--- a/packages/fx-shaping/package.json
+++ b/packages/fx-shaping/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@foundry-x/fx-shaping",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "dev": "wrangler dev",
+    "build": "tsc",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src/"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.36.3",
+    "@foundry-x/shared": "workspace:*",
+    "@hono/zod-openapi": "^0.9.0",
+    "hono": "^4.0.0",
+    "nanoid": "^5.0.0",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20241218.0",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.9.3",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/fx-shaping/src/__tests__/health.test.ts
+++ b/packages/fx-shaping/src/__tests__/health.test.ts
@@ -1,0 +1,23 @@
+// F540 TDD Red — fx-shaping health endpoint
+import { describe, it, expect } from "vitest";
+import app from "../app.js";
+
+const mockEnv = {
+  DB: {} as D1Database,
+  JWT_SECRET: "test-secret",
+  ANTHROPIC_API_KEY: undefined,
+  CACHE: {} as KVNamespace,
+  FILES_BUCKET: {} as R2Bucket,
+  MARKER_PROJECT_ID: undefined,
+};
+
+describe("fx-shaping health (F540)", () => {
+  it("GET /api/shaping/health returns domain=shaping", async () => {
+    const req = new Request("http://localhost/api/shaping/health");
+    const res = await app.fetch(req, mockEnv);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { domain: string; status: string };
+    expect(body.domain).toBe("shaping");
+    expect(body.status).toBe("ok");
+  });
+});

--- a/packages/fx-shaping/src/__tests__/shaping-routes.test.ts
+++ b/packages/fx-shaping/src/__tests__/shaping-routes.test.ts
@@ -1,0 +1,43 @@
+// F540 TDD Red — fx-shaping route authentication
+import { describe, it, expect } from "vitest";
+import app from "../app.js";
+
+const mockEnv = {
+  DB: {} as D1Database,
+  JWT_SECRET: "test-secret",
+  ANTHROPIC_API_KEY: undefined,
+  CACHE: {
+    get: async () => null,
+    put: async () => undefined,
+  } as unknown as KVNamespace,
+  FILES_BUCKET: {} as R2Bucket,
+  MARKER_PROJECT_ID: undefined,
+};
+
+describe("fx-shaping routes require auth (F540)", () => {
+  it("POST /api/shaping/runs without auth → 401", async () => {
+    const req = new Request("http://localhost/api/shaping/runs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ bizItemId: "test" }),
+    });
+    const res = await app.fetch(req, mockEnv);
+    expect(res.status).toBe(401);
+  });
+
+  it("POST /api/ax-bd/bmc without auth → 401", async () => {
+    const req = new Request("http://localhost/api/ax-bd/bmc", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    const res = await app.fetch(req, mockEnv);
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /api/ax-bd/persona-evals/test-item without auth → 401", async () => {
+    const req = new Request("http://localhost/api/ax-bd/persona-evals/test-item");
+    const res = await app.fetch(req, mockEnv);
+    expect(res.status).toBe(401);
+  });
+});

--- a/packages/fx-shaping/src/agent/services/agent-runner.ts
+++ b/packages/fx-shaping/src/agent/services/agent-runner.ts
@@ -1,0 +1,76 @@
+// Sprint 10 types — mirrors @foundry-x/shared agent.ts F53 types
+// (imported locally until shared/index.ts re-exports are updated)
+import type {
+  AgentExecutionRequest,
+  AgentExecutionResult,
+  AgentRunnerType,
+  AgentTaskType,
+} from "./execution-types.js";
+import { ClaudeApiRunner, MockRunner } from "./claude-api-runner.js";
+import { OpenRouterRunner } from "./openrouter-runner.js";
+import { ModelRouter } from "./model-router.js";
+
+/**
+ * 에이전트 실행의 추상화 계층.
+ * 다양한 실행 백엔드(Claude API, OpenRouter, MCP, mock)를 교체 가능하게 분리.
+ */
+export interface AgentRunner {
+  readonly type: AgentRunnerType;
+
+  /** 에이전트 작업 실행 */
+  execute(request: AgentExecutionRequest): Promise<AgentExecutionResult>;
+
+  /** 실행 가능 여부 (API key 존재, 서버 연결 등) */
+  isAvailable(): Promise<boolean>;
+
+  /** 특정 taskType 지원 여부 */
+  supportsTaskType(taskType: string): boolean;
+}
+
+/**
+ * AgentRunner 팩토리 — 환경에 따라 적절한 Runner를 생성
+ * 우선순위: OpenRouter > Claude API > Mock
+ */
+export function createAgentRunner(env: {
+  OPENROUTER_API_KEY?: string;
+  OPENROUTER_DEFAULT_MODEL?: string;
+  ANTHROPIC_API_KEY?: string;
+}): AgentRunner {
+  if (env.OPENROUTER_API_KEY) {
+    return new OpenRouterRunner(
+      env.OPENROUTER_API_KEY,
+      env.OPENROUTER_DEFAULT_MODEL,
+    );
+  }
+  if (env.ANTHROPIC_API_KEY) {
+    return new ClaudeApiRunner(env.ANTHROPIC_API_KEY);
+  }
+  return new MockRunner();
+}
+
+/**
+ * F136: 태스크별 모델 라우팅 팩토리
+ * D1 규칙 기반으로 taskType에 맞는 최적 모델의 Runner를 생성.
+ * db 미제공 시 기존 createAgentRunner 로직으로 폴백.
+ */
+export async function createRoutedRunner(
+  env: {
+    OPENROUTER_API_KEY?: string;
+    OPENROUTER_DEFAULT_MODEL?: string;
+    ANTHROPIC_API_KEY?: string;
+  },
+  taskType: AgentTaskType,
+  db?: D1Database,
+): Promise<AgentRunner> {
+  if (db) {
+    const router = new ModelRouter(db);
+    const rule = await router.getModelForTask(taskType);
+    if (rule.runnerType === "openrouter" && env.OPENROUTER_API_KEY) {
+      return new OpenRouterRunner(env.OPENROUTER_API_KEY, rule.modelId);
+    }
+    if (rule.runnerType === "claude-api" && env.ANTHROPIC_API_KEY) {
+      return new ClaudeApiRunner(env.ANTHROPIC_API_KEY, rule.modelId);
+    }
+  }
+  return createAgentRunner(env);
+}

--- a/packages/fx-shaping/src/agent/services/claude-api-runner.ts
+++ b/packages/fx-shaping/src/agent/services/claude-api-runner.ts
@@ -1,0 +1,123 @@
+import type {
+  AgentExecutionRequest,
+  AgentExecutionResult,
+} from "./execution-types.js";
+import type { AgentRunner } from "./agent-runner.js";
+import { TASK_SYSTEM_PROMPTS, buildUserPrompt, getSystemPrompt } from "./prompt-utils.js";
+
+// Re-export for backward compatibility (tests import from this module)
+export { UIHINT_INSTRUCTION, TASK_SYSTEM_PROMPTS, DEFAULT_LAYOUT_MAP, buildUserPrompt } from "./prompt-utils.js";
+
+export class ClaudeApiRunner implements AgentRunner {
+  readonly type = "claude-api" as const;
+
+  constructor(
+    private apiKey: string,
+    private model: string = "claude-haiku-4-5-20250714",
+  ) {}
+
+  async execute(request: AgentExecutionRequest): Promise<AgentExecutionResult> {
+    const startTime = Date.now();
+
+    const systemPrompt = getSystemPrompt(request);
+    const userPrompt = buildUserPrompt(request);
+
+    const res = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "x-api-key": this.apiKey,
+        "anthropic-version": "2023-06-01",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: this.model,
+        max_tokens: 4096,
+        system: systemPrompt,
+        messages: [{ role: "user", content: userPrompt }],
+      }),
+    });
+
+    if (!res.ok) {
+      return {
+        status: "failed",
+        output: {
+          analysis: `Claude API error: ${res.status} ${res.statusText}`,
+        },
+        tokensUsed: 0,
+        model: this.model,
+        duration: Date.now() - startTime,
+      };
+    }
+
+    const data = (await res.json()) as {
+      content: Array<{ type: string; text: string }>;
+      usage: { input_tokens: number; output_tokens: number };
+    };
+
+    const text = data.content
+      .filter((c) => c.type === "text")
+      .map((c) => c.text)
+      .join("");
+
+    const tokensUsed = data.usage.input_tokens + data.usage.output_tokens;
+
+    try {
+      const parsed = JSON.parse(text);
+      return {
+        status: "success",
+        output: {
+          analysis: parsed.analysis ?? text,
+          generatedCode: parsed.generatedCode,
+          reviewComments: parsed.reviewComments,
+          uiHint: parsed.uiHint,  // F60
+        },
+        tokensUsed,
+        model: this.model,
+        duration: Date.now() - startTime,
+      };
+    } catch {
+      return {
+        status: "partial",
+        output: { analysis: text },
+        tokensUsed,
+        model: this.model,
+        duration: Date.now() - startTime,
+      };
+    }
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return !!this.apiKey;
+  }
+
+  supportsTaskType(taskType: string): boolean {
+    return taskType in TASK_SYSTEM_PROMPTS;
+  }
+}
+
+/**
+ * Mock Runner — 테스트/오프라인용
+ */
+export class MockRunner implements AgentRunner {
+  readonly type = "mock" as const;
+
+  async execute(request: AgentExecutionRequest): Promise<AgentExecutionResult> {
+    return {
+      status: "success",
+      output: {
+        analysis: `[Mock] Task ${request.taskType} completed for ${request.context.targetFiles?.join(", ") ?? "no files"}`,
+      },
+      tokensUsed: 0,
+      model: "mock",
+      duration: 100,
+    };
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return true;
+  }
+
+  supportsTaskType(_taskType: string): boolean {
+    return true;
+  }
+}

--- a/packages/fx-shaping/src/agent/services/execution-types.ts
+++ b/packages/fx-shaping/src/agent/services/execution-types.ts
@@ -1,0 +1,109 @@
+/**
+ * Sprint 10 Agent Execution Types
+ * Mirrors @foundry-x/shared agent.ts F53 types.
+ * Will be replaced with direct import once shared/index.ts re-exports are updated.
+ */
+
+export type AgentTaskType =
+  | "code-review"
+  | "code-generation"
+  | "spec-analysis"
+  | "test-generation"
+  | "security-review"
+  | "qa-testing"
+  | "infra-analysis"
+  | "policy-evaluation"
+  | "skill-query"
+  | "ontology-lookup"
+  | "bmc-generation"
+  | "bmc-insight"
+  | "market-summary"
+  | "discovery-analysis";
+
+export interface AgentConstraintRule {
+  id: string;
+  tier: "always" | "ask" | "never";
+  action: string;
+  description: string;
+  enforcementMode: "block" | "warn" | "log";
+}
+
+export interface AgentExecutionRequest {
+  taskId: string;
+  agentId: string;
+  taskType: AgentTaskType;
+  context: {
+    repoUrl: string;
+    branch: string;
+    targetFiles?: string[];
+    spec?: {
+      title: string;
+      description: string;
+      acceptanceCriteria: string[];
+    };
+    instructions?: string;
+    fileContents?: Record<string, string>;
+    systemPromptOverride?: string;
+  };
+  constraints: AgentConstraintRule[];
+}
+
+/** F60: Generative UI rendering hint (mirrors shared/agent.ts UIHint) */
+export interface UIHint {
+  layout: "card" | "tabs" | "accordion" | "flow" | "iframe";
+  sections: Array<{
+    type: "text" | "code" | "diff" | "chart" | "diagram" | "table" | "timeline";
+    title: string;
+    data: unknown;
+    interactive?: boolean;
+  }>;
+  html?: string;
+  actions?: Array<{
+    type: "approve" | "reject" | "edit" | "expand";
+    label: string;
+    targetSection?: number;
+  }>;
+}
+
+export interface AgentExecutionResult {
+  status: "success" | "partial" | "failed";
+  output: {
+    analysis?: string;
+    generatedCode?: Array<{
+      path: string;
+      content: string;
+      action: "create" | "modify";
+    }>;
+    reviewComments?: Array<{
+      file: string;
+      line: number;
+      comment: string;
+      severity: "error" | "warning" | "info";
+    }>;
+    uiHint?: UIHint;  // F60: Generative UI
+  };
+  tokensUsed: number;
+  model: string;
+  duration: number;
+  reflection?: {             // F148: opt-in self-reflection metadata
+    score: number;
+    confidence: number;
+    reasoning: string;
+    suggestions: string[];
+    retryCount: number;
+    history: Array<{
+      iteration: number;
+      score: number;
+      confidence: number;
+    }>;
+  };
+}
+
+export type AgentRunnerType = "claude-api" | "openrouter" | "mcp" | "mock";
+
+export interface AgentRunnerInfo {
+  type: AgentRunnerType;
+  available: boolean;
+  model?: string;
+  description: string;
+}

--- a/packages/fx-shaping/src/agent/services/model-router.ts
+++ b/packages/fx-shaping/src/agent/services/model-router.ts
@@ -1,0 +1,157 @@
+/**
+ * F136: 태스크별 모델 라우팅 — D1 규칙 기반 자동 모델 선택
+ */
+import type { AgentTaskType, AgentRunnerType } from "./execution-types.js";
+
+export interface RoutingRule {
+  id: string;
+  taskType: AgentTaskType;
+  modelId: string;
+  runnerType: AgentRunnerType;
+  priority: number;
+  maxCostPerCall: number | null;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** D1 규칙 없을 때 하드코딩 폴백 */
+export const DEFAULT_MODEL_MAP: Record<AgentTaskType, string> = {
+  "code-review": "anthropic/claude-sonnet-4",
+  "code-generation": "anthropic/claude-sonnet-4",
+  "spec-analysis": "anthropic/claude-opus-4",
+  "test-generation": "anthropic/claude-haiku-4-5",
+  "policy-evaluation": "anthropic/claude-haiku-4-5",
+  "skill-query": "anthropic/claude-haiku-4-5",
+  "ontology-lookup": "anthropic/claude-haiku-4-5",
+  "security-review": "anthropic/claude-sonnet-4-5-20250514",
+  "qa-testing": "anthropic/claude-haiku-4-5",
+  "infra-analysis": "anthropic/claude-sonnet-4",
+  "bmc-generation": "anthropic/claude-sonnet-4-6",
+  "bmc-insight": "anthropic/claude-sonnet-4-6",
+  "market-summary": "anthropic/claude-sonnet-4-6",
+  "discovery-analysis": "anthropic/claude-haiku-4-5",
+};
+
+interface D1RoutingRow {
+  id: string;
+  task_type: string;
+  model_id: string;
+  runner_type: string;
+  priority: number;
+  max_cost_per_call: number | null;
+  enabled: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export function toRoutingRule(row: D1RoutingRow): RoutingRule {
+  return {
+    id: row.id,
+    taskType: row.task_type as AgentTaskType,
+    modelId: row.model_id,
+    runnerType: row.runner_type as AgentRunnerType,
+    priority: row.priority,
+    maxCostPerCall: row.max_cost_per_call,
+    enabled: row.enabled === 1,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export class ModelRouter {
+  constructor(private db: D1Database) {}
+
+  async getModelForTask(taskType: AgentTaskType): Promise<RoutingRule> {
+    const result = await this.db
+      .prepare(
+        "SELECT * FROM model_routing_rules WHERE task_type = ? AND enabled = 1 ORDER BY priority ASC LIMIT 1",
+      )
+      .bind(taskType)
+      .first<D1RoutingRow>();
+
+    if (result) {
+      return toRoutingRule(result);
+    }
+
+    // D1 규칙 없으면 DEFAULT_MODEL_MAP 폴백
+    const modelId = DEFAULT_MODEL_MAP[taskType] ?? "anthropic/claude-sonnet-4";
+    return {
+      id: `default_${taskType}`,
+      taskType,
+      modelId,
+      runnerType: "openrouter",
+      priority: 999,
+      maxCostPerCall: null,
+      enabled: true,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+  }
+
+  /** F144: task_type별 전체 enabled 규칙을 priority ASC로 반환 (Fallback 체인용) */
+  async getFallbackChain(taskType: AgentTaskType): Promise<RoutingRule[]> {
+    const { results } = await this.db
+      .prepare(
+        "SELECT * FROM model_routing_rules WHERE task_type = ? AND enabled = 1 ORDER BY priority ASC",
+      )
+      .bind(taskType)
+      .all<D1RoutingRow>();
+
+    if (results.length > 0) {
+      return results.map(toRoutingRule);
+    }
+
+    // D1 규칙 없으면 getModelForTask() 단일 항목 배열로 폴백
+    const fallback = await this.getModelForTask(taskType);
+    return [fallback];
+  }
+
+  async listRules(): Promise<RoutingRule[]> {
+    const { results } = await this.db
+      .prepare("SELECT * FROM model_routing_rules ORDER BY task_type, priority")
+      .all<D1RoutingRow>();
+
+    return results.map(toRoutingRule);
+  }
+
+  async upsertRule(
+    taskType: AgentTaskType,
+    patch: {
+      modelId: string;
+      runnerType?: AgentRunnerType;
+      priority?: number;
+      maxCostPerCall?: number | null;
+      enabled?: boolean;
+    },
+  ): Promise<RoutingRule> {
+    const id = `mrr_${Date.now()}`;
+    const runnerType = patch.runnerType ?? "openrouter";
+    const priority = patch.priority ?? 1;
+    const maxCostPerCall = patch.maxCostPerCall ?? null;
+    const enabled = patch.enabled !== undefined ? (patch.enabled ? 1 : 0) : 1;
+
+    await this.db
+      .prepare(
+        `INSERT INTO model_routing_rules (id, task_type, model_id, runner_type, priority, max_cost_per_call, enabled, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))
+         ON CONFLICT(task_type, model_id) DO UPDATE SET
+           runner_type = excluded.runner_type,
+           priority = excluded.priority,
+           max_cost_per_call = excluded.max_cost_per_call,
+           enabled = excluded.enabled,
+           updated_at = datetime('now')`,
+      )
+      .bind(id, taskType, patch.modelId, runnerType, priority, maxCostPerCall, enabled)
+      .run();
+
+    const row = await this.db
+      .prepare(
+        "SELECT * FROM model_routing_rules WHERE task_type = ? AND model_id = ?",
+      )
+      .bind(taskType, patch.modelId)
+      .first<D1RoutingRow>();
+
+    return toRoutingRule(row!);
+  }
+}

--- a/packages/fx-shaping/src/agent/services/openrouter-runner.ts
+++ b/packages/fx-shaping/src/agent/services/openrouter-runner.ts
@@ -1,0 +1,140 @@
+import type {
+  AgentExecutionRequest,
+  AgentExecutionResult,
+} from "./execution-types.js";
+import type { AgentRunner } from "./agent-runner.js";
+import { TASK_SYSTEM_PROMPTS, buildUserPrompt, getSystemPrompt } from "./prompt-utils.js";
+
+export const DEFAULT_BASE_URL = "https://openrouter.ai/api/v1";
+export const DEFAULT_MODEL = "anthropic/claude-sonnet-4";
+export const DEFAULT_MAX_TOKENS = 4096;
+export const REQUEST_TIMEOUT_MS = 60_000;
+
+interface OpenRouterResponse {
+  id: string;
+  model: string;
+  choices: Array<{
+    index: number;
+    message: { role: string; content: string };
+    finish_reason: string;
+  }>;
+  usage: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+}
+
+export class OpenRouterRunner implements AgentRunner {
+  readonly type = "openrouter" as const;
+
+  constructor(
+    private apiKey: string,
+    private model: string = DEFAULT_MODEL,
+    private baseUrl: string = DEFAULT_BASE_URL,
+  ) {}
+
+  async execute(request: AgentExecutionRequest): Promise<AgentExecutionResult> {
+    const startTime = Date.now();
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+    try {
+      const systemPrompt = getSystemPrompt(request);
+      const userPrompt = buildUserPrompt(request);
+
+      const res = await fetch(`${this.baseUrl}/chat/completions`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          "Content-Type": "application/json",
+          "HTTP-Referer": "https://foundry-x-api.ktds-axbd.workers.dev",
+          "X-Title": "Foundry-X",
+        },
+        body: JSON.stringify({
+          model: this.model,
+          messages: [
+            { role: "system", content: systemPrompt },
+            { role: "user", content: userPrompt },
+          ],
+          max_tokens: DEFAULT_MAX_TOKENS,
+          temperature: 0.1,
+        }),
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        return {
+          status: "failed",
+          output: {
+            analysis: `OpenRouter API error: ${res.status} ${res.statusText}`,
+          },
+          tokensUsed: 0,
+          model: this.model,
+          duration: Date.now() - startTime,
+        };
+      }
+
+      const data = (await res.json()) as OpenRouterResponse;
+      const text = data.choices[0]?.message?.content ?? "";
+      const tokensUsed =
+        (data.usage?.prompt_tokens ?? 0) + (data.usage?.completion_tokens ?? 0);
+      const actualModel = data.model ?? this.model;
+
+      try {
+        const parsed = JSON.parse(text);
+        return {
+          status: "success",
+          output: {
+            analysis: parsed.analysis ?? text,
+            generatedCode: parsed.generatedCode,
+            reviewComments: parsed.reviewComments,
+            uiHint: parsed.uiHint,
+          },
+          tokensUsed,
+          model: actualModel,
+          duration: Date.now() - startTime,
+        };
+      } catch {
+        return {
+          status: "partial",
+          output: { analysis: text },
+          tokensUsed,
+          model: actualModel,
+          duration: Date.now() - startTime,
+        };
+      }
+    } catch (err: unknown) {
+      if (err instanceof Error && err.name === "AbortError") {
+        return {
+          status: "failed",
+          output: {
+            analysis: `OpenRouter request timed out after ${REQUEST_TIMEOUT_MS}ms`,
+          },
+          tokensUsed: 0,
+          model: this.model,
+          duration: Date.now() - startTime,
+        };
+      }
+      return {
+        status: "failed",
+        output: {
+          analysis: `OpenRouter error: ${err instanceof Error ? err.message : String(err)}`,
+        },
+        tokensUsed: 0,
+        model: this.model,
+        duration: Date.now() - startTime,
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return !!this.apiKey;
+  }
+
+  supportsTaskType(taskType: string): boolean {
+    return taskType in TASK_SYSTEM_PROMPTS;
+  }
+}

--- a/packages/fx-shaping/src/agent/services/prompt-gateway.ts
+++ b/packages/fx-shaping/src/agent/services/prompt-gateway.ts
@@ -1,0 +1,215 @@
+/**
+ * F149: PromptGatewayService — Prompt sanitization & code abstraction gateway
+ * Strips secrets/PII/internal URLs before forwarding prompts to LLM backends.
+ */
+import type { AgentTaskType } from "./execution-types.js";
+import { AuditLogService } from "../../harness/services/audit-logger.js";
+
+// ── Interfaces ──────────────────────────────────────────
+
+export interface SanitizationRule {
+  id: string;
+  pattern: string;
+  replacement: string;
+  category: "secret" | "url" | "pii" | "custom";
+  enabled: boolean;
+  createdAt: string;
+}
+
+export interface SanitizeResult {
+  sanitizedContent: string;
+  appliedRules: Array<{ ruleId: string; category: string; matchCount: number }>;
+  originalLength: number;
+  sanitizedLength: number;
+}
+
+export interface CodeAbstraction {
+  filePath: string;
+  summary: string;
+  imports: string[];
+  exports: string[];
+  lineCount: number;
+}
+
+// ── Service ─────────────────────────────────────────────
+
+export class PromptGatewayService {
+  static readonly DEFAULT_RULES: SanitizationRule[] = [
+    {
+      id: "default-secret",
+      pattern: String.raw`(?:api[_-]?key|token|secret)\s*[:=]\s*['"][^'"]{8,}['"]`,
+      replacement: "[REDACTED_SECRET]",
+      category: "secret",
+      enabled: true,
+      createdAt: "2026-01-01T00:00:00Z",
+    },
+    {
+      id: "default-password",
+      pattern: String.raw`(?:password|passwd|pwd)\s*[:=]\s*['"][^'"]+['"]`,
+      replacement: "[REDACTED_PASSWORD]",
+      category: "secret",
+      enabled: true,
+      createdAt: "2026-01-01T00:00:00Z",
+    },
+    {
+      id: "default-internal-url",
+      pattern: String.raw`https?://(?:internal|staging|dev|localhost)[^\s'"]*`,
+      replacement: "[REDACTED_INTERNAL_URL]",
+      category: "url",
+      enabled: true,
+      createdAt: "2026-01-01T00:00:00Z",
+    },
+    {
+      id: "default-jwt",
+      pattern: String.raw`eyJ[A-Za-z0-9_-]{20,}\.eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}`,
+      replacement: "[REDACTED_JWT]",
+      category: "secret",
+      enabled: true,
+      createdAt: "2026-01-01T00:00:00Z",
+    },
+  ];
+
+  private db: D1Database;
+  private auditLogger: AuditLogService;
+
+  constructor(db: D1Database) {
+    this.db = db;
+    this.auditLogger = new AuditLogService(db);
+  }
+
+  /** Sanitize a prompt string, removing secrets/PII/internal URLs */
+  async sanitizePrompt(content: string, tenantId?: string): Promise<SanitizeResult> {
+    const rules = await this.loadRules();
+    const result = this.applyRules(content, rules);
+
+    // Sprint 47: 마스킹 발생 시 감사 로그 기록
+    if (result.appliedRules.length > 0 && tenantId) {
+      await this.auditLogger.logEvent({
+        tenantId,
+        eventType: "masking",
+        metadata: {
+          appliedRules: result.appliedRules,
+          originalLength: result.originalLength,
+          sanitizedLength: result.sanitizedLength,
+        },
+      }).catch(() => {
+        // 감사 로그 실패가 마스킹을 차단하면 안 됨
+      });
+    }
+
+    return result;
+  }
+
+  /** Extract structural abstractions from file contents (imports/exports/signatures only) */
+  abstractCode(fileContents: Record<string, string>): Record<string, CodeAbstraction> {
+    const result: Record<string, CodeAbstraction> = {};
+
+    for (const [filePath, content] of Object.entries(fileContents)) {
+      const lines = content.split("\n");
+      const imports: string[] = [];
+      const exports: string[] = [];
+      const signatureParts: string[] = [];
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (/^import\s/.test(trimmed)) {
+          imports.push(trimmed);
+        }
+        if (/^export\s/.test(trimmed)) {
+          exports.push(trimmed);
+        }
+        if (/^(?:export\s+)?(?:async\s+)?function\s+\w+/.test(trimmed)) {
+          signatureParts.push(trimmed);
+        }
+        if (/^(?:export\s+)?class\s+\w+/.test(trimmed)) {
+          signatureParts.push(trimmed);
+        }
+      }
+
+      const summary = signatureParts.length > 0
+        ? signatureParts.join("; ")
+        : `${imports.length} imports, ${exports.length} exports`;
+
+      result[filePath] = {
+        filePath,
+        summary,
+        imports,
+        exports,
+        lineCount: lines.length,
+      };
+    }
+
+    return result;
+  }
+
+  /** Load rules from D1 + DEFAULT_RULES fallback */
+  async loadRules(): Promise<SanitizationRule[]> {
+    try {
+      const stmt = this.db.prepare(
+        "SELECT id, pattern, replacement, category, enabled, created_at FROM prompt_sanitization_rules",
+      );
+      const { results } = await stmt.all<{
+        id: string;
+        pattern: string;
+        replacement: string;
+        category: string;
+        enabled: number;
+        created_at: string;
+      }>();
+
+      if (results && results.length > 0) {
+        const dbRules: SanitizationRule[] = results.map((r) => ({
+          id: r.id,
+          pattern: r.pattern,
+          replacement: r.replacement,
+          category: r.category as SanitizationRule["category"],
+          enabled: r.enabled === 1,
+          createdAt: r.created_at,
+        }));
+        return [...PromptGatewayService.DEFAULT_RULES, ...dbRules];
+      }
+    } catch {
+      // D1 table may not exist — fall back to defaults
+    }
+
+    return [...PromptGatewayService.DEFAULT_RULES];
+  }
+
+  /** Apply enabled rules to content, returning sanitized result + metrics */
+  applyRules(content: string, rules: SanitizationRule[]): SanitizeResult {
+    const originalLength = content.length;
+    let sanitized = content;
+    const appliedRules: SanitizeResult["appliedRules"] = [];
+
+    for (const rule of rules) {
+      if (!rule.enabled) continue;
+
+      const regex = new RegExp(rule.pattern, "gi");
+      let matchCount = 0;
+      sanitized = sanitized.replace(regex, () => {
+        matchCount++;
+        return rule.replacement;
+      });
+
+      if (matchCount > 0) {
+        appliedRules.push({
+          ruleId: rule.id,
+          category: rule.category,
+          matchCount,
+        });
+      }
+    }
+
+    return {
+      sanitizedContent: sanitized,
+      appliedRules,
+      originalLength,
+      sanitizedLength: sanitized.length,
+    };
+  }
+
+  /** List all rules (D1 + defaults) */
+  async listRules(): Promise<SanitizationRule[]> {
+    return this.loadRules();
+  }
+}

--- a/packages/fx-shaping/src/agent/services/prompt-utils.ts
+++ b/packages/fx-shaping/src/agent/services/prompt-utils.ts
@@ -1,0 +1,133 @@
+/**
+ * F135: Shared prompt utilities — extracted from ClaudeApiRunner
+ * for reuse across multiple runner backends (Claude API, OpenRouter, etc.)
+ */
+import type { AgentExecutionRequest, AgentTaskType } from "./execution-types.js";
+
+// F60: Generative UI — instruct LLM to include rendering hints
+export const UIHINT_INSTRUCTION = `\n\nAdditionally, include a "uiHint" field in your JSON response to suggest rendering.
+Format: { "layout": "card"|"tabs"|"accordion"|"iframe", "sections": [{ "type": "text"|"code"|"diff"|"chart"|"table", "title": string, "data": any }] }
+If the result contains HTML visualizations, include an "html" field with self-contained HTML.`;
+
+export const TASK_SYSTEM_PROMPTS: Record<AgentTaskType, string> = {
+  "code-review": `You are a code review agent for the Foundry-X project.
+Analyze the provided code files against the spec requirements.
+Return a JSON object with "reviewComments" array.
+Each comment: { "file": string, "line": number, "comment": string, "severity": "error"|"warning"|"info" }` + UIHINT_INSTRUCTION,
+
+  "code-generation": `You are a code generation agent for the Foundry-X project.
+Generate TypeScript code based on the spec requirements.
+Return a JSON object with "generatedCode" array.
+Each item: { "path": string, "content": string, "action": "create"|"modify" }` + UIHINT_INSTRUCTION,
+
+  "spec-analysis": `You are a spec analysis agent for the Foundry-X project.
+Analyze the provided spec for completeness, consistency, and feasibility.
+Return a JSON object with "analysis" field containing your assessment.` + UIHINT_INSTRUCTION,
+
+  "test-generation": `You are a test generation agent for the Foundry-X project.
+Generate vitest test cases for the provided code and spec.
+Return a JSON object with "generatedCode" array containing test files.` + UIHINT_INSTRUCTION,
+
+  "policy-evaluation": `You are a policy evaluation agent for the Foundry-X project.
+Evaluate the provided code or configuration against organizational policies and governance rules.
+Return a JSON object with "evaluation" field containing compliance assessment.` + UIHINT_INSTRUCTION,
+
+  "skill-query": `You are a skill query agent for the Foundry-X project.
+Search and retrieve relevant skills, capabilities, or knowledge from the AI Foundry asset registry.
+Return a JSON object with "results" array of matching skills.` + UIHINT_INSTRUCTION,
+
+  "ontology-lookup": `You are an ontology lookup agent for the Foundry-X project.
+Look up domain concepts, relationships, and definitions from the project ontology.
+Return a JSON object with "concepts" array of matching ontology entries.` + UIHINT_INSTRUCTION,
+
+  "security-review": `You are a security review agent for the Foundry-X project.
+Analyze code for OWASP Top 10 vulnerabilities and security anti-patterns.
+Return a JSON object with vulnerability findings and remediation suggestions.` + UIHINT_INSTRUCTION,
+
+  "qa-testing": `You are a QA testing agent for the Foundry-X project.
+Generate browser test scenarios and validate acceptance criteria.
+Return a JSON object with test scenarios and coverage analysis.` + UIHINT_INSTRUCTION,
+
+  "infra-analysis": `You are an infrastructure analysis agent for the Foundry-X project.
+Analyze Cloudflare Workers, D1, KV, and Pages configurations for health and optimization.
+Return a JSON object with health score, resource status, and optimization suggestions.` + UIHINT_INSTRUCTION,
+
+  "bmc-generation": `You are a BMC generation agent for the Foundry-X project.
+Generate Business Model Canvas content for all 9 blocks based on a business idea.
+Return a JSON object with block keys and string values.` + UIHINT_INSTRUCTION,
+
+  "bmc-insight": `You are a BMC insight agent for the Foundry-X project.
+Given a BMC block type and content, suggest 3 improvements.
+Return a JSON array with title, description, and suggestedContent.` + UIHINT_INSTRUCTION,
+
+  "market-summary": `You are a market analysis agent for the Foundry-X project.
+Given keywords, provide market summary, trends, opportunities, and risks.
+Return a JSON object with summary, trends, opportunities, and risks arrays.` + UIHINT_INSTRUCTION,
+
+  "discovery-analysis": `당신은 AX BD팀의 사업 발굴 분석 에이전트입니다.
+모든 응답은 반드시 다음 JSON 스키마로 출력하세요:
+{
+  "summary": "1~2문장 핵심 요약 (한국어)",
+  "details": "마크다운 형식 상세 분석 (한국어)",
+  "confidence": 0~100 사이 정수
+}
+다른 필드를 추가하지 마세요. 반드시 위 3개 필드만 포함된 유효한 JSON을 반환하세요.`,
+};
+
+/** F60: Default layout per task type — client fallback when uiHint is absent */
+export const DEFAULT_LAYOUT_MAP: Record<AgentTaskType, string> = {
+  "code-review": "tabs",
+  "code-generation": "accordion",
+  "spec-analysis": "card",
+  "test-generation": "accordion",
+  "policy-evaluation": "card",
+  "skill-query": "tabs",
+  "ontology-lookup": "card",
+  "security-review": "tabs",
+  "qa-testing": "accordion",
+  "infra-analysis": "card",
+  "bmc-generation": "card",
+  "bmc-insight": "card",
+  "market-summary": "card",
+  "discovery-analysis": "card",
+};
+
+/** F146: Get system prompt — custom override or task-type default */
+export function getSystemPrompt(request: AgentExecutionRequest): string {
+  if (request.context.systemPromptOverride) {
+    return request.context.systemPromptOverride + UIHINT_INSTRUCTION;
+  }
+  return TASK_SYSTEM_PROMPTS[request.taskType]
+    ?? `You are an AI agent for the Foundry-X project. Task: ${request.taskType}.` + UIHINT_INSTRUCTION;
+}
+
+/** Build a user prompt from an AgentExecutionRequest */
+export function buildUserPrompt(request: AgentExecutionRequest): string {
+  const parts: string[] = [];
+
+  if (request.context.spec) {
+    parts.push(
+      `## Spec\nTitle: ${request.context.spec.title}\nDescription: ${request.context.spec.description}`,
+    );
+    if (request.context.spec.acceptanceCriteria.length > 0) {
+      parts.push(
+        `\nAcceptance Criteria:\n${request.context.spec.acceptanceCriteria.map((c) => `- ${c}`).join("\n")}`,
+      );
+    }
+  }
+
+  if (request.context.instructions) {
+    parts.push(`\n## Instructions\n${request.context.instructions}`);
+  }
+
+  if (request.context.targetFiles?.length) {
+    parts.push(
+      `\n## Target Files\n${request.context.targetFiles.join("\n")}`,
+    );
+  }
+
+  parts.push(`\n## Context\nRepo: ${request.context.repoUrl}`);
+  parts.push(`Branch: ${request.context.branch}`);
+
+  return parts.join("\n");
+}

--- a/packages/fx-shaping/src/agent/services/skill-metrics.ts
+++ b/packages/fx-shaping/src/agent/services/skill-metrics.ts
@@ -1,0 +1,434 @@
+/**
+ * F274: SkillMetricsService — 스킬 실행 메트릭 기록 + 집계 + 감사 로그
+ */
+
+import type {
+  SkillMetricSummary,
+  SkillDetailMetrics,
+  SkillVersionRecord,
+  SkillExecutionRecord,
+  SkillLineageNode,
+  SkillAuditEntry,
+} from "@foundry-x/shared";
+
+export interface RecordSkillExecutionParams {
+  tenantId: string;
+  skillId: string;
+  version: number;
+  bizItemId?: string;
+  artifactId?: string;
+  model: string;
+  status: "completed" | "failed" | "timeout" | "cancelled";
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  durationMs: number;
+  executedBy: string;
+  errorMessage?: string;
+}
+
+export interface RegisterVersionParams {
+  tenantId: string;
+  skillId: string;
+  version: number;
+  promptHash: string;
+  model: string;
+  maxTokens: number;
+  changelog?: string;
+  createdBy: string;
+}
+
+export interface LogAuditParams {
+  tenantId: string;
+  entityType: "execution" | "version" | "lineage" | "skill";
+  entityId: string;
+  action: "created" | "updated" | "deleted" | "executed" | "versioned";
+  actorId: string;
+  details?: string;
+}
+
+export class SkillMetricsService {
+  constructor(private db: D1Database) {}
+
+  async recordExecution(params: RecordSkillExecutionParams): Promise<{ id: string }> {
+    const id = generateId("se");
+
+    await this.db
+      .prepare(
+        `INSERT INTO skill_executions
+          (id, tenant_id, skill_id, version, biz_item_id, artifact_id, model, status,
+           input_tokens, output_tokens, cost_usd, duration_ms, error_message, executed_by)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        id,
+        params.tenantId,
+        params.skillId,
+        params.version,
+        params.bizItemId ?? null,
+        params.artifactId ?? null,
+        params.model,
+        params.status,
+        params.inputTokens,
+        params.outputTokens,
+        params.costUsd,
+        params.durationMs,
+        params.errorMessage ?? null,
+        params.executedBy,
+      )
+      .run();
+
+    await this.logAudit({
+      tenantId: params.tenantId,
+      entityType: "execution",
+      entityId: id,
+      action: "executed",
+      actorId: params.executedBy,
+      details: JSON.stringify({ skillId: params.skillId, status: params.status, durationMs: params.durationMs }),
+    });
+
+    return { id };
+  }
+
+  async getSkillMetricsSummary(
+    tenantId: string,
+    params?: { days?: number; status?: string },
+  ): Promise<SkillMetricSummary[]> {
+    const days = params?.days ?? 30;
+    const cutoff = new Date(Date.now() - days * 86400_000).toISOString();
+
+    let sql = `SELECT
+        skill_id,
+        COUNT(*) as total,
+        SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) as success_cnt,
+        SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) as failed_cnt,
+        AVG(duration_ms) as avg_duration,
+        SUM(cost_usd) as total_cost,
+        AVG(input_tokens + output_tokens) as avg_tokens,
+        MAX(executed_at) as last_executed
+      FROM skill_executions
+      WHERE tenant_id = ? AND executed_at >= ?`;
+
+    const bindings: unknown[] = [tenantId, cutoff];
+
+    if (params?.status) {
+      sql += " AND status = ?";
+      bindings.push(params.status);
+    }
+
+    sql += " GROUP BY skill_id ORDER BY total DESC";
+
+    const rows = await this.db
+      .prepare(sql)
+      .bind(...bindings)
+      .all<{
+        skill_id: string;
+        total: number;
+        success_cnt: number;
+        failed_cnt: number;
+        avg_duration: number;
+        total_cost: number;
+        avg_tokens: number;
+        last_executed: string | null;
+      }>();
+
+    return (rows.results ?? []).map((r) => ({
+      skillId: r.skill_id,
+      totalExecutions: r.total,
+      successCount: r.success_cnt,
+      failedCount: r.failed_cnt,
+      successRate: r.total > 0 ? Math.round((r.success_cnt / r.total) * 100) : 0,
+      avgDurationMs: Math.round(r.avg_duration ?? 0),
+      totalCostUsd: Math.round((r.total_cost ?? 0) * 10000) / 10000,
+      avgTokensPerExecution: Math.round(r.avg_tokens ?? 0),
+      lastExecutedAt: r.last_executed,
+    }));
+  }
+
+  async getSkillDetailMetrics(
+    tenantId: string,
+    skillId: string,
+    params?: { days?: number },
+  ): Promise<SkillDetailMetrics> {
+    const days = params?.days ?? 30;
+    const cutoff = new Date(Date.now() - days * 86400_000).toISOString();
+
+    // Summary
+    const summaryRows = await this.db
+      .prepare(
+        `SELECT
+          COUNT(*) as total,
+          SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) as success_cnt,
+          SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) as failed_cnt,
+          AVG(duration_ms) as avg_duration,
+          SUM(cost_usd) as total_cost,
+          AVG(input_tokens + output_tokens) as avg_tokens,
+          MAX(executed_at) as last_executed
+        FROM skill_executions
+        WHERE tenant_id = ? AND skill_id = ? AND executed_at >= ?`,
+      )
+      .bind(tenantId, skillId, cutoff)
+      .first<{
+        total: number;
+        success_cnt: number;
+        failed_cnt: number;
+        avg_duration: number;
+        total_cost: number;
+        avg_tokens: number;
+        last_executed: string | null;
+      }>();
+
+    const total = summaryRows?.total ?? 0;
+
+    // Recent executions (last 20)
+    const recentRows = await this.db
+      .prepare(
+        `SELECT id, skill_id, version, model, status,
+                input_tokens + output_tokens as total_tokens,
+                cost_usd, duration_ms, executed_by, executed_at
+         FROM skill_executions
+         WHERE tenant_id = ? AND skill_id = ?
+         ORDER BY executed_at DESC LIMIT 20`,
+      )
+      .bind(tenantId, skillId)
+      .all<{
+        id: string;
+        skill_id: string;
+        version: number;
+        model: string;
+        status: string;
+        total_tokens: number;
+        cost_usd: number;
+        duration_ms: number;
+        executed_by: string;
+        executed_at: string;
+      }>();
+
+    // Versions
+    const versionRows = await this.db
+      .prepare(
+        `SELECT id, skill_id, version, prompt_hash, model, max_tokens, changelog, created_by, created_at
+         FROM skill_versions
+         WHERE tenant_id = ? AND skill_id = ?
+         ORDER BY version DESC`,
+      )
+      .bind(tenantId, skillId)
+      .all<{
+        id: string;
+        skill_id: string;
+        version: number;
+        prompt_hash: string;
+        model: string;
+        max_tokens: number;
+        changelog: string | null;
+        created_by: string;
+        created_at: string;
+      }>();
+
+    // Cost trend (daily aggregation)
+    const trendRows = await this.db
+      .prepare(
+        `SELECT date(executed_at) as day, SUM(cost_usd) as cost, COUNT(*) as execs
+         FROM skill_executions
+         WHERE tenant_id = ? AND skill_id = ? AND executed_at >= ?
+         GROUP BY date(executed_at)
+         ORDER BY day`,
+      )
+      .bind(tenantId, skillId, cutoff)
+      .all<{ day: string; cost: number; execs: number }>();
+
+    return {
+      skillId,
+      totalExecutions: total,
+      successCount: summaryRows?.success_cnt ?? 0,
+      failedCount: summaryRows?.failed_cnt ?? 0,
+      successRate: total > 0 ? Math.round(((summaryRows?.success_cnt ?? 0) / total) * 100) : 0,
+      avgDurationMs: Math.round(summaryRows?.avg_duration ?? 0),
+      totalCostUsd: Math.round((summaryRows?.total_cost ?? 0) * 10000) / 10000,
+      avgTokensPerExecution: Math.round(summaryRows?.avg_tokens ?? 0),
+      lastExecutedAt: summaryRows?.last_executed ?? null,
+      versions: (versionRows.results ?? []).map((v) => ({
+        id: v.id,
+        skillId: v.skill_id,
+        version: v.version,
+        promptHash: v.prompt_hash,
+        model: v.model,
+        maxTokens: v.max_tokens,
+        changelog: v.changelog,
+        createdBy: v.created_by,
+        createdAt: v.created_at,
+      })),
+      recentExecutions: (recentRows.results ?? []).map((e) => ({
+        id: e.id,
+        skillId: e.skill_id,
+        version: e.version,
+        model: e.model,
+        status: e.status as SkillExecutionRecord["status"],
+        totalTokens: e.total_tokens,
+        costUsd: e.cost_usd,
+        durationMs: e.duration_ms,
+        executedBy: e.executed_by,
+        executedAt: e.executed_at,
+      })),
+      costTrend: (trendRows.results ?? []).map((t) => ({
+        date: t.day,
+        cost: Math.round(t.cost * 10000) / 10000,
+        executions: t.execs,
+      })),
+    };
+  }
+
+  async getSkillVersions(tenantId: string, skillId: string): Promise<SkillVersionRecord[]> {
+    const rows = await this.db
+      .prepare(
+        `SELECT id, skill_id, version, prompt_hash, model, max_tokens, changelog, created_by, created_at
+         FROM skill_versions
+         WHERE tenant_id = ? AND skill_id = ?
+         ORDER BY version DESC`,
+      )
+      .bind(tenantId, skillId)
+      .all<{
+        id: string;
+        skill_id: string;
+        version: number;
+        prompt_hash: string;
+        model: string;
+        max_tokens: number;
+        changelog: string | null;
+        created_by: string;
+        created_at: string;
+      }>();
+
+    return (rows.results ?? []).map((v) => ({
+      id: v.id,
+      skillId: v.skill_id,
+      version: v.version,
+      promptHash: v.prompt_hash,
+      model: v.model,
+      maxTokens: v.max_tokens,
+      changelog: v.changelog,
+      createdBy: v.created_by,
+      createdAt: v.created_at,
+    }));
+  }
+
+  async getSkillLineage(tenantId: string, skillId: string): Promise<SkillLineageNode> {
+    const children = await this.db
+      .prepare(
+        `SELECT child_skill_id, derivation_type
+         FROM skill_lineage
+         WHERE tenant_id = ? AND parent_skill_id = ?`,
+      )
+      .bind(tenantId, skillId)
+      .all<{ child_skill_id: string; derivation_type: string }>();
+
+    const parents = await this.db
+      .prepare(
+        `SELECT parent_skill_id, derivation_type
+         FROM skill_lineage
+         WHERE tenant_id = ? AND child_skill_id = ?`,
+      )
+      .bind(tenantId, skillId)
+      .all<{ parent_skill_id: string; derivation_type: string }>();
+
+    return {
+      skillId,
+      derivationType: "manual",
+      children: (children.results ?? []).map((c) => ({
+        skillId: c.child_skill_id,
+        derivationType: c.derivation_type as SkillLineageNode["derivationType"],
+        children: [],
+        parents: [{ skillId, derivationType: c.derivation_type }],
+      })),
+      parents: (parents.results ?? []).map((p) => ({
+        skillId: p.parent_skill_id,
+        derivationType: p.derivation_type,
+      })),
+    };
+  }
+
+  async getAuditLog(
+    tenantId: string,
+    params?: { entityType?: string; days?: number; limit?: number; offset?: number },
+  ): Promise<SkillAuditEntry[]> {
+    const days = params?.days ?? 30;
+    const limit = params?.limit ?? 50;
+    const offset = params?.offset ?? 0;
+    const cutoff = new Date(Date.now() - days * 86400_000).toISOString();
+
+    let sql = `SELECT id, entity_type, entity_id, action, actor_id, details, created_at
+               FROM skill_audit_log
+               WHERE tenant_id = ? AND created_at >= ?`;
+    const bindings: unknown[] = [tenantId, cutoff];
+
+    if (params?.entityType) {
+      sql += " AND entity_type = ?";
+      bindings.push(params.entityType);
+    }
+
+    sql += " ORDER BY created_at DESC LIMIT ? OFFSET ?";
+    bindings.push(limit, offset);
+
+    const rows = await this.db
+      .prepare(sql)
+      .bind(...bindings)
+      .all<{
+        id: string;
+        entity_type: string;
+        entity_id: string;
+        action: string;
+        actor_id: string;
+        details: string | null;
+        created_at: string;
+      }>();
+
+    return (rows.results ?? []).map((r) => ({
+      id: r.id,
+      entityType: r.entity_type as SkillAuditEntry["entityType"],
+      entityId: r.entity_id,
+      action: r.action as SkillAuditEntry["action"],
+      actorId: r.actor_id,
+      details: r.details,
+      createdAt: r.created_at,
+    }));
+  }
+
+  async logAudit(params: LogAuditParams): Promise<void> {
+    const id = generateId("sal");
+    await this.db
+      .prepare(
+        `INSERT INTO skill_audit_log (id, tenant_id, entity_type, entity_id, action, actor_id, details)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(id, params.tenantId, params.entityType, params.entityId, params.action, params.actorId, params.details ?? null)
+      .run();
+  }
+
+  async registerVersion(params: RegisterVersionParams): Promise<{ id: string }> {
+    const id = generateId("sv");
+    await this.db
+      .prepare(
+        `INSERT INTO skill_versions (id, tenant_id, skill_id, version, prompt_hash, model, max_tokens, changelog, created_by)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(id, params.tenantId, params.skillId, params.version, params.promptHash, params.model, params.maxTokens, params.changelog ?? null, params.createdBy)
+      .run();
+
+    await this.logAudit({
+      tenantId: params.tenantId,
+      entityType: "version",
+      entityId: id,
+      action: "versioned",
+      actorId: params.createdBy,
+      details: JSON.stringify({ skillId: params.skillId, version: params.version }),
+    });
+
+    return { id };
+  }
+}
+
+function generateId(prefix: string): string {
+  const t = Date.now().toString(36);
+  const r = Math.random().toString(36).substring(2, 10);
+  return `${prefix}_${t}${r}`;
+}

--- a/packages/fx-shaping/src/app.ts
+++ b/packages/fx-shaping/src/app.ts
@@ -1,0 +1,58 @@
+// fx-shaping app (F540: FX-REQ-579)
+// Shaping 도메인 독립 Worker — 13 routes, 22 services
+import { Hono } from "hono";
+import type { ShapingEnv } from "./env.js";
+import { authMiddleware } from "./middleware/auth.js";
+import { tenantGuard, type TenantVariables } from "./middleware/tenant.js";
+import { shapingRoute } from "./routes/shaping.js";
+import { axBdBmcRoute } from "./routes/ax-bd-bmc.js";
+import { axBdAgentRoute } from "./routes/ax-bd-agent.js";
+import { axBdCommentsRoute } from "./routes/ax-bd-comments.js";
+import { axBdHistoryRoute } from "./routes/ax-bd-history.js";
+import { axBdLinksRoute } from "./routes/ax-bd-links.js";
+import { axBdViabilityRoute } from "./routes/ax-bd-viability.js";
+import { axBdPrototypesRoute } from "./routes/ax-bd-prototypes.js";
+import { axBdSkillsRoute } from "./routes/ax-bd-skills.js";
+import { axBdPersonaEvalRoute } from "./routes/ax-bd-persona-eval.js";
+import { axBdProgressRoute } from "./routes/ax-bd-progress.js";
+import { personaConfigsRoute } from "./routes/persona-configs.js";
+import { personaEvalsRoute } from "./routes/persona-evals.js";
+
+const app = new Hono<{ Bindings: ShapingEnv }>();
+
+// Health endpoint (public)
+app.get("/api/shaping/health", (c) => {
+  return c.json({ domain: "shaping", status: "ok" });
+});
+
+// JWT 인증 미들웨어
+app.use("/api/*", authMiddleware);
+
+// Authenticated routes with tenant guard
+const authenticated = new Hono<{ Bindings: ShapingEnv; Variables: TenantVariables }>();
+authenticated.use("*", tenantGuard);
+
+// Shaping runs
+authenticated.route("/api", shapingRoute);
+// BMC
+authenticated.route("/api", axBdBmcRoute);
+authenticated.route("/api", axBdAgentRoute);
+authenticated.route("/api", axBdCommentsRoute);
+authenticated.route("/api", axBdHistoryRoute);
+authenticated.route("/api", axBdLinksRoute);
+// Viability
+authenticated.route("/api", axBdViabilityRoute);
+// Prototypes
+authenticated.route("/api", axBdPrototypesRoute);
+// Skills
+authenticated.route("/api", axBdSkillsRoute);
+// Persona evaluation
+authenticated.route("/api", axBdPersonaEvalRoute);
+authenticated.route("/api", personaConfigsRoute);
+authenticated.route("/api", personaEvalsRoute);
+// BD process progress
+authenticated.route("/api", axBdProgressRoute);
+
+app.route("/", authenticated);
+
+export default app;

--- a/packages/fx-shaping/src/collection/services/idea-service.ts
+++ b/packages/fx-shaping/src/collection/services/idea-service.ts
@@ -1,0 +1,147 @@
+// ─── DB Row 타입 ───
+interface IdeaRow {
+  id: string;
+  title: string;
+  description: string | null;
+  tags: string | null; // JSON array
+  git_ref: string;
+  author_id: string;
+  org_id: string;
+  sync_status: string;
+  is_deleted: number;
+  created_at: number;
+  updated_at: number;
+}
+
+// ─── API 타입 ───
+export interface Idea {
+  id: string;
+  title: string;
+  description: string | null;
+  tags: string[];
+  gitRef: string;
+  authorId: string;
+  orgId: string;
+  syncStatus: "synced" | "pending" | "failed";
+  createdAt: number;
+  updatedAt: number;
+}
+
+function toIdea(row: IdeaRow): Idea {
+  return {
+    id: row.id,
+    title: row.title,
+    description: row.description,
+    tags: row.tags ? JSON.parse(row.tags) : [],
+    gitRef: row.git_ref,
+    authorId: row.author_id,
+    orgId: row.org_id,
+    syncStatus: row.sync_status as Idea["syncStatus"],
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export class IdeaService {
+  constructor(private db: D1Database) {}
+
+  async create(orgId: string, userId: string, data: { title: string; description?: string; tags?: string[] }): Promise<Idea> {
+    const id = crypto.randomUUID();
+    const now = Date.now();
+
+    await this.db
+      .prepare(
+        `INSERT INTO ax_ideas (id, title, description, tags, git_ref, author_id, org_id, sync_status, is_deleted, created_at, updated_at)
+         VALUES (?, ?, ?, ?, 'pending', ?, ?, 'pending', 0, ?, ?)`
+      )
+      .bind(id, data.title, data.description ?? null, data.tags ? JSON.stringify(data.tags) : null, userId, orgId, now, now)
+      .run();
+
+    return this.getById(orgId, id) as Promise<Idea>;
+  }
+
+  async getById(orgId: string, id: string): Promise<Idea | null> {
+    const row = await this.db
+      .prepare("SELECT * FROM ax_ideas WHERE id = ? AND org_id = ? AND is_deleted = 0")
+      .bind(id, orgId)
+      .first<IdeaRow>();
+    return row ? toIdea(row) : null;
+  }
+
+  async list(orgId: string, opts: { page: number; limit: number; tag?: string }) {
+    const offset = (opts.page - 1) * opts.limit;
+    let sql = "SELECT * FROM ax_ideas WHERE org_id = ? AND is_deleted = 0";
+    const params: unknown[] = [orgId];
+
+    if (opts.tag) {
+      // JSON array 내 태그 검색 (SQLite JSON 함수)
+      sql += " AND tags LIKE ?";
+      params.push(`%"${opts.tag}"%`);
+    }
+
+    sql += " ORDER BY updated_at DESC LIMIT ? OFFSET ?";
+    params.push(opts.limit, offset);
+
+    const { results } = await this.db
+      .prepare(sql)
+      .bind(...params)
+      .all<IdeaRow>();
+
+    const countSql = opts.tag
+      ? "SELECT COUNT(*) as total FROM ax_ideas WHERE org_id = ? AND is_deleted = 0 AND tags LIKE ?"
+      : "SELECT COUNT(*) as total FROM ax_ideas WHERE org_id = ? AND is_deleted = 0";
+    const countParams: unknown[] = opts.tag ? [orgId, `%"${opts.tag}"%`] : [orgId];
+
+    const countRow = await this.db
+      .prepare(countSql)
+      .bind(...countParams)
+      .first<{ total: number }>();
+
+    return {
+      items: (results ?? []).map(toIdea),
+      total: countRow?.total ?? 0,
+      page: opts.page,
+      limit: opts.limit,
+    };
+  }
+
+  async update(orgId: string, id: string, data: { title?: string; description?: string; tags?: string[] }): Promise<Idea | null> {
+    const existing = await this.getById(orgId, id);
+    if (!existing) return null;
+
+    const now = Date.now();
+    const updates: string[] = [];
+    const params: unknown[] = [];
+
+    if (data.title !== undefined) {
+      updates.push("title = ?");
+      params.push(data.title);
+    }
+    if (data.description !== undefined) {
+      updates.push("description = ?");
+      params.push(data.description);
+    }
+    if (data.tags !== undefined) {
+      updates.push("tags = ?");
+      params.push(JSON.stringify(data.tags));
+    }
+
+    updates.push("updated_at = ?", "sync_status = 'pending'");
+    params.push(now, id, orgId);
+
+    await this.db
+      .prepare(`UPDATE ax_ideas SET ${updates.join(", ")} WHERE id = ? AND org_id = ?`)
+      .bind(...params)
+      .run();
+
+    return this.getById(orgId, id);
+  }
+
+  async softDelete(orgId: string, id: string): Promise<boolean> {
+    const result = await this.db
+      .prepare("UPDATE ax_ideas SET is_deleted = 1, updated_at = ? WHERE id = ? AND org_id = ?")
+      .bind(Date.now(), id, orgId)
+      .run();
+    return (result.meta?.changes ?? 0) > 0;
+  }
+}

--- a/packages/fx-shaping/src/discovery/schemas/discovery-pipeline.ts
+++ b/packages/fx-shaping/src/discovery/schemas/discovery-pipeline.ts
@@ -1,0 +1,84 @@
+import { z } from "zod";
+
+// ── Pipeline Status ──
+export const PIPELINE_STATUSES = [
+  "idle", "discovery_running", "discovery_complete",
+  "shaping_queued", "shaping_running", "shaping_complete",
+  "paused", "failed", "aborted",
+] as const;
+export type DiscoveryPipelineStatus = (typeof PIPELINE_STATUSES)[number];
+
+// ── Event Types ──
+export const EVENT_TYPES = [
+  "START", "STEP_COMPLETE", "STEP_FAILED", "RETRY", "SKIP",
+  "ABORT", "PAUSE", "RESUME", "TRIGGER_SHAPING",
+  "SHAPING_PHASE_COMPLETE", "COMPLETE",
+] as const;
+export type PipelineEventType = (typeof EVENT_TYPES)[number];
+
+// ── Create Pipeline Run ──
+export const createPipelineRunSchema = z.object({
+  bizItemId: z.string().min(1),
+  triggerMode: z.enum(["manual", "auto"]).default("manual"),
+  maxRetries: z.number().int().min(0).max(10).optional().default(3),
+});
+export type CreatePipelineRunInput = z.infer<typeof createPipelineRunSchema>;
+
+// ── List Pipeline Runs ──
+export const listPipelineRunsSchema = z.object({
+  status: z.enum(PIPELINE_STATUSES).optional(),
+  bizItemId: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+// ── Step Action (retry/skip/abort) ──
+export const stepActionSchema = z.object({
+  action: z.enum(["retry", "skip", "abort"]),
+  reason: z.string().max(2000).optional(),
+});
+export type StepAction = z.infer<typeof stepActionSchema>;
+
+// ── Trigger Shaping ──
+export const triggerShapingSchema = z.object({
+  mode: z.enum(["hitl", "auto"]).default("auto"),
+  maxIterations: z.number().int().min(1).max(10).optional().default(3),
+});
+export type TriggerShapingInput = z.infer<typeof triggerShapingSchema>;
+
+// ── Step Complete Event ──
+export const stepCompleteSchema = z.object({
+  stepId: z.string().min(1),
+  payload: z.record(z.unknown()).optional(),
+});
+export type StepCompleteInput = z.infer<typeof stepCompleteSchema>;
+
+// ── Step Failed Event ──
+export const stepFailedSchema = z.object({
+  stepId: z.string().min(1),
+  errorCode: z.string().max(100).optional(),
+  errorMessage: z.string().max(5000),
+});
+export type StepFailedInput = z.infer<typeof stepFailedSchema>;
+
+// ── HITL Checkpoint (F314) ──
+export const CHECKPOINT_STEPS = ["2-1", "2-3", "2-5", "2-7"] as const;
+export const COMMIT_GATE_STEP = "2-5" as const;
+
+export const checkpointDecisionSchema = z.object({
+  decision: z.enum(["approved", "rejected"]),
+  responses: z.array(z.object({
+    question: z.string(),
+    answer: z.string(),
+    signal: z.enum(["go", "pivot", "drop"]).optional(),
+  })).optional(),
+  reason: z.string().max(2000).optional(),
+});
+export type CheckpointDecision = z.infer<typeof checkpointDecisionSchema>;
+
+// ── Auto Advance (F314) ──
+export const autoAdvanceSchema = z.object({
+  fromStep: z.string().min(1).optional(),
+  skipCheckpoints: z.boolean().default(false),
+});
+export type AutoAdvanceInput = z.infer<typeof autoAdvanceSchema>;

--- a/packages/fx-shaping/src/env.ts
+++ b/packages/fx-shaping/src/env.ts
@@ -1,0 +1,12 @@
+/** fx-shaping Workers 환경 바인딩 (F540: FX-REQ-579) */
+export interface ShapingEnv {
+  DB: D1Database;
+  JWT_SECRET: string;
+  ANTHROPIC_API_KEY?: string;
+  /** KV Cache — rate limiting (ax-bd-agent, ax-bd-persona-eval) */
+  CACHE: KVNamespace;
+  /** R2 — prototype HTML 서빙 (ax-bd-prototypes) */
+  FILES_BUCKET: R2Bucket;
+  /** Marker.io 피드백 위젯 (ax-bd-prototypes, optional) */
+  MARKER_PROJECT_ID?: string;
+}

--- a/packages/fx-shaping/src/harness/schemas/prototype-build.ts
+++ b/packages/fx-shaping/src/harness/schemas/prototype-build.ts
@@ -1,0 +1,11 @@
+// Sprint 222: F457 — Prototype Builder 실행 요청 스키마
+import { z } from "zod";
+
+export const PrototypeBuildSchema = z.object({
+  prdContent: z.string().min(100, "PRD 내용이 너무 짧아요"),
+  prdTitle: z.string().min(1),
+  bizItemId: z.string().min(1),
+  builderType: z.enum(["cli", "api", "ensemble"]).default("cli"),
+});
+
+export type PrototypeBuildInput = z.infer<typeof PrototypeBuildSchema>;

--- a/packages/fx-shaping/src/harness/schemas/prototype-ext.ts
+++ b/packages/fx-shaping/src/harness/schemas/prototype-ext.ts
@@ -1,0 +1,63 @@
+/**
+ * Sprint 67: F209 — PoC 환경 + 기술 검증 Zod 스키마
+ */
+import { z } from "@hono/zod-openapi";
+
+export const PocEnvProvisionSchema = z.object({
+  config: z.record(z.unknown()).optional(),
+}).openapi("PocEnvProvisionRequest");
+
+export const PocEnvStatusEnum = z.enum([
+  "pending", "provisioning", "ready", "teardown", "terminated", "failed",
+]);
+
+export const PocEnvResponseSchema = z.object({
+  id: z.string(),
+  prototypeId: z.string(),
+  status: PocEnvStatusEnum,
+  config: z.record(z.unknown()),
+  provisionedAt: z.string().nullable(),
+  terminatedAt: z.string().nullable(),
+  createdAt: z.string(),
+}).openapi("PocEnvResponse");
+
+export const TechReviewResponseSchema = z.object({
+  id: z.string(),
+  prototypeId: z.string(),
+  feasibility: z.enum(["high", "medium", "low"]),
+  stackFit: z.number().min(0).max(100),
+  complexity: z.enum(["low", "medium", "high"]),
+  risks: z.array(z.string()),
+  recommendation: z.enum(["proceed", "modify", "reject"]),
+  estimatedEffort: z.string(),
+  reviewedAt: z.string(),
+  createdAt: z.string(),
+}).openapi("TechReviewResponse");
+
+export const PrototypeListItemSchema = z.object({
+  id: z.string(),
+  bizItemId: z.string(),
+  version: z.number(),
+  format: z.string(),
+  templateUsed: z.string().nullable(),
+  generatedAt: z.string(),
+}).openapi("PrototypeListItem");
+
+export const PrototypeListResponseSchema = z.object({
+  items: z.array(PrototypeListItemSchema),
+  total: z.number(),
+}).openapi("PrototypeListResponse");
+
+export const PrototypeDetailSchema = z.object({
+  id: z.string(),
+  bizItemId: z.string(),
+  version: z.number(),
+  format: z.string(),
+  content: z.string(),
+  templateUsed: z.string().nullable(),
+  modelUsed: z.string().nullable(),
+  tokensUsed: z.number(),
+  generatedAt: z.string(),
+  pocEnv: PocEnvResponseSchema.nullable(),
+  techReview: TechReviewResponseSchema.nullable(),
+}).openapi("PrototypeDetail");

--- a/packages/fx-shaping/src/harness/schemas/prototype-job.ts
+++ b/packages/fx-shaping/src/harness/schemas/prototype-job.ts
@@ -1,0 +1,63 @@
+// ─── F353: Prototype Job Zod 스키마 (Sprint 159) ───
+
+import { z } from "@hono/zod-openapi";
+
+export const JOB_STATUSES = [
+  "queued", "building", "deploying", "live",
+  "failed", "deploy_failed", "dead_letter", "feedback_pending",
+] as const;
+
+export const BUILDER_TYPES = ["cli", "api", "ensemble"] as const;
+
+const JobStatusEnum = z.enum(JOB_STATUSES);
+const BuilderTypeEnum = z.enum(BUILDER_TYPES);
+
+// ─── 요청 스키마 ───
+
+export const CreatePrototypeJobSchema = z.object({
+  prdContent: z.string().min(10),
+  prdTitle: z.string().min(1).max(200),
+}).openapi("CreatePrototypeJob");
+
+export const UpdatePrototypeJobSchema = z.object({
+  status: JobStatusEnum.optional(),
+  buildLog: z.string().optional(),
+  pagesProject: z.string().optional(),
+  pagesUrl: z.string().url().optional(),
+  errorMessage: z.string().optional(),
+  costInputTokens: z.number().int().min(0).optional(),
+  costOutputTokens: z.number().int().min(0).optional(),
+  costUsd: z.number().min(0).optional(),
+  modelUsed: z.string().optional(),
+  fallbackUsed: z.boolean().optional(),
+}).openapi("UpdatePrototypeJob");
+
+// ─── 응답 스키마 ───
+
+export const PrototypeJobSchema = z.object({
+  id: z.string(),
+  orgId: z.string(),
+  prdTitle: z.string(),
+  status: JobStatusEnum,
+  builderType: BuilderTypeEnum,
+  pagesUrl: z.string().nullable(),
+  costUsd: z.number(),
+  modelUsed: z.string(),
+  fallbackUsed: z.boolean(),
+  retryCount: z.number(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+  startedAt: z.number().nullable(),
+  completedAt: z.number().nullable(),
+}).openapi("PrototypeJob");
+
+export const PrototypeJobListSchema = z.object({
+  items: z.array(PrototypeJobSchema),
+  total: z.number(),
+}).openapi("PrototypeJobList");
+
+export const PrototypeJobDetailSchema = PrototypeJobSchema.extend({
+  prdContent: z.string(),
+  buildLog: z.string(),
+  errorMessage: z.string().nullable(),
+}).openapi("PrototypeJobDetail");

--- a/packages/fx-shaping/src/harness/services/audit-logger.ts
+++ b/packages/fx-shaping/src/harness/services/audit-logger.ts
@@ -1,0 +1,192 @@
+/**
+ * AuditLogService — AI 생성 코드 감사 로그 서비스 (F165)
+ */
+
+export interface AuditEvent {
+  tenantId: string;
+  eventType: string;
+  agentId?: string;
+  modelId?: string;
+  promptHash?: string;
+  inputClassification?: string;
+  outputType?: string;
+  approvedBy?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AuditLog {
+  id: string;
+  tenantId: string;
+  eventType: string;
+  agentId: string | null;
+  modelId: string | null;
+  promptHash: string | null;
+  inputClassification: string;
+  outputType: string | null;
+  approvedBy: string | null;
+  approvedAt: string | null;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+}
+
+export interface AuditQueryParams {
+  eventType?: string;
+  agentId?: string;
+  modelId?: string;
+  startDate?: string;
+  endDate?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface AuditStats {
+  stats: { eventType: string; count: number }[];
+  total: number;
+  period: { from: string; to: string };
+}
+
+export class AuditLogService {
+  constructor(private db: D1Database) {}
+
+  async logEvent(event: AuditEvent): Promise<{ id: string; recorded: boolean }> {
+    const id = `audit-${crypto.randomUUID()}`;
+    const metadata = JSON.stringify(event.metadata ?? {});
+    const approvedAt = event.approvedBy ? new Date().toISOString() : null;
+
+    await this.db
+      .prepare(
+        `INSERT INTO audit_logs (id, tenant_id, event_type, agent_id, model_id, prompt_hash, input_classification, output_type, approved_by, approved_at, metadata)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        id,
+        event.tenantId,
+        event.eventType,
+        event.agentId ?? null,
+        event.modelId ?? null,
+        event.promptHash ?? null,
+        event.inputClassification ?? "internal",
+        event.outputType ?? null,
+        event.approvedBy ?? null,
+        approvedAt,
+        metadata,
+      )
+      .run();
+
+    return { id, recorded: true };
+  }
+
+  async getEvents(
+    tenantId: string,
+    params?: AuditQueryParams,
+  ): Promise<{ logs: AuditLog[]; total: number; page: number; pageSize: number }> {
+    const page = params?.page ?? 1;
+    const pageSize = params?.pageSize ?? 20;
+    const offset = (page - 1) * pageSize;
+
+    let countSql = "SELECT COUNT(*) as cnt FROM audit_logs WHERE tenant_id = ?";
+    let querySql = "SELECT * FROM audit_logs WHERE tenant_id = ?";
+    const bindings: unknown[] = [tenantId];
+
+    if (params?.eventType) {
+      countSql += " AND event_type = ?";
+      querySql += " AND event_type = ?";
+      bindings.push(params.eventType);
+    }
+
+    if (params?.agentId) {
+      countSql += " AND agent_id = ?";
+      querySql += " AND agent_id = ?";
+      bindings.push(params.agentId);
+    }
+
+    if (params?.modelId) {
+      countSql += " AND model_id = ?";
+      querySql += " AND model_id = ?";
+      bindings.push(params.modelId);
+    }
+
+    if (params?.startDate) {
+      countSql += " AND created_at >= ?";
+      querySql += " AND created_at >= ?";
+      bindings.push(params.startDate);
+    }
+
+    if (params?.endDate) {
+      countSql += " AND created_at <= ?";
+      querySql += " AND created_at <= ?";
+      bindings.push(params.endDate);
+    }
+
+    querySql += " ORDER BY created_at DESC LIMIT ? OFFSET ?";
+
+    const countResult = await this.db
+      .prepare(countSql)
+      .bind(...bindings)
+      .first<{ cnt: number }>();
+
+    const rows = await this.db
+      .prepare(querySql)
+      .bind(...bindings, pageSize, offset)
+      .all<{
+        id: string;
+        tenant_id: string;
+        event_type: string;
+        agent_id: string | null;
+        model_id: string | null;
+        prompt_hash: string | null;
+        input_classification: string;
+        output_type: string | null;
+        approved_by: string | null;
+        approved_at: string | null;
+        metadata: string;
+        created_at: string;
+      }>();
+
+    const logs: AuditLog[] = (rows.results ?? []).map((r) => ({
+      id: r.id,
+      tenantId: r.tenant_id,
+      eventType: r.event_type,
+      agentId: r.agent_id,
+      modelId: r.model_id,
+      promptHash: r.prompt_hash,
+      inputClassification: r.input_classification,
+      outputType: r.output_type,
+      approvedBy: r.approved_by,
+      approvedAt: r.approved_at,
+      metadata: JSON.parse(r.metadata || "{}"),
+      createdAt: r.created_at,
+    }));
+
+    return { logs, total: countResult?.cnt ?? 0, page, pageSize };
+  }
+
+  async getStats(tenantId: string, period: number = 7): Promise<AuditStats> {
+    const cutoff = new Date(Date.now() - period * 86400_000).toISOString();
+    const now = new Date().toISOString();
+
+    const rows = await this.db
+      .prepare(
+        `SELECT event_type, COUNT(*) as cnt
+         FROM audit_logs
+         WHERE tenant_id = ? AND created_at >= ?
+         GROUP BY event_type
+         ORDER BY cnt DESC`,
+      )
+      .bind(tenantId, cutoff)
+      .all<{ event_type: string; cnt: number }>();
+
+    const stats = (rows.results ?? []).map((r) => ({
+      eventType: r.event_type,
+      count: r.cnt,
+    }));
+
+    const total = stats.reduce((sum, s) => sum + s.count, 0);
+
+    return {
+      stats,
+      total,
+      period: { from: cutoff, to: now },
+    };
+  }
+}

--- a/packages/fx-shaping/src/harness/services/prototype-job-service.ts
+++ b/packages/fx-shaping/src/harness/services/prototype-job-service.ts
@@ -1,0 +1,246 @@
+// ─── F353: Prototype Job Service (Sprint 159) ───
+
+import { JOB_STATUSES } from "../schemas/prototype-job.js";
+
+type JobStatus = (typeof JOB_STATUSES)[number];
+
+const VALID_TRANSITIONS: Record<string, string[]> = {
+  queued: ["building"],
+  building: ["deploying", "failed"],
+  deploying: ["live", "deploy_failed"],
+  live: ["feedback_pending"],
+  failed: ["queued", "dead_letter"],
+  deploy_failed: ["queued", "dead_letter"],
+  feedback_pending: ["building"],
+};
+
+const MAX_RETRY = 3;
+
+interface JobRow {
+  id: string;
+  org_id: string;
+  prd_content: string;
+  prd_title: string;
+  status: string;
+  builder_type: string;
+  pages_project: string | null;
+  pages_url: string | null;
+  build_log: string | null;
+  error_message: string | null;
+  cost_input_tokens: number;
+  cost_output_tokens: number;
+  cost_usd: number;
+  model_used: string;
+  fallback_used: number;
+  retry_count: number;
+  created_at: number;
+  updated_at: number;
+  started_at: number | null;
+  completed_at: number | null;
+}
+
+export interface PrototypeJobRecord {
+  id: string;
+  orgId: string;
+  prdTitle: string;
+  status: JobStatus;
+  builderType: string;
+  pagesUrl: string | null;
+  costUsd: number;
+  modelUsed: string;
+  fallbackUsed: boolean;
+  retryCount: number;
+  createdAt: number;
+  updatedAt: number;
+  startedAt: number | null;
+  completedAt: number | null;
+}
+
+export interface PrototypeJobDetail extends PrototypeJobRecord {
+  prdContent: string;
+  buildLog: string;
+  errorMessage: string | null;
+}
+
+interface JobUpdates {
+  buildLog?: string;
+  pagesProject?: string;
+  pagesUrl?: string;
+  errorMessage?: string;
+  costInputTokens?: number;
+  costOutputTokens?: number;
+  costUsd?: number;
+  modelUsed?: string;
+  fallbackUsed?: boolean;
+}
+
+function toRecord(row: JobRow): PrototypeJobRecord {
+  return {
+    id: row.id,
+    orgId: row.org_id,
+    prdTitle: row.prd_title,
+    status: row.status as JobStatus,
+    builderType: row.builder_type,
+    pagesUrl: row.pages_url,
+    costUsd: row.cost_usd,
+    modelUsed: row.model_used,
+    fallbackUsed: row.fallback_used === 1,
+    retryCount: row.retry_count,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    startedAt: row.started_at,
+    completedAt: row.completed_at,
+  };
+}
+
+function toDetail(row: JobRow): PrototypeJobDetail {
+  return {
+    ...toRecord(row),
+    prdContent: row.prd_content,
+    buildLog: row.build_log ?? "",
+    errorMessage: row.error_message,
+  };
+}
+
+export class PrototypeJobService {
+  constructor(private db: D1Database) {}
+
+  async create(orgId: string, prdContent: string, prdTitle: string): Promise<PrototypeJobRecord> {
+    const id = crypto.randomUUID();
+    const now = Math.floor(Date.now() / 1000);
+    await this.db
+      .prepare(
+        `INSERT INTO prototype_jobs (id, org_id, prd_content, prd_title, status, created_at, updated_at)
+         VALUES (?, ?, ?, ?, 'queued', ?, ?)`,
+      )
+      .bind(id, orgId, prdContent, prdTitle, now, now)
+      .run();
+
+    const row = await this.db
+      .prepare("SELECT * FROM prototype_jobs WHERE id = ?")
+      .bind(id)
+      .first<JobRow>();
+    return toRecord(row!);
+  }
+
+  async list(
+    orgId: string,
+    opts: { status?: string; limit: number; offset: number },
+  ): Promise<{ items: PrototypeJobRecord[]; total: number }> {
+    const params: unknown[] = [orgId];
+    let where = "WHERE org_id = ?";
+    if (opts.status) {
+      where += " AND status = ?";
+      params.push(opts.status);
+    }
+
+    const countResult = await this.db
+      .prepare(`SELECT COUNT(*) as cnt FROM prototype_jobs ${where}`)
+      .bind(...params)
+      .first<{ cnt: number }>();
+    const total = countResult?.cnt ?? 0;
+
+    const rows = await this.db
+      .prepare(
+        `SELECT * FROM prototype_jobs ${where} ORDER BY created_at DESC LIMIT ? OFFSET ?`,
+      )
+      .bind(...params, opts.limit, opts.offset)
+      .all<JobRow>();
+
+    return { items: (rows.results ?? []).map(toRecord), total };
+  }
+
+  async getById(id: string, orgId: string): Promise<PrototypeJobDetail | null> {
+    const row = await this.db
+      .prepare("SELECT * FROM prototype_jobs WHERE id = ? AND org_id = ?")
+      .bind(id, orgId)
+      .first<JobRow>();
+    return row ? toDetail(row) : null;
+  }
+
+  async transition(
+    id: string,
+    orgId: string,
+    toStatus: string,
+    updates?: JobUpdates,
+  ): Promise<PrototypeJobRecord> {
+    const row = await this.db
+      .prepare("SELECT * FROM prototype_jobs WHERE id = ? AND org_id = ?")
+      .bind(id, orgId)
+      .first<JobRow>();
+    if (!row) throw new Error("Job not found");
+
+    const allowed = VALID_TRANSITIONS[row.status];
+    if (!allowed || !allowed.includes(toStatus)) {
+      throw new Error(`Invalid transition: ${row.status} → ${toStatus}`);
+    }
+
+    // retry_count 기반 dead_letter 강제
+    if (
+      (row.status === "failed" || row.status === "deploy_failed") &&
+      toStatus === "queued" &&
+      row.retry_count >= MAX_RETRY
+    ) {
+      throw new Error(`Max retry exceeded (${MAX_RETRY}), use dead_letter`);
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+    const sets: string[] = ["status = ?", "updated_at = ?"];
+    const params: unknown[] = [toStatus, now];
+
+    if (toStatus === "building") {
+      sets.push("started_at = ?");
+      params.push(now);
+    }
+    if (toStatus === "live") {
+      sets.push("completed_at = ?");
+      params.push(now);
+    }
+    if (toStatus === "queued" && (row.status === "failed" || row.status === "deploy_failed")) {
+      sets.push("retry_count = ?");
+      params.push(row.retry_count + 1);
+    }
+
+    if (updates) {
+      if (updates.buildLog !== undefined) { sets.push("build_log = ?"); params.push(updates.buildLog); }
+      if (updates.pagesProject !== undefined) { sets.push("pages_project = ?"); params.push(updates.pagesProject); }
+      if (updates.pagesUrl !== undefined) { sets.push("pages_url = ?"); params.push(updates.pagesUrl); }
+      if (updates.errorMessage !== undefined) { sets.push("error_message = ?"); params.push(updates.errorMessage); }
+      if (updates.costInputTokens !== undefined) { sets.push("cost_input_tokens = ?"); params.push(updates.costInputTokens); }
+      if (updates.costOutputTokens !== undefined) { sets.push("cost_output_tokens = ?"); params.push(updates.costOutputTokens); }
+      if (updates.costUsd !== undefined) { sets.push("cost_usd = ?"); params.push(updates.costUsd); }
+      if (updates.modelUsed !== undefined) { sets.push("model_used = ?"); params.push(updates.modelUsed); }
+      if (updates.fallbackUsed !== undefined) { sets.push("fallback_used = ?"); params.push(updates.fallbackUsed ? 1 : 0); }
+    }
+
+    params.push(id, orgId);
+    await this.db
+      .prepare(`UPDATE prototype_jobs SET ${sets.join(", ")} WHERE id = ? AND org_id = ?`)
+      .bind(...params)
+      .run();
+
+    const updated = await this.db
+      .prepare("SELECT * FROM prototype_jobs WHERE id = ?")
+      .bind(id)
+      .first<JobRow>();
+    return toRecord(updated!);
+  }
+
+  async retry(id: string, orgId: string): Promise<PrototypeJobRecord> {
+    const row = await this.db
+      .prepare("SELECT * FROM prototype_jobs WHERE id = ? AND org_id = ?")
+      .bind(id, orgId)
+      .first<JobRow>();
+    if (!row) throw new Error("Job not found");
+
+    if (row.status !== "failed" && row.status !== "deploy_failed") {
+      throw new Error(`Cannot retry from status: ${row.status}`);
+    }
+
+    if (row.retry_count >= MAX_RETRY) {
+      return this.transition(id, orgId, "dead_letter");
+    }
+
+    return this.transition(id, orgId, "queued");
+  }
+}

--- a/packages/fx-shaping/src/harness/services/prototype-review-service.ts
+++ b/packages/fx-shaping/src/harness/services/prototype-review-service.ts
@@ -1,0 +1,129 @@
+/**
+ * Sprint 118: F297 — Prototype 섹션별 HITL 리뷰 서비스
+ * Sprint 230: F470 — revision_requested → 피드백 자동 생성 연결
+ */
+
+import type { SectionReviewInput } from "../../schemas/hitl-section.schema.js";
+
+export interface PrototypeSectionReview {
+  id: string;
+  orgId: string;
+  prototypeId: string;
+  sectionId: string;
+  status: string;
+  reviewerId: string;
+  comment: string | null;
+  framework: string;
+  createdAt: string;
+}
+
+export interface PrototypeReviewSummary {
+  total: number;
+  approved: number;
+  pending: number;
+  rejected: number;
+  revisionRequested: number;
+}
+
+// F470: revision_requested 시 피드백 자동 생성을 위한 콜백 타입
+export type OnRevisionRequestedFn = (
+  orgId: string,
+  prototypeId: string,
+  sectionId: string,
+  comment: string,
+) => Promise<void>;
+
+export class PrototypeReviewService {
+  private onRevisionRequested: OnRevisionRequestedFn | null = null;
+
+  constructor(private db: D1Database) {}
+
+  /** F470: revision_requested 발생 시 호출될 콜백 등록 */
+  setOnRevisionRequested(fn: OnRevisionRequestedFn): void {
+    this.onRevisionRequested = fn;
+  }
+
+  async reviewSection(
+    orgId: string,
+    prototypeId: string,
+    input: SectionReviewInput,
+    reviewerId: string,
+    framework: string = "react",
+  ): Promise<PrototypeSectionReview> {
+    const id = crypto.randomUUID();
+
+    await this.db
+      .prepare(
+        `INSERT INTO prototype_section_reviews (id, org_id, prototype_id, section_id, status, reviewer_id, comment, framework)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(id, orgId, prototypeId, input.sectionId, input.action, reviewerId, input.comment ?? null, framework)
+      .run();
+
+    // F470: revision_requested 시 자동으로 피드백 생성
+    if (input.action === "revision_requested" && input.comment && this.onRevisionRequested) {
+      await this.onRevisionRequested(orgId, prototypeId, input.sectionId, input.comment);
+    }
+
+    return {
+      id,
+      orgId,
+      prototypeId,
+      sectionId: input.sectionId,
+      status: input.action,
+      reviewerId,
+      comment: input.comment ?? null,
+      framework,
+      createdAt: new Date().toISOString(),
+    };
+  }
+
+  async listReviews(orgId: string, prototypeId: string): Promise<PrototypeSectionReview[]> {
+    const { results } = await this.db
+      .prepare(
+        `SELECT id, org_id, prototype_id, section_id, status, reviewer_id, comment, framework, created_at
+         FROM prototype_section_reviews WHERE org_id = ? AND prototype_id = ?
+         ORDER BY created_at DESC`,
+      )
+      .bind(orgId, prototypeId)
+      .all<Record<string, unknown>>();
+
+    return results.map((r) => this.mapRow(r));
+  }
+
+  async getSummary(orgId: string, prototypeId: string): Promise<PrototypeReviewSummary> {
+    const { results } = await this.db
+      .prepare(
+        `SELECT status, COUNT(*) as cnt
+         FROM prototype_section_reviews WHERE org_id = ? AND prototype_id = ?
+         GROUP BY status`,
+      )
+      .bind(orgId, prototypeId)
+      .all<{ status: string; cnt: number }>();
+
+    const summary: PrototypeReviewSummary = { total: 0, approved: 0, pending: 0, rejected: 0, revisionRequested: 0 };
+    for (const row of results) {
+      const count = row.cnt;
+      summary.total += count;
+      if (row.status === "approved") summary.approved = count;
+      else if (row.status === "pending") summary.pending = count;
+      else if (row.status === "rejected") summary.rejected = count;
+      else if (row.status === "revision_requested") summary.revisionRequested = count;
+    }
+    return summary;
+  }
+
+  private mapRow(r: Record<string, unknown>): PrototypeSectionReview {
+    return {
+      id: r.id as string,
+      orgId: r.org_id as string,
+      prototypeId: r.prototype_id as string,
+      sectionId: r.section_id as string,
+      status: r.status as string,
+      reviewerId: r.reviewer_id as string,
+      comment: (r.comment as string) ?? null,
+      framework: r.framework as string,
+      createdAt: r.created_at as string,
+    };
+  }
+}

--- a/packages/fx-shaping/src/harness/services/prototype-service.ts
+++ b/packages/fx-shaping/src/harness/services/prototype-service.ts
@@ -1,0 +1,238 @@
+/**
+ * Sprint 67: F209 — Prototype CRUD 래퍼 서비스
+ * 기존 PrototypeGeneratorService는 생성 전담, 이 서비스는 조회/삭제 CRUD
+ */
+
+interface ProtoRow {
+  id: string;
+  biz_item_id: string;
+  biz_item_title?: string;
+  version: number;
+  format: string;
+  content: string;
+  template_used: string | null;
+  model_used: string | null;
+  tokens_used: number;
+  generated_at: string;
+}
+
+interface PocEnvRow {
+  id: string;
+  prototype_id: string;
+  status: string;
+  config: string;
+  provisioned_at: string | null;
+  terminated_at: string | null;
+  created_at: string;
+}
+
+interface TechReviewRow {
+  id: string;
+  prototype_id: string;
+  feasibility: string;
+  stack_fit: number;
+  complexity: string;
+  risks: string;
+  recommendation: string;
+  estimated_effort: string | null;
+  reviewed_at: string;
+  created_at: string;
+}
+
+export interface PrototypeListItem {
+  id: string;
+  bizItemId: string;
+  bizItemTitle: string;
+  version: number;
+  format: string;
+  templateUsed: string | null;
+  generatedAt: string;
+}
+
+export interface LinkedOffering {
+  offeringId: string;
+  offeringTitle: string;
+}
+
+export interface PrototypeDetail {
+  id: string;
+  bizItemId: string;
+  bizItemTitle: string;
+  version: number;
+  format: string;
+  content: string;
+  templateUsed: string | null;
+  modelUsed: string | null;
+  tokensUsed: number;
+  generatedAt: string;
+  linkedOfferings: LinkedOffering[];
+  pocEnv: {
+    id: string;
+    prototypeId: string;
+    status: string;
+    config: Record<string, unknown>;
+    provisionedAt: string | null;
+    terminatedAt: string | null;
+    createdAt: string;
+  } | null;
+  techReview: {
+    id: string;
+    prototypeId: string;
+    feasibility: string;
+    stackFit: number;
+    complexity: string;
+    risks: string[];
+    recommendation: string;
+    estimatedEffort: string;
+    reviewedAt: string;
+    createdAt: string;
+  } | null;
+}
+
+function toListItem(row: ProtoRow): PrototypeListItem {
+  return {
+    id: row.id,
+    bizItemId: row.biz_item_id,
+    bizItemTitle: row.biz_item_title ?? row.biz_item_id,
+    version: row.version,
+    format: row.format,
+    templateUsed: row.template_used,
+    generatedAt: row.generated_at,
+  };
+}
+
+function toPocEnv(row: PocEnvRow) {
+  return {
+    id: row.id,
+    prototypeId: row.prototype_id,
+    status: row.status,
+    config: JSON.parse(row.config || "{}") as Record<string, unknown>,
+    provisionedAt: row.provisioned_at,
+    terminatedAt: row.terminated_at,
+    createdAt: row.created_at,
+  };
+}
+
+function toTechReview(row: TechReviewRow) {
+  return {
+    id: row.id,
+    prototypeId: row.prototype_id,
+    feasibility: row.feasibility,
+    stackFit: row.stack_fit,
+    complexity: row.complexity,
+    risks: JSON.parse(row.risks || "[]") as string[],
+    recommendation: row.recommendation,
+    estimatedEffort: row.estimated_effort ?? "",
+    reviewedAt: row.reviewed_at,
+    createdAt: row.created_at,
+  };
+}
+
+export class PrototypeService {
+  constructor(private db: D1Database) {}
+
+  async list(tenantId: string, opts?: {
+    bizItemId?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<{ items: PrototypeListItem[]; total: number }> {
+    const limit = opts?.limit ?? 20;
+    const offset = opts?.offset ?? 0;
+
+    let query: string;
+    let countQuery: string;
+    const bindings: unknown[] = [];
+    const countBindings: unknown[] = [];
+
+    if (opts?.bizItemId) {
+      query = `SELECT p.*, bi.title AS biz_item_title FROM prototypes p
+        JOIN biz_items bi ON p.biz_item_id = bi.id
+        WHERE bi.org_id = ? AND p.biz_item_id = ?
+        ORDER BY p.generated_at DESC LIMIT ? OFFSET ?`;
+      bindings.push(tenantId, opts.bizItemId, limit, offset);
+
+      countQuery = `SELECT COUNT(*) as total FROM prototypes p
+        JOIN biz_items bi ON p.biz_item_id = bi.id
+        WHERE bi.org_id = ? AND p.biz_item_id = ?`;
+      countBindings.push(tenantId, opts.bizItemId);
+    } else {
+      query = `SELECT p.*, bi.title AS biz_item_title FROM prototypes p
+        JOIN biz_items bi ON p.biz_item_id = bi.id
+        WHERE bi.org_id = ?
+        ORDER BY p.generated_at DESC LIMIT ? OFFSET ?`;
+      bindings.push(tenantId, limit, offset);
+
+      countQuery = `SELECT COUNT(*) as total FROM prototypes p
+        JOIN biz_items bi ON p.biz_item_id = bi.id
+        WHERE bi.org_id = ?`;
+      countBindings.push(tenantId);
+    }
+
+    const { results } = await this.db.prepare(query).bind(...bindings).all<ProtoRow>();
+    const countRow = await this.db.prepare(countQuery).bind(...countBindings).first<{ total: number }>();
+
+    return {
+      items: (results ?? []).map(toListItem),
+      total: countRow?.total ?? 0,
+    };
+  }
+
+  async getById(id: string, tenantId: string): Promise<PrototypeDetail | null> {
+    const row = await this.db.prepare(
+      `SELECT p.*, bi.title AS biz_item_title FROM prototypes p
+       JOIN biz_items bi ON p.biz_item_id = bi.id
+       WHERE p.id = ? AND bi.org_id = ?`
+    ).bind(id, tenantId).first<ProtoRow>();
+    if (!row) return null;
+
+    // Fetch linked offerings
+    const { results: offeringRows } = await this.db.prepare(
+      `SELECT o.id AS offering_id, o.title AS offering_title
+       FROM offering_prototypes op
+       JOIN offerings o ON o.id = op.offering_id
+       WHERE op.prototype_id = ?`
+    ).bind(id).all<{ offering_id: string; offering_title: string }>();
+
+    // Fetch related poc_env and tech_review
+    const pocRow = await this.db.prepare(
+      "SELECT * FROM poc_environments WHERE prototype_id = ?"
+    ).bind(id).first<PocEnvRow>();
+
+    const reviewRow = await this.db.prepare(
+      "SELECT * FROM tech_reviews WHERE prototype_id = ? ORDER BY created_at DESC LIMIT 1"
+    ).bind(id).first<TechReviewRow>();
+
+    return {
+      id: row.id,
+      bizItemId: row.biz_item_id,
+      bizItemTitle: row.biz_item_title ?? row.biz_item_id,
+      version: row.version,
+      format: row.format,
+      content: row.content,
+      templateUsed: row.template_used,
+      modelUsed: row.model_used,
+      tokensUsed: row.tokens_used,
+      generatedAt: row.generated_at,
+      linkedOfferings: (offeringRows ?? []).map(r => ({
+        offeringId: r.offering_id,
+        offeringTitle: r.offering_title,
+      })),
+      pocEnv: pocRow ? toPocEnv(pocRow) : null,
+      techReview: reviewRow ? toTechReview(reviewRow) : null,
+    };
+  }
+
+  async delete(id: string, tenantId: string): Promise<boolean> {
+    // Verify ownership via biz_items.org_id
+    const row = await this.db.prepare(
+      `SELECT p.id FROM prototypes p
+       JOIN biz_items bi ON p.biz_item_id = bi.id
+       WHERE p.id = ? AND bi.org_id = ?`
+    ).bind(id, tenantId).first();
+    if (!row) return false;
+
+    // CASCADE will handle poc_environments and tech_reviews
+    const result = await this.db.prepare("DELETE FROM prototypes WHERE id = ?").bind(id).run();
+    return (result.meta?.changes ?? 0) > 0;
+  }
+}

--- a/packages/fx-shaping/src/harness/services/tech-review-service.ts
+++ b/packages/fx-shaping/src/harness/services/tech-review-service.ts
@@ -1,0 +1,134 @@
+/**
+ * Sprint 67: F209 — 기술 타당성 분석 서비스
+ * Phase 1: 규칙 기반 분석 (AI 분석은 Phase 2)
+ */
+
+export interface TechReviewResult {
+  id: string;
+  prototypeId: string;
+  feasibility: "high" | "medium" | "low";
+  stackFit: number;
+  complexity: "low" | "medium" | "high";
+  risks: string[];
+  recommendation: "proceed" | "modify" | "reject";
+  estimatedEffort: string;
+  reviewedAt: string;
+  createdAt: string;
+}
+
+interface TechReviewRow {
+  id: string;
+  prototype_id: string;
+  feasibility: string;
+  stack_fit: number;
+  complexity: string;
+  risks: string;
+  recommendation: string;
+  estimated_effort: string | null;
+  reviewed_at: string;
+  created_at: string;
+}
+
+function toReview(row: TechReviewRow): TechReviewResult {
+  return {
+    id: row.id,
+    prototypeId: row.prototype_id,
+    feasibility: row.feasibility as TechReviewResult["feasibility"],
+    stackFit: row.stack_fit,
+    complexity: row.complexity as TechReviewResult["complexity"],
+    risks: JSON.parse(row.risks || "[]") as string[],
+    recommendation: row.recommendation as TechReviewResult["recommendation"],
+    estimatedEffort: row.estimated_effort ?? "",
+    reviewedAt: row.reviewed_at,
+    createdAt: row.created_at,
+  };
+}
+
+export class TechReviewService {
+  constructor(private db: D1Database) {}
+
+  async analyze(prototypeId: string, tenantId: string): Promise<TechReviewResult> {
+    // 1. Verify prototype and get content
+    const proto = await this.db.prepare(
+      `SELECT p.id, p.content, p.template_used, bi.title, bi.description
+       FROM prototypes p
+       JOIN biz_items bi ON p.biz_item_id = bi.id
+       WHERE p.id = ? AND bi.org_id = ?`
+    ).bind(prototypeId, tenantId).first<{
+      id: string;
+      content: string;
+      template_used: string | null;
+      title: string;
+      description: string | null;
+    }>();
+    if (!proto) throw new Error("Prototype not found");
+
+    // 2. Rule-based analysis
+    const contentLength = proto.content?.length ?? 0;
+    const hasTemplate = !!proto.template_used;
+
+    // Feasibility: based on content richness
+    let feasibility: TechReviewResult["feasibility"];
+    if (contentLength > 5000 && hasTemplate) feasibility = "high";
+    else if (contentLength > 2000) feasibility = "medium";
+    else feasibility = "low";
+
+    // Stack fit: 0~100 based on template completeness
+    const stackFit = Math.min(100, Math.round((contentLength / 100) + (hasTemplate ? 30 : 0)));
+
+    // Complexity
+    let complexity: TechReviewResult["complexity"];
+    if (contentLength > 10000) complexity = "high";
+    else if (contentLength > 3000) complexity = "medium";
+    else complexity = "low";
+
+    // Risks
+    const risks: string[] = [];
+    if (!hasTemplate) risks.push("No template applied — may lack structure");
+    if (contentLength < 1000) risks.push("Prototype content is minimal");
+    if (complexity === "high") risks.push("High complexity may require extended timeline");
+
+    // Recommendation
+    let recommendation: TechReviewResult["recommendation"];
+    if (feasibility === "high" && risks.length === 0) recommendation = "proceed";
+    else if (feasibility === "low") recommendation = "reject";
+    else recommendation = "modify";
+
+    // Effort estimate
+    const effortWeeks = complexity === "high" ? 4 : complexity === "medium" ? 2 : 1;
+    const estimatedEffort = `${effortWeeks} weeks`;
+
+    // 3. Save to DB
+    const id = crypto.randomUUID();
+    const now = new Date().toISOString();
+
+    await this.db.prepare(
+      `INSERT INTO tech_reviews (id, prototype_id, feasibility, stack_fit, complexity, risks, recommendation, estimated_effort, reviewed_at, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).bind(id, prototypeId, feasibility, stackFit, complexity, JSON.stringify(risks), recommendation, estimatedEffort, now, now).run();
+
+    return {
+      id,
+      prototypeId,
+      feasibility,
+      stackFit,
+      complexity,
+      risks,
+      recommendation,
+      estimatedEffort,
+      reviewedAt: now,
+      createdAt: now,
+    };
+  }
+
+  async getByPrototype(prototypeId: string, tenantId: string): Promise<TechReviewResult | null> {
+    const row = await this.db.prepare(
+      `SELECT tr.* FROM tech_reviews tr
+       JOIN prototypes p ON tr.prototype_id = p.id
+       JOIN biz_items bi ON p.biz_item_id = bi.id
+       WHERE tr.prototype_id = ? AND bi.org_id = ?
+       ORDER BY tr.created_at DESC LIMIT 1`
+    ).bind(prototypeId, tenantId).first<TechReviewRow>();
+    return row ? toReview(row) : null;
+  }
+}

--- a/packages/fx-shaping/src/index.ts
+++ b/packages/fx-shaping/src/index.ts
@@ -1,0 +1,7 @@
+// fx-shaping — Shaping Domain Worker (F540: FX-REQ-579)
+import app from "./app.js";
+import type { ShapingEnv } from "./env.js";
+
+export default {
+  fetch: app.fetch.bind(app) as ExportedHandlerFetchHandler<ShapingEnv>,
+} satisfies ExportedHandler<ShapingEnv>;

--- a/packages/fx-shaping/src/launch/services/pipeline-state-machine.ts
+++ b/packages/fx-shaping/src/launch/services/pipeline-state-machine.ts
@@ -1,0 +1,160 @@
+/**
+ * F313: PipelineStateMachine — FSM 기반 파이프라인 상태 전이 엔진
+ */
+import type { DiscoveryPipelineStatus, PipelineEventType } from "../../discovery/schemas/discovery-pipeline.js";
+
+export interface TransitionResult {
+  fromStatus: DiscoveryPipelineStatus;
+  toStatus: DiscoveryPipelineStatus;
+  valid: boolean;
+}
+
+interface TransitionRule {
+  to: DiscoveryPipelineStatus;
+  /** 조건 함수 — stepId 등 컨텍스트로 분기 */
+  when?: (ctx: TransitionContext) => boolean;
+}
+
+interface TransitionContext {
+  stepId?: string;
+  retryCount?: number;
+  maxRetries?: number;
+}
+
+type TransitionMap = Partial<
+  Record<DiscoveryPipelineStatus, Partial<Record<PipelineEventType, TransitionRule[]>>>
+>;
+
+const TRANSITIONS: TransitionMap = {
+  idle: {
+    START: [{ to: "discovery_running" }],
+  },
+  discovery_running: {
+    STEP_COMPLETE: [
+      { to: "discovery_complete", when: (ctx) => ctx.stepId === "2-10" },
+      { to: "discovery_running" }, // 중간 단계
+    ],
+    STEP_FAILED: [
+      { to: "failed", when: (ctx) => (ctx.retryCount ?? 0) >= (ctx.maxRetries ?? 3) },
+      { to: "discovery_running" }, // 재시도 가능
+    ],
+    PAUSE: [{ to: "paused" }],
+    ABORT: [{ to: "aborted" }],
+  },
+  discovery_complete: {
+    TRIGGER_SHAPING: [{ to: "shaping_queued" }],
+    ABORT: [{ to: "aborted" }],
+  },
+  shaping_queued: {
+    START: [{ to: "shaping_running" }],
+    ABORT: [{ to: "aborted" }],
+  },
+  shaping_running: {
+    SHAPING_PHASE_COMPLETE: [
+      { to: "shaping_complete", when: (ctx) => ctx.stepId === "phase-F" },
+      { to: "paused", when: (ctx) => ctx.stepId === "phase-F-hitl" },
+      { to: "shaping_running" }, // 중간 phase
+    ],
+    STEP_FAILED: [
+      { to: "failed", when: (ctx) => (ctx.retryCount ?? 0) >= (ctx.maxRetries ?? 3) },
+      { to: "shaping_running" },
+    ],
+    PAUSE: [{ to: "paused" }],
+    ABORT: [{ to: "aborted" }],
+    COMPLETE: [{ to: "shaping_complete" }],
+  },
+  paused: {
+    RESUME: [
+      { to: "discovery_running", when: (ctx) => ctx.stepId?.startsWith("2-") ?? false },
+      { to: "shaping_running" },
+    ],
+    ABORT: [{ to: "aborted" }],
+  },
+  failed: {
+    RETRY: [
+      { to: "discovery_running", when: (ctx) => ctx.stepId?.startsWith("2-") ?? false },
+      { to: "shaping_running" },
+    ],
+    ABORT: [{ to: "aborted" }],
+  },
+};
+
+const TERMINAL_STATUSES: Set<DiscoveryPipelineStatus> = new Set([
+  "shaping_complete", "aborted",
+]);
+
+export class PipelineStateMachine {
+  constructor(private db: D1Database) {}
+
+  /**
+   * 상태 전이 실행 + pipeline_events 기록
+   */
+  async transition(
+    runId: string,
+    event: PipelineEventType,
+    ctx: TransitionContext = {},
+    createdBy?: string,
+  ): Promise<TransitionResult> {
+    const run = await this.db
+      .prepare("SELECT status, retry_count, max_retries FROM discovery_pipeline_runs WHERE id = ?")
+      .bind(runId)
+      .first<{ status: DiscoveryPipelineStatus; retry_count: number; max_retries: number }>();
+
+    if (!run) {
+      throw new Error(`Pipeline run not found: ${runId}`);
+    }
+
+    const fromStatus = run.status;
+    const fullCtx: TransitionContext = {
+      ...ctx,
+      retryCount: ctx.retryCount ?? run.retry_count,
+      maxRetries: ctx.maxRetries ?? run.max_retries,
+    };
+
+    const rules = TRANSITIONS[fromStatus]?.[event];
+    if (!rules) {
+      return { fromStatus, toStatus: fromStatus, valid: false };
+    }
+
+    const matched = rules.find((r) => !r.when || r.when(fullCtx));
+    if (!matched) {
+      return { fromStatus, toStatus: fromStatus, valid: false };
+    }
+
+    const toStatus = matched.to;
+
+    // DB 갱신
+    await this.db
+      .prepare(
+        `UPDATE discovery_pipeline_runs
+         SET status = ?, current_step = COALESCE(?, current_step), updated_at = datetime('now')
+         WHERE id = ?`,
+      )
+      .bind(toStatus, ctx.stepId ?? null, runId)
+      .run();
+
+    // 이벤트 기록
+    const eventId = crypto.randomUUID();
+    await this.db
+      .prepare(
+        `INSERT INTO pipeline_events (id, pipeline_run_id, event_type, from_status, to_status, step_id, created_by)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(eventId, runId, event, fromStatus, toStatus, ctx.stepId ?? null, createdBy ?? null)
+      .run();
+
+    return { fromStatus, toStatus, valid: true };
+  }
+
+  /**
+   * 현재 상태에서 가능한 이벤트 목록
+   */
+  getValidEvents(status: DiscoveryPipelineStatus): PipelineEventType[] {
+    const rules = TRANSITIONS[status];
+    return rules ? (Object.keys(rules) as PipelineEventType[]) : [];
+  }
+
+  isTerminal(status: DiscoveryPipelineStatus): boolean {
+    return TERMINAL_STATUSES.has(status);
+  }
+}

--- a/packages/fx-shaping/src/launch/services/poc-env-service.ts
+++ b/packages/fx-shaping/src/launch/services/poc-env-service.ts
@@ -1,0 +1,112 @@
+/**
+ * Sprint 67: F209 — PoC 환경 관리 서비스
+ * 상태 머신: pending → provisioning → ready → teardown → terminated
+ *                         ↓ (실패)
+ *                       failed
+ */
+
+export type PocEnvStatus = "pending" | "provisioning" | "ready" | "teardown" | "terminated" | "failed";
+
+export interface PocEnvironment {
+  id: string;
+  prototypeId: string;
+  status: PocEnvStatus;
+  config: Record<string, unknown>;
+  provisionedAt: string | null;
+  terminatedAt: string | null;
+  createdAt: string;
+}
+
+interface PocEnvRow {
+  id: string;
+  prototype_id: string;
+  status: string;
+  config: string;
+  provisioned_at: string | null;
+  terminated_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+function toEnv(row: PocEnvRow): PocEnvironment {
+  return {
+    id: row.id,
+    prototypeId: row.prototype_id,
+    status: row.status as PocEnvStatus,
+    config: JSON.parse(row.config || "{}") as Record<string, unknown>,
+    provisionedAt: row.provisioned_at,
+    terminatedAt: row.terminated_at,
+    createdAt: row.created_at,
+  };
+}
+
+export class PocEnvService {
+  constructor(private db: D1Database) {}
+
+  async provision(prototypeId: string, tenantId: string, config?: Record<string, unknown>): Promise<PocEnvironment> {
+    // 1. Verify prototype exists and belongs to tenant
+    const proto = await this.db.prepare(
+      `SELECT p.id FROM prototypes p
+       JOIN biz_items bi ON p.biz_item_id = bi.id
+       WHERE p.id = ? AND bi.org_id = ?`
+    ).bind(prototypeId, tenantId).first();
+    if (!proto) throw new Error("Prototype not found");
+
+    // 2. Check for existing environment
+    const existing = await this.db.prepare(
+      "SELECT id, status FROM poc_environments WHERE prototype_id = ?"
+    ).bind(prototypeId).first<{ id: string; status: string }>();
+
+    if (existing) {
+      if (existing.status !== "terminated" && existing.status !== "failed") {
+        throw new Error("Active PoC environment already exists");
+      }
+      // Remove old terminated/failed record to allow re-provision
+      await this.db.prepare("DELETE FROM poc_environments WHERE id = ?").bind(existing.id).run();
+    }
+
+    // 3. Create new environment
+    const id = crypto.randomUUID();
+    const now = new Date().toISOString();
+    const configJson = JSON.stringify(config ?? {});
+
+    await this.db.prepare(
+      `INSERT INTO poc_environments (id, prototype_id, status, config, created_at, updated_at)
+       VALUES (?, ?, 'pending', ?, ?, ?)`
+    ).bind(id, prototypeId, configJson, now, now).run();
+
+    return {
+      id,
+      prototypeId,
+      status: "pending",
+      config: config ?? {},
+      provisionedAt: null,
+      terminatedAt: null,
+      createdAt: now,
+    };
+  }
+
+  async getByPrototype(prototypeId: string, tenantId: string): Promise<PocEnvironment | null> {
+    const row = await this.db.prepare(
+      `SELECT pe.* FROM poc_environments pe
+       JOIN prototypes p ON pe.prototype_id = p.id
+       JOIN biz_items bi ON p.biz_item_id = bi.id
+       WHERE pe.prototype_id = ? AND bi.org_id = ?`
+    ).bind(prototypeId, tenantId).first<PocEnvRow>();
+    return row ? toEnv(row) : null;
+  }
+
+  async teardown(prototypeId: string, tenantId: string): Promise<void> {
+    // Verify access
+    const env = await this.getByPrototype(prototypeId, tenantId);
+    if (!env) throw new Error("PoC environment not found");
+    if (env.status === "terminated" || env.status === "failed") {
+      throw new Error("Environment already terminated");
+    }
+
+    const now = new Date().toISOString();
+    await this.db.prepare(
+      "UPDATE poc_environments SET status = 'terminated', terminated_at = ?, updated_at = ? WHERE prototype_id = ?"
+    ).bind(now, now, prototypeId).run();
+  }
+}

--- a/packages/fx-shaping/src/middleware/auth.ts
+++ b/packages/fx-shaping/src/middleware/auth.ts
@@ -1,0 +1,19 @@
+/**
+ * F540: fx-shaping JWT 인증 미들웨어
+ * packages/api/src/middleware/auth.ts 기반 — shaping 도메인 전용
+ */
+import { jwt } from "hono/jwt";
+import type { MiddlewareHandler } from "hono";
+import type { ShapingEnv } from "../env.js";
+
+const PUBLIC_PATHS = ["/api/shaping/health"];
+
+export const authMiddleware: MiddlewareHandler<{ Bindings: ShapingEnv }> = async (c, next) => {
+  const path = c.req.path;
+  if (PUBLIC_PATHS.some((p) => path.startsWith(p))) {
+    return next();
+  }
+  const secret = c.env?.JWT_SECRET ?? "dev-secret";
+  const handler = jwt({ secret, alg: "HS256" });
+  return handler(c, next);
+};

--- a/packages/fx-shaping/src/middleware/tenant.ts
+++ b/packages/fx-shaping/src/middleware/tenant.ts
@@ -1,0 +1,46 @@
+/**
+ * F540: fx-shaping Tenant 가드 미들웨어
+ * packages/api/src/middleware/tenant.ts 기반 — shaping 도메인 전용
+ */
+import type { Context, Next } from "hono";
+import type { ShapingEnv } from "../env.js";
+
+export interface TenantVariables {
+  orgId: string;
+  orgRole: string;
+  userId: string;
+}
+
+export async function tenantGuard(
+  c: Context<{ Bindings: ShapingEnv; Variables: TenantVariables }>,
+  next: Next,
+) {
+  const payload = c.get("jwtPayload") as
+    | { sub?: string; orgId?: string; orgRole?: string }
+    | undefined;
+
+  if (!payload?.orgId) {
+    return c.json({ error: "Organization context required" }, 403);
+  }
+
+  let orgRole = payload.orgRole ?? "member";
+
+  const db = c.env?.DB;
+  if (db && payload.sub) {
+    const member = await db
+      .prepare("SELECT role FROM org_members WHERE org_id = ? AND user_id = ?")
+      .bind(payload.orgId, payload.sub)
+      .first();
+
+    if (!member) {
+      return c.json({ error: "Not a member of this organization" }, 403);
+    }
+    orgRole = (member as { role: string }).role;
+  }
+
+  c.set("orgId", payload.orgId);
+  c.set("orgRole", orgRole);
+  c.set("userId", payload.sub ?? "");
+
+  return next();
+}

--- a/packages/fx-shaping/src/routes/ax-bd-agent.ts
+++ b/packages/fx-shaping/src/routes/ax-bd-agent.ts
@@ -1,0 +1,64 @@
+/**
+ * F199: BMCAgent 라우트 — BMC 초안 자동 생성 엔드포인트
+ */
+import { Hono } from "hono";
+import type { ShapingEnv } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import { GenerateBmcDraftSchema } from "../schemas/bmc-agent.schema.js";
+import { BmcAgentService } from "../services/bmc-agent.js";
+
+export const axBdAgentRoute = new Hono<{
+  Bindings: ShapingEnv;
+  Variables: TenantVariables;
+}>();
+
+// POST /ax-bd/bmc/generate — BMC 초안 자동 생성
+axBdAgentRoute.post("/ax-bd/bmc/generate", async (c) => {
+  // 1. Zod validation
+  const body = await c.req.json();
+  const parsed = GenerateBmcDraftSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  // 2. Rate Limit: KV 기반 사용자당 분당 5회
+  const userId = c.get("userId");
+  const kvKey = `bmc-gen:${userId}`;
+
+  if (c.env.CACHE) {
+    const existing = await c.env.CACHE.get(kvKey);
+    const count = existing ? parseInt(existing, 10) : 0;
+    if (count >= 5) {
+      return c.json({ error: "Rate limit exceeded. Max 5 requests per minute." }, 429);
+    }
+    await c.env.CACHE.put(kvKey, String(count + 1), { expirationTtl: 60 });
+  }
+
+  // 3. Generate BMC draft
+  const apiKey = c.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    return c.json({ error: "ANTHROPIC_API_KEY not configured" }, 500);
+  }
+
+  try {
+    const service = new BmcAgentService(c.env.DB, apiKey);
+    const result = await service.generateDraft(
+      parsed.data.idea,
+      parsed.data.context,
+      c.get("orgId"),
+    );
+    return c.json(result, 200);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    if (message === "LLM_TIMEOUT") {
+      return c.json({ error: "LLM request timed out" }, 504);
+    }
+    if (message === "LLM_PARSE_ERROR") {
+      return c.json({ error: "Failed to parse LLM response" }, 502);
+    }
+    if (message === "GATEWAY_NOT_PROCESSED") {
+      return c.json({ error: "Prompt gateway processing failed" }, 502);
+    }
+    return c.json({ error: message }, 500);
+  }
+});

--- a/packages/fx-shaping/src/routes/ax-bd-bmc.ts
+++ b/packages/fx-shaping/src/routes/ax-bd-bmc.ts
@@ -1,0 +1,74 @@
+import { Hono } from "hono";
+import type { ShapingEnv } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import { BmcService } from "../services/bmc-service.js";
+import {
+  CreateBmcSchema,
+  UpdateBmcBlocksSchema,
+} from "../schemas/bmc.schema.js";
+
+export const axBdBmcRoute = new Hono<{
+  Bindings: ShapingEnv;
+  Variables: TenantVariables;
+}>();
+
+// POST /ax-bd/bmc — BMC 생성
+axBdBmcRoute.post("/ax-bd/bmc", async (c) => {
+  const body = await c.req.json();
+  const parsed = CreateBmcSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+  const svc = new BmcService(c.env.DB);
+  const bmc = await svc.create(c.get("orgId"), c.get("userId"), parsed.data);
+  return c.json(bmc, 201);
+});
+
+// GET /ax-bd/bmc — BMC 목록
+axBdBmcRoute.get("/ax-bd/bmc", async (c) => {
+  const svc = new BmcService(c.env.DB);
+  const { page, limit, sort } = c.req.query();
+  const result = await svc.list(c.get("orgId"), {
+    page: Number(page) || 1,
+    limit: Number(limit) || 20,
+    sort: sort || "updated_at_desc",
+  });
+  return c.json(result);
+});
+
+// GET /ax-bd/bmc/:id — BMC 상세 (블록 포함)
+axBdBmcRoute.get("/ax-bd/bmc/:id", async (c) => {
+  const svc = new BmcService(c.env.DB);
+  const bmc = await svc.getById(c.get("orgId"), c.req.param("id"));
+  if (!bmc) return c.json({ error: "BMC not found" }, 404);
+  return c.json(bmc);
+});
+
+// PUT /ax-bd/bmc/:id — BMC 블록 업데이트
+axBdBmcRoute.put("/ax-bd/bmc/:id", async (c) => {
+  const body = await c.req.json();
+  const parsed = UpdateBmcBlocksSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+  const svc = new BmcService(c.env.DB);
+  const bmc = await svc.update(c.get("orgId"), c.req.param("id"), c.get("userId"), parsed.data);
+  if (!bmc) return c.json({ error: "BMC not found" }, 404);
+  return c.json(bmc);
+});
+
+// DELETE /ax-bd/bmc/:id — BMC 삭제 (soft delete)
+axBdBmcRoute.delete("/ax-bd/bmc/:id", async (c) => {
+  const svc = new BmcService(c.env.DB);
+  const ok = await svc.softDelete(c.get("orgId"), c.req.param("id"));
+  if (!ok) return c.json({ error: "BMC not found" }, 404);
+  return c.json({ success: true });
+});
+
+// POST /ax-bd/bmc/:id/stage — Git staging 상태 전환
+axBdBmcRoute.post("/ax-bd/bmc/:id/stage", async (c) => {
+  const svc = new BmcService(c.env.DB);
+  const result = await svc.stage(c.get("orgId"), c.req.param("id"), c.get("userId"));
+  if (!result) return c.json({ error: "BMC not found" }, 404);
+  return c.json(result);
+});

--- a/packages/fx-shaping/src/routes/ax-bd-comments.ts
+++ b/packages/fx-shaping/src/routes/ax-bd-comments.ts
@@ -1,0 +1,72 @@
+import { Hono } from "hono";
+import type { ShapingEnv } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import {
+  BmcCommentService,
+  NotFoundError,
+  ForbiddenError,
+  ValidationError,
+} from "../services/bmc-comment-service.js";
+import { CreateCommentSchema } from "../schemas/bmc-comment.schema.js";
+
+export const axBdCommentsRoute = new Hono<{
+  Bindings: ShapingEnv;
+  Variables: TenantVariables;
+}>();
+
+// POST /ax-bd/bmcs/:bmcId/comments — 댓글 작성
+axBdCommentsRoute.post("/ax-bd/bmcs/:bmcId/comments", async (c) => {
+  const body = await c.req.json();
+  const parsed = CreateCommentSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new BmcCommentService(c.env.DB);
+  try {
+    const comment = await svc.createComment(
+      c.req.param("bmcId"),
+      c.get("userId"),
+      parsed.data.content,
+      parsed.data.blockType
+    );
+    return c.json(comment, 201);
+  } catch (e) {
+    if (e instanceof NotFoundError) return c.json({ error: e.message }, 404);
+    if (e instanceof ValidationError) return c.json({ error: e.message }, 400);
+    throw e;
+  }
+});
+
+// GET /ax-bd/bmcs/:bmcId/comments — 댓글 목록
+axBdCommentsRoute.get("/ax-bd/bmcs/:bmcId/comments", async (c) => {
+  const { block, limit, offset } = c.req.query();
+  const svc = new BmcCommentService(c.env.DB);
+  const result = await svc.getComments(
+    c.req.param("bmcId"),
+    block || undefined,
+    Number(limit) || 20,
+    Number(offset) || 0
+  );
+  return c.json(result);
+});
+
+// GET /ax-bd/bmcs/:bmcId/comments/count — 블록별 댓글 수
+axBdCommentsRoute.get("/ax-bd/bmcs/:bmcId/comments/count", async (c) => {
+  const svc = new BmcCommentService(c.env.DB);
+  const counts = await svc.getCommentCounts(c.req.param("bmcId"));
+  return c.json(counts);
+});
+
+// DELETE /ax-bd/bmcs/:bmcId/comments/:commentId — 댓글 삭제
+axBdCommentsRoute.delete("/ax-bd/bmcs/:bmcId/comments/:commentId", async (c) => {
+  const svc = new BmcCommentService(c.env.DB);
+  try {
+    await svc.deleteComment(c.req.param("commentId"), c.get("userId"));
+    return c.json({ success: true });
+  } catch (e) {
+    if (e instanceof NotFoundError) return c.json({ error: e.message }, 404);
+    if (e instanceof ForbiddenError) return c.json({ error: e.message }, 403);
+    throw e;
+  }
+});

--- a/packages/fx-shaping/src/routes/ax-bd-history.ts
+++ b/packages/fx-shaping/src/routes/ax-bd-history.ts
@@ -1,0 +1,38 @@
+import { Hono } from "hono";
+import type { ShapingEnv } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import { BmcHistoryService } from "../services/bmc-history.js";
+
+export const axBdHistoryRoute = new Hono<{
+  Bindings: ShapingEnv;
+  Variables: TenantVariables;
+}>();
+
+// GET /ax-bd/bmc/:id/history — 버전 히스토리 목록
+axBdHistoryRoute.get("/ax-bd/bmc/:id/history", async (c) => {
+  const bmcId = c.req.param("id");
+  const limit = Number(c.req.query("limit")) || 20;
+  const svc = new BmcHistoryService(c.env.DB);
+  const versions = await svc.getHistory(bmcId, limit);
+  return c.json({ versions });
+});
+
+// GET /ax-bd/bmc/:id/history/:commitSha — 특정 버전 스냅샷
+axBdHistoryRoute.get("/ax-bd/bmc/:id/history/:commitSha", async (c) => {
+  const bmcId = c.req.param("id");
+  const commitSha = c.req.param("commitSha");
+  const svc = new BmcHistoryService(c.env.DB);
+  const snapshot = await svc.getVersion(bmcId, commitSha);
+  if (!snapshot) return c.json({ error: "Version not found" }, 404);
+  return c.json(snapshot);
+});
+
+// POST /ax-bd/bmc/:id/history/:commitSha/restore — 버전 복원
+axBdHistoryRoute.post("/ax-bd/bmc/:id/history/:commitSha/restore", async (c) => {
+  const bmcId = c.req.param("id");
+  const commitSha = c.req.param("commitSha");
+  const svc = new BmcHistoryService(c.env.DB);
+  const snapshot = await svc.restoreVersion(bmcId, commitSha);
+  if (!snapshot) return c.json({ error: "Version not found" }, 404);
+  return c.json({ restored: snapshot });
+});

--- a/packages/fx-shaping/src/routes/ax-bd-links.ts
+++ b/packages/fx-shaping/src/routes/ax-bd-links.ts
@@ -1,0 +1,105 @@
+import { Hono } from "hono";
+import type { ShapingEnv } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import {
+  IdeaBmcLinkService,
+  NotFoundError,
+  ConflictError,
+} from "../services/idea-bmc-link-service.js";
+import {
+  LinkBmcSchema,
+  CreateBmcFromIdeaSchema,
+} from "../schemas/idea-bmc-link.schema.js";
+
+export const axBdLinksRoute = new Hono<{
+  Bindings: ShapingEnv;
+  Variables: TenantVariables;
+}>();
+
+// POST /ax-bd/ideas/:ideaId/bmc — 아이디어에서 새 BMC 생성 + 자동 링크
+axBdLinksRoute.post("/ax-bd/ideas/:ideaId/bmc", async (c) => {
+  const body = await c.req.json().catch(() => ({}));
+  const parsed = CreateBmcFromIdeaSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new IdeaBmcLinkService(c.env.DB);
+  try {
+    const result = await svc.createBmcFromIdea(
+      c.req.param("ideaId"),
+      c.get("orgId"),
+      c.get("userId"),
+      parsed.data.title
+    );
+    return c.json(result, 201);
+  } catch (e) {
+    if (e instanceof NotFoundError) return c.json({ error: e.message }, 404);
+    throw e;
+  }
+});
+
+// POST /ax-bd/ideas/:ideaId/bmc/link — 기존 BMC 연결
+axBdLinksRoute.post("/ax-bd/ideas/:ideaId/bmc/link", async (c) => {
+  const body = await c.req.json();
+  const parsed = LinkBmcSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new IdeaBmcLinkService(c.env.DB);
+  try {
+    const result = await svc.linkBmc(
+      c.req.param("ideaId"),
+      parsed.data.bmcId,
+      c.get("orgId")
+    );
+    return c.json(result, 201);
+  } catch (e) {
+    if (e instanceof NotFoundError) return c.json({ error: e.message }, 404);
+    if (e instanceof ConflictError) return c.json({ error: e.message }, 409);
+    throw e;
+  }
+});
+
+// DELETE /ax-bd/ideas/:ideaId/bmc/link — 연결 해제
+axBdLinksRoute.delete("/ax-bd/ideas/:ideaId/bmc/link", async (c) => {
+  const body = await c.req.json();
+  const parsed = LinkBmcSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new IdeaBmcLinkService(c.env.DB);
+  try {
+    await svc.unlinkBmc(c.req.param("ideaId"), parsed.data.bmcId, c.get("orgId"));
+    return c.json({ success: true });
+  } catch (e) {
+    if (e instanceof NotFoundError) return c.json({ error: e.message }, 404);
+    throw e;
+  }
+});
+
+// GET /ax-bd/ideas/:ideaId/bmcs — 아이디어에 연결된 BMC 목록
+axBdLinksRoute.get("/ax-bd/ideas/:ideaId/bmcs", async (c) => {
+  const svc = new IdeaBmcLinkService(c.env.DB);
+  try {
+    const bmcs = await svc.getBmcsByIdea(c.req.param("ideaId"), c.get("orgId"));
+    return c.json({ items: bmcs });
+  } catch (e) {
+    if (e instanceof NotFoundError) return c.json({ error: e.message }, 404);
+    throw e;
+  }
+});
+
+// GET /ax-bd/bmcs/:bmcId/idea — BMC에 연결된 아이디어 조회
+axBdLinksRoute.get("/ax-bd/bmcs/:bmcId/idea", async (c) => {
+  const svc = new IdeaBmcLinkService(c.env.DB);
+  try {
+    const idea = await svc.getIdeaByBmc(c.req.param("bmcId"), c.get("orgId"));
+    return c.json({ idea });
+  } catch (e) {
+    if (e instanceof NotFoundError) return c.json({ error: e.message }, 404);
+    throw e;
+  }
+});

--- a/packages/fx-shaping/src/routes/ax-bd-persona-eval.ts
+++ b/packages/fx-shaping/src/routes/ax-bd-persona-eval.ts
@@ -1,0 +1,154 @@
+/**
+ * Sprint 155 F344+F345: 멀티 페르소나 평가 API 라우트
+ * - POST /ax-bd/persona-eval — SSE 스트리밍 평가 (rate limit: IP 기반 1분 5회)
+ * - GET /ax-bd/persona-configs/:itemId — 설정 조회
+ * - PUT /ax-bd/persona-configs/:itemId — 설정 저장
+ * - GET /ax-bd/persona-evals/:itemId — 결과 조회
+ */
+import { Hono } from "hono";
+import type { ShapingEnv } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import { StartEvalSchema } from "../schemas/persona-eval.js";
+import { UpsertPersonaConfigsSchema } from "../schemas/persona-config.js";
+import { PersonaConfigService } from "../services/persona-config-service.js";
+import { PersonaEvalService } from "../services/persona-eval-service.js";
+
+/** IP 기반 Rate Limiter — KV 슬라이딩 윈도우 (1분 5회) */
+async function checkRateLimit(
+  kv: KVNamespace,
+  ip: string,
+  limit = 5,
+  windowSec = 60,
+): Promise<{ allowed: boolean; remaining: number; resetAt: number }> {
+  const key = `rl:persona-eval:${ip}`;
+  const now = Math.floor(Date.now() / 1000);
+  const windowStart = now - windowSec;
+
+  const raw = await kv.get(key);
+  const timestamps: number[] = raw ? (JSON.parse(raw) as number[]) : [];
+
+  // 윈도우 밖 타임스탬프 제거
+  const valid = timestamps.filter((t) => t > windowStart);
+  const remaining = Math.max(0, limit - valid.length);
+  const allowed = valid.length < limit;
+
+  if (allowed) {
+    valid.push(now);
+    await kv.put(key, JSON.stringify(valid), { expirationTtl: windowSec + 5 });
+  }
+
+  const oldest = valid[0];
+  const resetAt = oldest !== undefined ? oldest + windowSec : now + windowSec;
+  return { allowed, remaining, resetAt };
+}
+
+export const axBdPersonaEvalRoute = new Hono<{
+  Bindings: ShapingEnv;
+  Variables: TenantVariables;
+}>();
+
+// POST /ax-bd/persona-eval — SSE 스트리밍 평가
+axBdPersonaEvalRoute.post("/ax-bd/persona-eval", async (c) => {
+  // Rate Limit 체크 (IP 기반 1분 5회)
+  const ip =
+    c.req.header("cf-connecting-ip") ??
+    c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ??
+    "unknown";
+
+  const { allowed, remaining, resetAt } = await checkRateLimit(c.env.CACHE, ip);
+
+  if (!allowed) {
+    return c.json(
+      {
+        error: "Too Many Requests",
+        message: "페르소나 평가는 1분당 최대 5회까지 실행할 수 있어요.",
+        resetAt,
+      },
+      429,
+    );
+  }
+
+  const body = await c.req.json();
+  const parsed = StartEvalSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const orgId = c.get("orgId");
+  const { itemId, configs, briefing, demoMode } = parsed.data;
+
+  // 데모 모드가 아닌데 API 키가 없으면 에러
+  if (!demoMode && !c.env.ANTHROPIC_API_KEY) {
+    return c.json({ error: "ANTHROPIC_API_KEY not configured. Use demoMode: true for demo." }, 500);
+  }
+
+  const service = new PersonaEvalService(c.env.DB, c.env.ANTHROPIC_API_KEY);
+  const stream = service.createEvalStream(itemId, orgId, configs, briefing, demoMode);
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      "Connection": "keep-alive",
+      "X-RateLimit-Limit": "5",
+      "X-RateLimit-Remaining": String(remaining),
+      "X-RateLimit-Reset": String(resetAt),
+    },
+  });
+});
+
+// GET /ax-bd/persona-configs/:itemId — 설정 조회
+axBdPersonaEvalRoute.get("/ax-bd/persona-configs/:itemId", async (c) => {
+  const itemId = c.req.param("itemId");
+  const orgId = c.get("orgId");
+  const service = new PersonaConfigService(c.env.DB);
+  const configs = await service.getByItemId(itemId, orgId);
+
+  return c.json({
+    items: configs.map((r) => ({
+      id: r.id,
+      itemId: r.item_id,
+      personaId: r.persona_id,
+      weights: JSON.parse(r.weights),
+      context: JSON.parse(r.context_json),
+      createdAt: r.created_at,
+      updatedAt: r.updated_at,
+    })),
+  });
+});
+
+// PUT /ax-bd/persona-configs/:itemId — 설정 저장
+axBdPersonaEvalRoute.put("/ax-bd/persona-configs/:itemId", async (c) => {
+  const itemId = c.req.param("itemId");
+  const orgId = c.get("orgId");
+  const body = await c.req.json();
+  const parsed = UpsertPersonaConfigsSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const service = new PersonaConfigService(c.env.DB);
+  await service.upsertConfigs(itemId, orgId, parsed.data.configs);
+  return c.json({ success: true });
+});
+
+// GET /ax-bd/persona-evals/:itemId — 이전 평가 결과 조회
+axBdPersonaEvalRoute.get("/ax-bd/persona-evals/:itemId", async (c) => {
+  const itemId = c.req.param("itemId");
+  const orgId = c.get("orgId");
+  const service = new PersonaEvalService(c.env.DB, c.env.ANTHROPIC_API_KEY);
+  const evals = await service.getByItemId(itemId, orgId);
+
+  return c.json({
+    items: evals.map((r) => ({
+      id: r.id,
+      itemId: r.item_id,
+      personaId: r.persona_id,
+      scores: JSON.parse(r.scores),
+      verdict: r.verdict,
+      summary: r.summary,
+      concerns: r.concerns ? JSON.parse(r.concerns) : [],
+      createdAt: r.created_at,
+    })),
+  });
+});

--- a/packages/fx-shaping/src/routes/ax-bd-progress.ts
+++ b/packages/fx-shaping/src/routes/ax-bd-progress.ts
@@ -1,0 +1,47 @@
+/**
+ * F262: BD 프로세스 진행 추적 라우트
+ */
+import { Hono } from "hono";
+import type { ShapingEnv } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import { BdProcessTracker } from "../services/bd-process-tracker.js";
+import { progressQuerySchema } from "../schemas/bd-progress.schema.js";
+
+export const axBdProgressRoute = new Hono<{
+  Bindings: ShapingEnv;
+  Variables: TenantVariables;
+}>();
+
+// ─── GET /ax-bd/progress/summary — 포트폴리오 요약만 ───
+
+axBdProgressRoute.get("/ax-bd/progress/summary", async (c) => {
+  const tracker = new BdProcessTracker(c.env.DB);
+  const summary = await tracker.getPortfolioSummary(c.get("orgId"));
+  return c.json(summary);
+});
+
+// ─── GET /ax-bd/progress/:bizItemId — 단일 아이템 진행 상태 ───
+
+axBdProgressRoute.get("/ax-bd/progress/:bizItemId", async (c) => {
+  const tracker = new BdProcessTracker(c.env.DB);
+  const progress = await tracker.getItemProgress(c.req.param("bizItemId"), c.get("orgId"));
+
+  if (!progress) {
+    return c.json({ error: "Item not found in pipeline" }, 404);
+  }
+
+  return c.json(progress);
+});
+
+// ─── GET /ax-bd/progress — 포트폴리오 진행 목록 ───
+
+axBdProgressRoute.get("/ax-bd/progress", async (c) => {
+  const parsed = progressQuerySchema.safeParse(c.req.query());
+  if (!parsed.success) {
+    return c.json({ error: "Invalid query", details: parsed.error.flatten() }, 400);
+  }
+
+  const tracker = new BdProcessTracker(c.env.DB);
+  const result = await tracker.getPortfolioProgress(c.get("orgId"), parsed.data);
+  return c.json(result);
+});

--- a/packages/fx-shaping/src/routes/ax-bd-prototypes.ts
+++ b/packages/fx-shaping/src/routes/ax-bd-prototypes.ts
@@ -1,0 +1,230 @@
+/**
+ * Sprint 67: F209 — Prototype + PoC 환경 + 기술 검증 라우트
+ * 8 endpoints: list, getById, delete, pocEnv (provision/get/teardown), techReview (analyze/get)
+ */
+import { Hono } from "hono";
+import type { ShapingEnv } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import { PrototypeService } from "../harness/services/prototype-service.js";
+import { PocEnvService } from "../launch/services/poc-env-service.js";
+import { TechReviewService } from "../harness/services/tech-review-service.js";
+import { PocEnvProvisionSchema } from "../harness/schemas/prototype-ext.js";
+import { PrototypeReviewService } from "../harness/services/prototype-review-service.js";
+import { sectionReviewSchema } from "../schemas/hitl-section.schema.js";
+import { PrototypeJobService } from "../harness/services/prototype-job-service.js";
+import { PrototypeBuildSchema } from "../harness/schemas/prototype-build.js";
+
+export const axBdPrototypesRoute = new Hono<{
+  Bindings: ShapingEnv;
+  Variables: TenantVariables;
+}>();
+
+// GET /ax-bd/prototypes — 목록
+axBdPrototypesRoute.get("/ax-bd/prototypes", async (c) => {
+  const svc = new PrototypeService(c.env.DB);
+  const { bizItemId, limit, offset } = c.req.query();
+  const result = await svc.list(c.get("orgId"), {
+    bizItemId: bizItemId || undefined,
+    limit: Number(limit) || 20,
+    offset: Number(offset) || 0,
+  });
+  return c.json(result);
+});
+
+// GET /ax-bd/prototypes/:id — 상세 (PoC + TechReview 포함)
+axBdPrototypesRoute.get("/ax-bd/prototypes/:id", async (c) => {
+  const svc = new PrototypeService(c.env.DB);
+  const proto = await svc.getById(c.req.param("id"), c.get("orgId"));
+  if (!proto) return c.json({ error: "Prototype not found" }, 404);
+  return c.json(proto);
+});
+
+// DELETE /ax-bd/prototypes/:id — 삭제 (CASCADE)
+axBdPrototypesRoute.delete("/ax-bd/prototypes/:id", async (c) => {
+  const svc = new PrototypeService(c.env.DB);
+  const ok = await svc.delete(c.req.param("id"), c.get("orgId"));
+  if (!ok) return c.json({ error: "Prototype not found" }, 404);
+  return c.json({ success: true });
+});
+
+// POST /ax-bd/prototypes/:id/poc-env — PoC 환경 프로비저닝
+axBdPrototypesRoute.post("/ax-bd/prototypes/:id/poc-env", async (c) => {
+  const body = await c.req.json();
+  const parsed = PocEnvProvisionSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new PocEnvService(c.env.DB);
+  try {
+    const env = await svc.provision(c.req.param("id"), c.get("orgId"), parsed.data.config);
+    return c.json(env, 201);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Unknown error";
+    if (msg === "Prototype not found") return c.json({ error: msg }, 404);
+    if (msg === "Active PoC environment already exists") return c.json({ error: msg }, 409);
+    throw e;
+  }
+});
+
+// GET /ax-bd/prototypes/:id/poc-env — PoC 환경 조회
+axBdPrototypesRoute.get("/ax-bd/prototypes/:id/poc-env", async (c) => {
+  const svc = new PocEnvService(c.env.DB);
+  const env = await svc.getByPrototype(c.req.param("id"), c.get("orgId"));
+  if (!env) return c.json({ error: "PoC environment not found" }, 404);
+  return c.json(env);
+});
+
+// DELETE /ax-bd/prototypes/:id/poc-env — PoC 환경 teardown
+axBdPrototypesRoute.delete("/ax-bd/prototypes/:id/poc-env", async (c) => {
+  const svc = new PocEnvService(c.env.DB);
+  try {
+    await svc.teardown(c.req.param("id"), c.get("orgId"));
+    return c.json({ success: true });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Unknown error";
+    if (msg === "PoC environment not found") return c.json({ error: msg }, 404);
+    if (msg === "Environment already terminated") return c.json({ error: msg }, 409);
+    throw e;
+  }
+});
+
+// POST /ax-bd/prototypes/:id/tech-review — 기술 검증 분석 요청
+axBdPrototypesRoute.post("/ax-bd/prototypes/:id/tech-review", async (c) => {
+  const svc = new TechReviewService(c.env.DB);
+  try {
+    const review = await svc.analyze(c.req.param("id"), c.get("orgId"));
+    return c.json(review, 201);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Unknown error";
+    if (msg === "Prototype not found") return c.json({ error: msg }, 404);
+    throw e;
+  }
+});
+
+// GET /ax-bd/prototypes/:id/tech-review — 기술 검증 결과 조회
+axBdPrototypesRoute.get("/ax-bd/prototypes/:id/tech-review", async (c) => {
+  const svc = new TechReviewService(c.env.DB);
+  const review = await svc.getByPrototype(c.req.param("id"), c.get("orgId"));
+  if (!review) return c.json({ error: "Tech review not found" }, 404);
+  return c.json(review);
+});
+
+// POST /ax-bd/prototypes/:id/sections/:sectionId/review — 섹션 리뷰 제출 (F297)
+axBdPrototypesRoute.post("/ax-bd/prototypes/:id/sections/:sectionId/review", async (c) => {
+  const orgId = c.get("orgId");
+  const prototypeId = c.req.param("id");
+  const sectionId = c.req.param("sectionId");
+  const userId = (c.get("jwtPayload") as Record<string, string> | undefined)?.sub ?? (c.get("userId") as string) ?? "";
+
+  const body = await c.req.json();
+  const parsed = sectionReviewSchema.safeParse({ ...body, sectionId });
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new PrototypeReviewService(c.env.DB);
+  const review = await svc.reviewSection(orgId, prototypeId, parsed.data, userId, body.framework);
+  return c.json(review, 201);
+});
+
+// GET /ax-bd/prototypes/:id/reviews — 리뷰 목록 (F297)
+axBdPrototypesRoute.get("/ax-bd/prototypes/:id/reviews", async (c) => {
+  const orgId = c.get("orgId");
+  const prototypeId = c.req.param("id");
+
+  const svc = new PrototypeReviewService(c.env.DB);
+  const reviews = await svc.listReviews(orgId, prototypeId);
+  return c.json(reviews);
+});
+
+// GET /ax-bd/prototypes/:id/review-summary — 상태 요약 (F297)
+axBdPrototypesRoute.get("/ax-bd/prototypes/:id/review-summary", async (c) => {
+  const orgId = c.get("orgId");
+  const prototypeId = c.req.param("id");
+
+  const svc = new PrototypeReviewService(c.env.DB);
+  const summary = await svc.getSummary(orgId, prototypeId);
+  return c.json(summary);
+});
+
+// POST /ax-bd/prototypes/build — Prototype Builder 실행 (F457, Sprint 222)
+axBdPrototypesRoute.post("/ax-bd/prototypes/build", async (c) => {
+  const body = await c.req.json();
+  const parsed = PrototypeBuildSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new PrototypeJobService(c.env.DB);
+  const job = await svc.create(
+    c.get("orgId"),
+    parsed.data.prdContent,
+    parsed.data.prdTitle,
+  );
+  return c.json(job, 201);
+});
+
+// POST /ax-bd/prototypes/:id/link-offering — Offering 연결 (F458, Sprint 222)
+axBdPrototypesRoute.post("/ax-bd/prototypes/:id/link-offering", async (c) => {
+  const body = await c.req.json() as { offeringId?: string };
+  if (!body?.offeringId) {
+    return c.json({ error: "offeringId required" }, 400);
+  }
+
+  const prototypeId = c.req.param("id");
+  const id = crypto.randomUUID();
+  await c.env.DB.prepare(
+    `INSERT INTO offering_prototypes (id, offering_id, prototype_id)
+     VALUES (?, ?, ?)`
+  ).bind(id, body.offeringId, prototypeId).run();
+
+  return c.json({ id, offeringId: body.offeringId, prototypeId }, 201);
+});
+
+// GET /ax-bd/prototypes/:id/html — HTML 콘텐츠 직접 서빙 (프레젠테이션용)
+// content가 [R2:key] 참조이면 R2에서 실제 HTML을 가져옴
+// 모든 응답에 Marker.io 피드백 위젯 snippet을 </body> 직전에 주입 (MARKER_PROJECT_ID 설정 시)
+axBdPrototypesRoute.get("/ax-bd/prototypes/:id/html", async (c) => {
+  const svc = new PrototypeService(c.env.DB);
+  const proto = await svc.getById(c.req.param("id"), c.get("orgId"));
+  if (!proto) return c.json({ error: "Prototype not found" }, 404);
+
+  // 1) HTML 본문을 먼저 문자열로 확보
+  let html: string;
+  const r2Match = proto.content.match(/^\[R2:([^\]]+)\]/);
+  if (r2Match) {
+    const r2Key = r2Match[1]!;
+    const obj = await c.env.FILES_BUCKET.get(r2Key);
+    if (!obj) {
+      return c.json({ error: "R2에서 프로토타입 HTML을 찾을 수 없어요", r2Key }, 404);
+    }
+    html = await obj.text();
+  } else {
+    html = proto.content;
+  }
+
+  // 2) Marker.io 피드백 위젯 주입 (프로젝트 ID가 env에 설정되어 있을 때만)
+  const markerProjectId = c.env.MARKER_PROJECT_ID;
+  if (markerProjectId) {
+    const markerSnippet = `
+<script>
+  window.markerConfig = { project: ${JSON.stringify(markerProjectId)}, source: "prototype" };
+</script>
+<script src="https://edge.marker.io/latest/shim.js" async></script>
+`;
+    if (html.includes("</body>")) {
+      html = html.replace("</body>", `${markerSnippet}</body>`);
+    } else {
+      html = `${html}\n${markerSnippet}`;
+    }
+  }
+
+  return new Response(html, {
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      // 위젯 주입 캐시 오염 방지 — 항상 fresh 렌더
+      "Cache-Control": "no-store",
+    },
+  });
+});

--- a/packages/fx-shaping/src/routes/ax-bd-skills.ts
+++ b/packages/fx-shaping/src/routes/ax-bd-skills.ts
@@ -1,0 +1,54 @@
+import { Hono } from "hono";
+import type { ShapingEnv } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import { z } from "zod";
+import { BdSkillExecutor } from "../services/bd-skill-executor.js";
+import { getSupportedSkillIds } from "../services/bd-skill-prompts.js";
+
+// F538: executeSkillSchema — shaping 도메인 전용 (discovery 도메인 cross-import 제거)
+const executeSkillSchema = z.object({
+  bizItemId: z.string().min(1),
+  stageId: z.string().regex(/^2-(?:10|[0-9])$/, "stageId must be 2-0 ~ 2-10"),
+  inputText: z.string().min(1).max(10000),
+});
+
+export const axBdSkillsRoute = new Hono<{
+  Bindings: ShapingEnv;
+  Variables: TenantVariables;
+}>();
+
+// GET /ax-bd/skills — 서버 측 지원 스킬 목록
+axBdSkillsRoute.get("/ax-bd/skills", (c) => {
+  const skillIds = getSupportedSkillIds();
+  return c.json({ skills: skillIds, total: skillIds.length });
+});
+
+// POST /ax-bd/skills/:skillId/execute — 스킬 실행
+axBdSkillsRoute.post("/ax-bd/skills/:skillId/execute", async (c) => {
+  const skillId = c.req.param("skillId");
+  const apiKey = c.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    return c.json({ error: "ANTHROPIC_API_KEY not configured" }, 503);
+  }
+
+  const body = await c.req.json();
+  const parsed = executeSkillSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const executor = new BdSkillExecutor(c.env.DB, apiKey);
+  try {
+    const result = await executor.execute(
+      c.get("orgId"),
+      c.get("userId"),
+      skillId,
+      parsed.data,
+    );
+    const statusCode = result.status === "completed" ? 200 : 500;
+    return c.json(result, statusCode);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Execution failed";
+    return c.json({ error: message }, 400);
+  }
+});

--- a/packages/fx-shaping/src/routes/ax-bd-viability.ts
+++ b/packages/fx-shaping/src/routes/ax-bd-viability.ts
@@ -1,0 +1,98 @@
+/**
+ * Sprint 69: 사업성 체크포인트 + Commit Gate 라우트 (F213)
+ */
+import { Hono } from "hono";
+import type { ShapingEnv } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import { ViabilityCheckpointService } from "../services/viability-checkpoint-service.js";
+import { CommitGateService } from "../services/commit-gate-service.js";
+import { CreateCheckpointSchema, UpdateCheckpointSchema } from "../schemas/viability-checkpoint.schema.js";
+import { CreateCommitGateSchema } from "../schemas/commit-gate.schema.js";
+
+export const axBdViabilityRoute = new Hono<{
+  Bindings: ShapingEnv;
+  Variables: TenantVariables;
+}>();
+
+// ─── POST /ax-bd/viability/checkpoints — 체크포인트 기록 ───
+
+axBdViabilityRoute.post("/ax-bd/viability/checkpoints", async (c) => {
+  const body = await c.req.json();
+  const parsed = CreateCheckpointSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new ViabilityCheckpointService(c.env.DB);
+  const checkpoint = await svc.create(c.get("orgId"), c.get("userId"), parsed.data);
+  return c.json(checkpoint, 201);
+});
+
+// ─── GET /ax-bd/viability/checkpoints/:bizItemId — 아이템별 전체 조회 ───
+
+axBdViabilityRoute.get("/ax-bd/viability/checkpoints/:bizItemId", async (c) => {
+  const svc = new ViabilityCheckpointService(c.env.DB);
+  const checkpoints = await svc.listByItem(c.req.param("bizItemId"));
+  return c.json({ checkpoints });
+});
+
+// ─── PUT /ax-bd/viability/checkpoints/:bizItemId/:stage — 수정 ───
+
+axBdViabilityRoute.put("/ax-bd/viability/checkpoints/:bizItemId/:stage", async (c) => {
+  const body = await c.req.json();
+  const parsed = UpdateCheckpointSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new ViabilityCheckpointService(c.env.DB);
+  const checkpoint = await svc.update(c.req.param("bizItemId"), c.req.param("stage"), parsed.data);
+  if (!checkpoint) {
+    return c.json({ error: "Checkpoint not found" }, 404);
+  }
+  return c.json(checkpoint);
+});
+
+// ─── DELETE /ax-bd/viability/checkpoints/:bizItemId/:stage — 삭제 ───
+
+axBdViabilityRoute.delete("/ax-bd/viability/checkpoints/:bizItemId/:stage", async (c) => {
+  const svc = new ViabilityCheckpointService(c.env.DB);
+  const ok = await svc.delete(c.req.param("bizItemId"), c.req.param("stage"));
+  if (!ok) {
+    return c.json({ error: "Checkpoint not found" }, 404);
+  }
+  return c.json({ success: true });
+});
+
+// ─── GET /ax-bd/viability/traffic-light/:bizItemId — 누적 신호등 ───
+
+axBdViabilityRoute.get("/ax-bd/viability/traffic-light/:bizItemId", async (c) => {
+  const svc = new ViabilityCheckpointService(c.env.DB);
+  const trafficLight = await svc.getTrafficLight(c.req.param("bizItemId"));
+  return c.json(trafficLight);
+});
+
+// ─── POST /ax-bd/viability/commit-gate — Commit Gate 기록 ───
+
+axBdViabilityRoute.post("/ax-bd/viability/commit-gate", async (c) => {
+  const body = await c.req.json();
+  const parsed = CreateCommitGateSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new CommitGateService(c.env.DB);
+  const gate = await svc.create(c.get("orgId"), c.get("userId"), parsed.data);
+  return c.json(gate, 201);
+});
+
+// ─── GET /ax-bd/viability/commit-gate/:bizItemId — Commit Gate 조회 ───
+
+axBdViabilityRoute.get("/ax-bd/viability/commit-gate/:bizItemId", async (c) => {
+  const svc = new CommitGateService(c.env.DB);
+  const gate = await svc.getByItem(c.req.param("bizItemId"));
+  if (!gate) {
+    return c.json({ error: "Commit gate not found" }, 404);
+  }
+  return c.json(gate);
+});

--- a/packages/fx-shaping/src/routes/persona-configs.ts
+++ b/packages/fx-shaping/src/routes/persona-configs.ts
@@ -1,0 +1,58 @@
+/**
+ * Sprint 154: F342 PersonaConfigs Route — 페르소나 설정 CRUD
+ */
+import { Hono } from "hono";
+import type { ShapingEnv } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import { PersonaConfigService } from "../services/persona-config-service.js";
+import { UpsertPersonaConfigSchema, UpdateWeightsSchema } from "../schemas/persona-config-schema.js";
+
+export const personaConfigsRoute = new Hono<{
+  Bindings: ShapingEnv;
+  Variables: TenantVariables;
+}>();
+
+// GET /ax-bd/persona-configs/:itemId — 아이템별 페르소나 설정 조회
+personaConfigsRoute.get("/ax-bd/persona-configs/:itemId", async (c) => {
+  const svc = new PersonaConfigService(c.env.DB);
+  const configs = await svc.getByItem(c.req.param("itemId"));
+  return c.json({ data: configs });
+});
+
+// POST /ax-bd/persona-configs/:itemId/init — 기본 8인 시딩
+personaConfigsRoute.post("/ax-bd/persona-configs/:itemId/init", async (c) => {
+  const svc = new PersonaConfigService(c.env.DB);
+  const orgId = c.get("orgId");
+  const count = await svc.initDefaults(c.req.param("itemId"), orgId);
+  return c.json({ message: `${count} personas initialized`, count }, 201);
+});
+
+// PUT /ax-bd/persona-configs/:itemId/:personaId — 개별 설정 수정
+personaConfigsRoute.put("/ax-bd/persona-configs/:itemId/:personaId", async (c) => {
+  const body = await c.req.json();
+  const parsed = UpsertPersonaConfigSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new PersonaConfigService(c.env.DB);
+  const orgId = c.get("orgId");
+  const config = await svc.upsert(c.req.param("itemId"), orgId, {
+    ...parsed.data,
+    personaId: c.req.param("personaId"),
+  });
+  return c.json({ data: config });
+});
+
+// PATCH /ax-bd/persona-configs/:itemId/:personaId/weights — 가중치만 수정
+personaConfigsRoute.patch("/ax-bd/persona-configs/:itemId/:personaId/weights", async (c) => {
+  const body = await c.req.json();
+  const parsed = UpdateWeightsSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new PersonaConfigService(c.env.DB);
+  await svc.updateWeights(c.req.param("itemId"), c.req.param("personaId"), parsed.data.weights);
+  return c.json({ message: "Weights updated" });
+});

--- a/packages/fx-shaping/src/routes/persona-evals.ts
+++ b/packages/fx-shaping/src/routes/persona-evals.ts
@@ -1,0 +1,41 @@
+/**
+ * Sprint 154: F342 PersonaEvals Route — 페르소나 평가 결과 관리
+ */
+import { Hono } from "hono";
+import type { ShapingEnv } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import { PersonaEvalService } from "../services/persona-eval-service.js";
+import { SavePersonaEvalSchema } from "../schemas/persona-eval-schema.js";
+
+export const personaEvalsRoute = new Hono<{
+  Bindings: ShapingEnv;
+  Variables: TenantVariables;
+}>();
+
+// GET /ax-bd/persona-evals/:itemId — 아이템별 평가 결과 조회
+personaEvalsRoute.get("/ax-bd/persona-evals/:itemId", async (c) => {
+  const svc = new PersonaEvalService(c.env.DB);
+  const evals = await svc.getByItem(c.req.param("itemId"));
+  return c.json({ data: evals });
+});
+
+// POST /ax-bd/persona-evals/:itemId — 평가 결과 저장 (단건)
+personaEvalsRoute.post("/ax-bd/persona-evals/:itemId", async (c) => {
+  const body = await c.req.json();
+  const parsed = SavePersonaEvalSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid request", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new PersonaEvalService(c.env.DB);
+  const orgId = c.get("orgId");
+  const result = await svc.save(c.req.param("itemId"), orgId, parsed.data);
+  return c.json({ data: result }, 201);
+});
+
+// GET /ax-bd/persona-evals/:itemId/verdict — 종합 판정 조회
+personaEvalsRoute.get("/ax-bd/persona-evals/:itemId/verdict", async (c) => {
+  const svc = new PersonaEvalService(c.env.DB);
+  const verdict = await svc.getOverallVerdict(c.req.param("itemId"));
+  return c.json({ data: verdict });
+});

--- a/packages/fx-shaping/src/routes/shaping.ts
+++ b/packages/fx-shaping/src/routes/shaping.ts
@@ -1,0 +1,164 @@
+/**
+ * F286+F287: BD 형상화 Phase F — CRUD 10 EP + 승인 워크플로 3 EP = 13 EP
+ */
+
+import { Hono } from "hono";
+import type { ShapingEnv } from "../env.js";
+import type { TenantVariables } from "../middleware/tenant.js";
+import { ShapingService } from "../services/shaping-service.js";
+import { ShapingReviewService } from "../services/shaping-review-service.js";
+import {
+  createShapingRunSchema,
+  updateShapingRunSchema,
+  listShapingRunsQuerySchema,
+  createPhaseLogSchema,
+  createExpertReviewSchema,
+  createSixHatsSchema,
+  reviewSectionSchema,
+} from "../schemas/shaping.js";
+
+export const shapingRoute = new Hono<{
+  Bindings: ShapingEnv;
+  Variables: TenantVariables;
+}>();
+
+// ─── F287: CRUD 10 EP ───
+
+// 1) POST /shaping/runs — 형상화 실행 시작
+shapingRoute.post("/shaping/runs", async (c) => {
+  const body = await c.req.json();
+  const parsed = createShapingRunSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid input", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new ShapingService(c.env.DB);
+  const run = await svc.createRun(c.get("orgId"), parsed.data);
+  return c.json(run, 201);
+});
+
+// 2) GET /shaping/runs — 실행 이력 목록
+shapingRoute.get("/shaping/runs", async (c) => {
+  const parsed = listShapingRunsQuerySchema.safeParse(c.req.query());
+  if (!parsed.success) {
+    return c.json({ error: "Invalid query", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new ShapingService(c.env.DB);
+  const result = await svc.listRuns(c.get("orgId"), parsed.data);
+  return c.json(result);
+});
+
+// 3) GET /shaping/runs/:runId — 실행 상세 (조인)
+shapingRoute.get("/shaping/runs/:runId", async (c) => {
+  const svc = new ShapingService(c.env.DB);
+  const detail = await svc.getRunDetail(c.get("orgId"), c.req.param("runId"));
+  if (!detail) return c.json({ error: "Run not found" }, 404);
+  return c.json(detail);
+});
+
+// 4) PATCH /shaping/runs/:runId — 실행 상태 갱신
+shapingRoute.patch("/shaping/runs/:runId", async (c) => {
+  const body = await c.req.json();
+  const parsed = updateShapingRunSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid input", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new ShapingService(c.env.DB);
+  const updated = await svc.updateRun(c.get("orgId"), c.req.param("runId"), parsed.data);
+  if (!updated) return c.json({ error: "Run not found" }, 404);
+  return c.json(updated);
+});
+
+// 5) POST /shaping/runs/:runId/phase-logs — Phase 로그 추가
+shapingRoute.post("/shaping/runs/:runId/phase-logs", async (c) => {
+  const body = await c.req.json();
+  const parsed = createPhaseLogSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid input", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new ShapingService(c.env.DB);
+  const log = await svc.addPhaseLog(c.req.param("runId"), parsed.data);
+  return c.json(log, 201);
+});
+
+// 6) GET /shaping/runs/:runId/phase-logs — Phase 로그 목록
+shapingRoute.get("/shaping/runs/:runId/phase-logs", async (c) => {
+  const svc = new ShapingService(c.env.DB);
+  const logs = await svc.listPhaseLogs(c.req.param("runId"));
+  return c.json(logs);
+});
+
+// 7) POST /shaping/runs/:runId/expert-reviews — 전문가 리뷰 추가
+shapingRoute.post("/shaping/runs/:runId/expert-reviews", async (c) => {
+  const body = await c.req.json();
+  const parsed = createExpertReviewSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid input", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new ShapingService(c.env.DB);
+  const review = await svc.addExpertReview(c.req.param("runId"), parsed.data);
+  return c.json(review, 201);
+});
+
+// 8) GET /shaping/runs/:runId/expert-reviews — 전문가 리뷰 목록
+shapingRoute.get("/shaping/runs/:runId/expert-reviews", async (c) => {
+  const svc = new ShapingService(c.env.DB);
+  const reviews = await svc.listExpertReviews(c.req.param("runId"));
+  return c.json(reviews);
+});
+
+// 9) POST /shaping/runs/:runId/six-hats — Six Hats 의견 추가
+shapingRoute.post("/shaping/runs/:runId/six-hats", async (c) => {
+  const body = await c.req.json();
+  const parsed = createSixHatsSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid input", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new ShapingService(c.env.DB);
+  const hat = await svc.addSixHats(c.req.param("runId"), parsed.data);
+  return c.json(hat, 201);
+});
+
+// 10) GET /shaping/runs/:runId/six-hats — Six Hats 의견 목록
+shapingRoute.get("/shaping/runs/:runId/six-hats", async (c) => {
+  const svc = new ShapingService(c.env.DB);
+  const hats = await svc.listSixHats(c.req.param("runId"));
+  return c.json(hats);
+});
+
+// ─── F286: 승인 워크플로 3 EP ───
+
+// 11) POST /shaping/runs/:runId/review — HITL 섹션별 승인/수정요청/반려
+shapingRoute.post("/shaping/runs/:runId/review", async (c) => {
+  const body = await c.req.json();
+  const parsed = reviewSectionSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid input", details: parsed.error.flatten() }, 400);
+  }
+
+  const svc = new ShapingReviewService(c.env.DB);
+  const result = await svc.reviewSection(c.get("orgId"), c.req.param("runId"), parsed.data, c.get("userId"));
+  if (!result) return c.json({ error: "Run not found" }, 404);
+  return c.json(result);
+});
+
+// 12) POST /shaping/runs/:runId/auto-review — 자동 모드: AI 3 페르소나 리뷰
+shapingRoute.post("/shaping/runs/:runId/auto-review", async (c) => {
+  const svc = new ShapingReviewService(c.env.DB);
+  const result = await svc.autoReview(c.get("orgId"), c.req.param("runId"));
+  if (!result) return c.json({ error: "Run not found" }, 404);
+  return c.json(result);
+});
+
+// 13) GET /shaping/runs/:runId/diff — 2단계 PRD 대비 변경 diff
+shapingRoute.get("/shaping/runs/:runId/diff", async (c) => {
+  const svc = new ShapingReviewService(c.env.DB);
+  const diff = await svc.getDiff(c.get("orgId"), c.req.param("runId"));
+  if (!diff) return c.json({ error: "Run not found" }, 404);
+  return c.json(diff);
+});

--- a/packages/fx-shaping/src/schemas/bd-progress.schema.ts
+++ b/packages/fx-shaping/src/schemas/bd-progress.schema.ts
@@ -1,0 +1,13 @@
+/**
+ * F262: BD 프로세스 진행 추적 스키마
+ */
+import { z } from "zod";
+
+export const progressQuerySchema = z.object({
+  signal: z.enum(["green", "yellow", "red"]).optional(),
+  pipelineStage: z.string().optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+export type ProgressQuery = z.infer<typeof progressQuerySchema>;

--- a/packages/fx-shaping/src/schemas/bmc-agent.schema.ts
+++ b/packages/fx-shaping/src/schemas/bmc-agent.schema.ts
@@ -1,0 +1,13 @@
+import { z } from "@hono/zod-openapi";
+
+export const GenerateBmcDraftSchema = z.object({
+  idea: z.string().min(1).max(500),
+  context: z.string().max(1000).optional(),
+}).openapi("GenerateBmcDraft");
+
+export const BmcDraftResultSchema = z.object({
+  draft: z.record(z.string(), z.string()),
+  processingTimeMs: z.number(),
+  model: z.string(),
+  masked: z.boolean(),
+}).openapi("BmcDraftResult");

--- a/packages/fx-shaping/src/schemas/bmc-comment.schema.ts
+++ b/packages/fx-shaping/src/schemas/bmc-comment.schema.ts
@@ -1,0 +1,7 @@
+import { z } from "@hono/zod-openapi";
+import { BmcBlockTypeSchema } from "./bmc.schema.js";
+
+export const CreateCommentSchema = z.object({
+  content: z.string().min(1).max(2000),
+  blockType: BmcBlockTypeSchema.optional(),
+}).openapi("CreateBmcComment");

--- a/packages/fx-shaping/src/schemas/bmc-history.schema.ts
+++ b/packages/fx-shaping/src/schemas/bmc-history.schema.ts
@@ -1,0 +1,18 @@
+import { z } from "@hono/zod-openapi";
+
+export const BmcVersionSchema = z.object({
+  id: z.string(),
+  bmcId: z.string(),
+  commitSha: z.string(),
+  authorId: z.string(),
+  message: z.string(),
+  createdAt: z.string(),
+}).openapi("BmcVersion");
+
+export const BmcSnapshotSchema = z.object({
+  version: BmcVersionSchema,
+  blocks: z.record(z.string(), z.string().nullable()),
+}).openapi("BmcSnapshot");
+
+export type BmcVersion = z.infer<typeof BmcVersionSchema>;
+export type BmcSnapshot = z.infer<typeof BmcSnapshotSchema>;

--- a/packages/fx-shaping/src/schemas/bmc-insight.schema.ts
+++ b/packages/fx-shaping/src/schemas/bmc-insight.schema.ts
@@ -1,0 +1,6 @@
+import { z } from "@hono/zod-openapi";
+
+export const GenerateInsightSchema = z.object({
+  currentContent: z.string().min(20).max(2000),
+  bmcContext: z.record(z.string(), z.string()).optional(),
+}).openapi("GenerateInsight");

--- a/packages/fx-shaping/src/schemas/bmc.schema.ts
+++ b/packages/fx-shaping/src/schemas/bmc.schema.ts
@@ -1,0 +1,47 @@
+import { z } from "@hono/zod-openapi";
+
+export const BmcBlockTypeSchema = z.enum([
+  "customer_segments",
+  "value_propositions",
+  "channels",
+  "customer_relationships",
+  "revenue_streams",
+  "key_resources",
+  "key_activities",
+  "key_partnerships",
+  "cost_structure",
+]).openapi("BmcBlockType");
+
+export const CreateBmcSchema = z.object({
+  title: z.string().min(1).max(100),
+  ideaId: z.string().optional(),
+}).openapi("CreateBmc");
+
+export const UpdateBmcBlocksSchema = z.object({
+  title: z.string().min(1).max(100).optional(),
+  blocks: z.array(
+    z.object({
+      blockType: BmcBlockTypeSchema,
+      content: z.string().max(2000),
+    })
+  ).optional(),
+}).openapi("UpdateBmcBlocks");
+
+export const BmcSchema = z.object({
+  id: z.string(),
+  ideaId: z.string().nullable(),
+  title: z.string(),
+  gitRef: z.string(),
+  authorId: z.string(),
+  orgId: z.string(),
+  syncStatus: z.enum(["synced", "pending", "failed"]),
+  blocks: z.array(
+    z.object({
+      blockType: BmcBlockTypeSchema,
+      content: z.string().nullable(),
+      updatedAt: z.number(),
+    })
+  ),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+}).openapi("Bmc");

--- a/packages/fx-shaping/src/schemas/commit-gate.schema.ts
+++ b/packages/fx-shaping/src/schemas/commit-gate.schema.ts
@@ -1,0 +1,15 @@
+import { z } from "@hono/zod-openapi";
+
+export const commitGateDecisionEnum = z.enum(["commit", "explore_alternatives", "drop"]);
+
+export const CreateCommitGateSchema = z
+  .object({
+    bizItemId: z.string().min(1),
+    question1Answer: z.string().max(2000).optional(),
+    question2Answer: z.string().max(2000).optional(),
+    question3Answer: z.string().max(2000).optional(),
+    question4Answer: z.string().max(2000).optional(),
+    finalDecision: commitGateDecisionEnum,
+    reason: z.string().max(2000).optional(),
+  })
+  .openapi("CreateCommitGate");

--- a/packages/fx-shaping/src/schemas/hitl-section.schema.ts
+++ b/packages/fx-shaping/src/schemas/hitl-section.schema.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const sectionReviewSchema = z.object({
+  action: z.enum(["approved", "revision_requested", "rejected"]),
+  sectionId: z.string().min(1).max(200),
+  comment: z.string().max(5000).optional(),
+});
+
+export type SectionReviewInput = z.infer<typeof sectionReviewSchema>;
+
+export const sectionReviewQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).optional().default(20),
+  offset: z.coerce.number().int().min(0).optional().default(0),
+});

--- a/packages/fx-shaping/src/schemas/idea-bmc-link.schema.ts
+++ b/packages/fx-shaping/src/schemas/idea-bmc-link.schema.ts
@@ -1,0 +1,9 @@
+import { z } from "@hono/zod-openapi";
+
+export const LinkBmcSchema = z.object({
+  bmcId: z.string().min(1),
+}).openapi("LinkBmc");
+
+export const CreateBmcFromIdeaSchema = z.object({
+  title: z.string().max(200).optional(),
+}).openapi("CreateBmcFromIdea");

--- a/packages/fx-shaping/src/schemas/persona-config-schema.ts
+++ b/packages/fx-shaping/src/schemas/persona-config-schema.ts
@@ -1,0 +1,28 @@
+/**
+ * Sprint 154: F342 페르소나 설정 스키마
+ */
+import { z } from "zod";
+
+export const PersonaWeightsSchema = z.object({
+  strategic_fit: z.number().min(0).max(100),
+  market_potential: z.number().min(0).max(100),
+  technical_feasibility: z.number().min(0).max(100),
+  financial_viability: z.number().min(0).max(100),
+  competitive_advantage: z.number().min(0).max(100),
+  risk_assessment: z.number().min(0).max(100),
+  team_readiness: z.number().min(0).max(100),
+});
+
+export const UpsertPersonaConfigSchema = z.object({
+  personaId: z.string().min(1),
+  personaName: z.string().min(1),
+  personaRole: z.string().default(""),
+  weights: PersonaWeightsSchema,
+  contextJson: z.record(z.unknown()).default({}),
+});
+
+export type UpsertPersonaConfigInput = z.infer<typeof UpsertPersonaConfigSchema>;
+
+export const UpdateWeightsSchema = z.object({
+  weights: PersonaWeightsSchema,
+});

--- a/packages/fx-shaping/src/schemas/persona-config.ts
+++ b/packages/fx-shaping/src/schemas/persona-config.ts
@@ -1,0 +1,55 @@
+/**
+ * Sprint 155 F344: 페르소나 설정 Zod 스키마
+ */
+import { z } from "@hono/zod-openapi";
+
+export const WEIGHT_AXES = [
+  "businessViability",
+  "strategicFit",
+  "customerValue",
+  "techMarket",
+  "execution",
+  "financialFeasibility",
+  "competitiveDiff",
+] as const;
+
+export const WeightsSchema = z.object({
+  businessViability: z.number().min(0).max(100).default(15),
+  strategicFit: z.number().min(0).max(100).default(15),
+  customerValue: z.number().min(0).max(100).default(15),
+  techMarket: z.number().min(0).max(100).default(15),
+  execution: z.number().min(0).max(100).default(15),
+  financialFeasibility: z.number().min(0).max(100).default(15),
+  competitiveDiff: z.number().min(0).max(100).default(10),
+});
+
+export const PersonaContextSchema = z.object({
+  situation: z.string().default(""),
+  priorities: z.array(z.string()).default([]),
+  style: z.string().default("neutral"),
+  redLines: z.array(z.string()).default([]),
+});
+
+export const PersonaConfigSchema = z.object({
+  personaId: z.string(),
+  weights: WeightsSchema,
+  context: PersonaContextSchema,
+});
+
+export const UpsertPersonaConfigsSchema = z.object({
+  configs: z.array(PersonaConfigSchema).min(1).max(8),
+});
+
+export const PersonaConfigResponseSchema = z.object({
+  id: z.string(),
+  itemId: z.string(),
+  personaId: z.string(),
+  weights: WeightsSchema,
+  context: PersonaContextSchema,
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export type Weights = z.infer<typeof WeightsSchema>;
+export type PersonaContext = z.infer<typeof PersonaContextSchema>;
+export type PersonaConfigInput = z.infer<typeof PersonaConfigSchema>;

--- a/packages/fx-shaping/src/schemas/persona-eval-schema.ts
+++ b/packages/fx-shaping/src/schemas/persona-eval-schema.ts
@@ -1,0 +1,19 @@
+/**
+ * Sprint 154: F342 페르소나 평가 결과 스키마
+ */
+import { z } from "zod";
+import { PersonaWeightsSchema } from "./persona-config-schema.js";
+
+export const SavePersonaEvalSchema = z.object({
+  personaId: z.string().min(1),
+  scores: PersonaWeightsSchema,
+  verdict: z.enum(["Go", "Conditional", "NoGo"]),
+  summary: z.string().min(1),
+  concern: z.string().nullable().optional(),
+  condition: z.string().nullable().optional(),
+  evalModel: z.string().optional(),
+  evalDurationMs: z.number().int().optional(),
+  evalCostUsd: z.number().optional(),
+});
+
+export type SavePersonaEvalInput = z.infer<typeof SavePersonaEvalSchema>;

--- a/packages/fx-shaping/src/schemas/persona-eval.ts
+++ b/packages/fx-shaping/src/schemas/persona-eval.ts
@@ -1,0 +1,48 @@
+/**
+ * Sprint 155 F345: 페르소나 평가 Zod 스키마
+ */
+import { z } from "@hono/zod-openapi";
+import { PersonaConfigSchema } from "./persona-config.js";
+
+export const ScoresSchema = z.object({
+  businessViability: z.number().min(0).max(10),
+  strategicFit: z.number().min(0).max(10),
+  customerValue: z.number().min(0).max(10),
+  techMarket: z.number().min(0).max(10),
+  execution: z.number().min(0).max(10),
+  financialFeasibility: z.number().min(0).max(10),
+  competitiveDiff: z.number().min(0).max(10),
+  scalability: z.number().min(0).max(10),
+});
+
+export const VerdictEnum = z.enum(["green", "keep", "red", "pending"]);
+
+export const StartEvalSchema = z.object({
+  itemId: z.string().min(1),
+  configs: z.array(PersonaConfigSchema).min(1).max(8),
+  briefing: z.string().default(""),
+  demoMode: z.boolean().default(false),
+});
+
+export const PersonaEvalResultSchema = z.object({
+  personaId: z.string(),
+  scores: ScoresSchema,
+  verdict: VerdictEnum,
+  summary: z.string().nullable(),
+  concerns: z.array(z.string()),
+  index: z.number(),
+});
+
+export const FinalResultSchema = z.object({
+  verdict: VerdictEnum,
+  avgScore: z.number(),
+  totalConcerns: z.number(),
+  scores: z.array(PersonaEvalResultSchema),
+  warnings: z.array(z.string()),
+});
+
+export type Scores = z.infer<typeof ScoresSchema>;
+export type Verdict = z.infer<typeof VerdictEnum>;
+export type StartEvalInput = z.infer<typeof StartEvalSchema>;
+export type PersonaEvalResult = z.infer<typeof PersonaEvalResultSchema>;
+export type FinalResult = z.infer<typeof FinalResultSchema>;

--- a/packages/fx-shaping/src/schemas/shaping.ts
+++ b/packages/fx-shaping/src/schemas/shaping.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+
+// ── Create Run ──
+export const createShapingRunSchema = z.object({
+  discoveryPrdId: z.string().min(1),
+  mode: z.enum(["hitl", "auto"]).default("hitl"),
+  gitPath: z.string().max(500).optional(),
+  maxIterations: z.number().int().min(1).max(10).optional().default(3),
+  tokenLimit: z.number().int().min(10000).max(2000000).optional().default(500000),
+});
+
+export type CreateShapingRunInput = z.infer<typeof createShapingRunSchema>;
+
+// ── Update Run ──
+export const updateShapingRunSchema = z.object({
+  status: z.enum(["running", "completed", "failed", "escalated"]).optional(),
+  currentPhase: z.enum(["A", "B", "C", "D", "E", "F"]).optional(),
+  qualityScore: z.number().min(0).max(1).optional(),
+  tokenCost: z.number().int().min(0).optional(),
+  gitPath: z.string().max(500).optional(),
+});
+
+export type UpdateShapingRunInput = z.infer<typeof updateShapingRunSchema>;
+
+// ── List Runs Query ──
+export const listShapingRunsQuerySchema = z.object({
+  status: z.enum(["running", "completed", "failed", "escalated"]).optional(),
+  mode: z.enum(["hitl", "auto"]).optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional().default(20),
+  offset: z.coerce.number().int().min(0).optional().default(0),
+});
+
+export type ListShapingRunsQuery = z.infer<typeof listShapingRunsQuerySchema>;
+
+// ── Phase Log ──
+export const createPhaseLogSchema = z.object({
+  phase: z.enum(["A", "B", "C", "D", "E", "F"]),
+  round: z.number().int().min(0).default(0),
+  inputSnapshot: z.string().max(50000).optional(),
+  outputSnapshot: z.string().max(50000).optional(),
+  verdict: z.enum(["PASS", "MINOR_FIX", "MAJOR_ISSUE", "ESCALATED"]).optional(),
+  qualityScore: z.number().min(0).max(1).optional(),
+  findings: z.string().max(50000).optional(),
+  durationMs: z.number().int().min(0).optional(),
+});
+
+export type CreatePhaseLogInput = z.infer<typeof createPhaseLogSchema>;
+
+// ── Expert Review ──
+export const createExpertReviewSchema = z.object({
+  expertRole: z.enum(["TA", "AA", "CA", "DA", "QA"]),
+  reviewBody: z.string().min(1).max(100000),
+  findings: z.string().max(50000).optional(),
+  qualityScore: z.number().min(0).max(1).optional(),
+});
+
+export type CreateExpertReviewInput = z.infer<typeof createExpertReviewSchema>;
+
+// ── Six Hats ──
+export const createSixHatsSchema = z.object({
+  hatColor: z.enum(["white", "red", "black", "yellow", "green", "blue"]),
+  round: z.number().int().min(1),
+  opinion: z.string().min(1).max(50000),
+  verdict: z.enum(["accept", "concern", "reject"]).optional(),
+});
+
+export type CreateSixHatsInput = z.infer<typeof createSixHatsSchema>;
+
+// ── HITL Review ──
+export const reviewSectionSchema = z.object({
+  action: z.enum(["approved", "revision_requested", "rejected"]),
+  section: z.string().min(1).max(200),
+  comment: z.string().max(5000).optional(),
+});
+
+export type ReviewSectionInput = z.infer<typeof reviewSectionSchema>;

--- a/packages/fx-shaping/src/schemas/viability-checkpoint.schema.ts
+++ b/packages/fx-shaping/src/schemas/viability-checkpoint.schema.ts
@@ -1,0 +1,29 @@
+import { z } from "@hono/zod-openapi";
+
+export const discoveryTypeEnum = z.enum(["I", "M", "P", "T", "S"]);
+export const stageEnum = z.enum(["2-1", "2-2", "2-3", "2-4", "2-5", "2-6", "2-7"]);
+export const checkpointDecisionEnum = z.enum(["go", "pivot", "drop"]);
+
+export const SetDiscoveryTypeSchema = z
+  .object({
+    discoveryType: discoveryTypeEnum,
+  })
+  .openapi("SetDiscoveryType");
+
+export const CreateCheckpointSchema = z
+  .object({
+    bizItemId: z.string().min(1),
+    stage: stageEnum,
+    decision: checkpointDecisionEnum,
+    question: z.string().min(1).max(500),
+    reason: z.string().max(2000).optional(),
+  })
+  .openapi("CreateCheckpoint");
+
+export const UpdateCheckpointSchema = z
+  .object({
+    decision: checkpointDecisionEnum.optional(),
+    question: z.string().min(1).max(500).optional(),
+    reason: z.string().max(2000).optional(),
+  })
+  .openapi("UpdateCheckpoint");

--- a/packages/fx-shaping/src/services/bd-artifact-service.ts
+++ b/packages/fx-shaping/src/services/bd-artifact-service.ts
@@ -1,0 +1,183 @@
+/**
+ * F261: BD 산출물 CRUD + 버전 관리 서비스
+ */
+
+import type { BdArtifact, ArtifactListQuery } from "@foundry-x/shared";
+
+interface ArtifactRow {
+  id: string;
+  org_id: string;
+  biz_item_id: string;
+  skill_id: string;
+  stage_id: string;
+  version: number;
+  input_text: string;
+  output_text: string | null;
+  model: string;
+  tokens_used: number;
+  duration_ms: number;
+  status: string;
+  created_by: string;
+  created_at: string;
+}
+
+function rowToArtifact(row: ArtifactRow): BdArtifact {
+  return {
+    id: row.id,
+    orgId: row.org_id,
+    bizItemId: row.biz_item_id,
+    skillId: row.skill_id,
+    stageId: row.stage_id,
+    version: row.version,
+    inputText: row.input_text,
+    outputText: row.output_text,
+    model: row.model,
+    tokensUsed: row.tokens_used,
+    durationMs: row.duration_ms,
+    status: row.status as BdArtifact["status"],
+    createdBy: row.created_by,
+    createdAt: row.created_at,
+  };
+}
+
+export class BdArtifactService {
+  constructor(private db: D1Database) {}
+
+  async create(input: {
+    id: string;
+    orgId: string;
+    bizItemId: string;
+    skillId: string;
+    stageId: string;
+    version: number;
+    inputText: string;
+    model: string;
+    createdBy: string;
+  }): Promise<BdArtifact> {
+    const now = new Date().toISOString();
+    await this.db
+      .prepare(
+        `INSERT INTO bd_artifacts (id, org_id, biz_item_id, skill_id, stage_id, version, input_text, model, status, created_by, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)`,
+      )
+      .bind(
+        input.id,
+        input.orgId,
+        input.bizItemId,
+        input.skillId,
+        input.stageId,
+        input.version,
+        input.inputText,
+        input.model,
+        input.createdBy,
+        now,
+      )
+      .run();
+
+    return {
+      ...input,
+      outputText: null,
+      tokensUsed: 0,
+      durationMs: 0,
+      status: "pending",
+      createdAt: now,
+    };
+  }
+
+  async getById(orgId: string, id: string): Promise<BdArtifact | null> {
+    const row = await this.db
+      .prepare("SELECT * FROM bd_artifacts WHERE id = ? AND org_id = ?")
+      .bind(id, orgId)
+      .first<ArtifactRow>();
+    return row ? rowToArtifact(row) : null;
+  }
+
+  async list(orgId: string, query: ArtifactListQuery): Promise<{ items: BdArtifact[]; total: number }> {
+    const conditions = ["org_id = ?"];
+    const params: unknown[] = [orgId];
+
+    if (query.bizItemId) {
+      conditions.push("biz_item_id = ?");
+      params.push(query.bizItemId);
+    }
+    if (query.stageId) {
+      conditions.push("stage_id = ?");
+      params.push(query.stageId);
+    }
+    if (query.skillId) {
+      conditions.push("skill_id = ?");
+      params.push(query.skillId);
+    }
+    if (query.status) {
+      conditions.push("status = ?");
+      params.push(query.status);
+    }
+
+    const where = conditions.join(" AND ");
+    const offset = ((query.page ?? 1) - 1) * (query.limit ?? 20);
+
+    const countResult = await this.db
+      .prepare(`SELECT COUNT(*) as cnt FROM bd_artifacts WHERE ${where}`)
+      .bind(...params)
+      .first<{ cnt: number }>();
+    const total = countResult?.cnt ?? 0;
+
+    const { results } = await this.db
+      .prepare(
+        `SELECT * FROM bd_artifacts WHERE ${where} ORDER BY created_at DESC LIMIT ? OFFSET ?`,
+      )
+      .bind(...params, query.limit ?? 20, offset)
+      .all<ArtifactRow>();
+
+    return {
+      items: (results ?? []).map(rowToArtifact),
+      total,
+    };
+  }
+
+  async getVersionHistory(orgId: string, bizItemId: string, skillId: string): Promise<BdArtifact[]> {
+    const { results } = await this.db
+      .prepare(
+        `SELECT * FROM bd_artifacts WHERE org_id = ? AND biz_item_id = ? AND skill_id = ? ORDER BY version DESC`,
+      )
+      .bind(orgId, bizItemId, skillId)
+      .all<ArtifactRow>();
+    return (results ?? []).map(rowToArtifact);
+  }
+
+  async getNextVersion(bizItemId: string, skillId: string): Promise<number> {
+    const row = await this.db
+      .prepare(
+        "SELECT MAX(version) as max_ver FROM bd_artifacts WHERE biz_item_id = ? AND skill_id = ?",
+      )
+      .bind(bizItemId, skillId)
+      .first<{ max_ver: number | null }>();
+    return (row?.max_ver ?? 0) + 1;
+  }
+
+  async updateStatus(
+    id: string,
+    status: string,
+    output?: { outputText?: string; tokensUsed?: number; durationMs?: number },
+  ): Promise<void> {
+    if (output) {
+      await this.db
+        .prepare(
+          "UPDATE bd_artifacts SET status = ?, output_text = ?, tokens_used = ?, duration_ms = ? WHERE id = ?",
+        )
+        .bind(
+          status,
+          output.outputText ?? null,
+          output.tokensUsed ?? 0,
+          output.durationMs ?? 0,
+          id,
+        )
+        .run();
+    } else {
+      await this.db
+        .prepare("UPDATE bd_artifacts SET status = ? WHERE id = ?")
+        .bind(status, id)
+        .run();
+    }
+  }
+}

--- a/packages/fx-shaping/src/services/bd-process-tracker.ts
+++ b/packages/fx-shaping/src/services/bd-process-tracker.ts
@@ -1,0 +1,417 @@
+/**
+ * F262: BD 프로세스 진행 추적 — 기존 5개 테이블 Aggregation Layer
+ * 새 DB 테이블 없이 pipeline_stages, ax_viability_checkpoints, ax_commit_gates,
+ * decisions, bd_artifacts를 조합하여 통합 진행 상태를 제공한다.
+ */
+
+export const DISCOVERY_STAGES = [
+  { id: "2-0", name: "아이템 등록" },
+  { id: "2-1", name: "시장 조사" },
+  { id: "2-2", name: "경쟁 분석" },
+  { id: "2-3", name: "고객 분석" },
+  { id: "2-4", name: "비즈니스 모델" },
+  { id: "2-5", name: "Commit Gate" },
+  { id: "2-6", name: "기술 검증" },
+  { id: "2-7", name: "시제품 검증" },
+  { id: "2-8", name: "사업 계획서" },
+  { id: "2-9", name: "투자 심사" },
+  { id: "2-10", name: "최종 보고" },
+] as const;
+
+export interface DiscoveryStageProgress {
+  stageId: string;
+  stageName: string;
+  hasArtifacts: boolean;
+  artifactCount: number;
+  checkpoint?: {
+    decision: string;
+    decidedAt: string;
+  };
+}
+
+export interface ProcessProgress {
+  bizItemId: string;
+  title: string;
+  status: string;
+  pipelineStage: string;
+  pipelineEnteredAt: string;
+  currentDiscoveryStage: string;
+  discoveryStages: DiscoveryStageProgress[];
+  completedStageCount: number;
+  totalStageCount: number;
+  trafficLight: {
+    overallSignal: "green" | "yellow" | "red";
+    go: number;
+    pivot: number;
+    drop: number;
+    pending: number;
+  };
+  commitGate: { decision: string; decidedAt: string } | null;
+  lastDecision: {
+    decision: string;
+    stage: string;
+    comment: string;
+    decidedAt: string;
+  } | null;
+}
+
+export interface PortfolioSummary {
+  totalItems: number;
+  bySignal: { green: number; yellow: number; red: number };
+  byPipelineStage: Record<string, number>;
+  avgCompletionRate: number;
+  bottleneck: { stageId: string; stageName: string; itemCount: number } | null;
+}
+
+interface PipelineRow {
+  biz_item_id: string;
+  stage: string;
+  entered_at: string;
+  title: string;
+  status: string;
+}
+
+interface CheckpointRow {
+  biz_item_id: string;
+  stage: string;
+  decision: string;
+  decided_at: string;
+}
+
+interface CommitGateRow {
+  biz_item_id: string;
+  final_decision: string;
+  decided_at: string;
+}
+
+interface ArtifactCountRow {
+  biz_item_id: string;
+  stage_id: string;
+  cnt: number;
+}
+
+interface DecisionRow {
+  biz_item_id: string;
+  decision: string;
+  stage: string;
+  comment: string;
+  created_at: string;
+}
+
+const ALL_CHECKPOINT_STAGES = ["2-1", "2-2", "2-3", "2-4", "2-5", "2-6", "2-7"];
+
+function computeSignal(
+  checkpoints: CheckpointRow[],
+  commitGate: CommitGateRow | undefined,
+): "green" | "yellow" | "red" {
+  const dropCount = checkpoints.filter((c) => c.decision === "drop").length;
+  const pivotCount = checkpoints.filter((c) => c.decision === "pivot").length;
+
+  if (dropCount >= 1 || commitGate?.final_decision === "drop") return "red";
+  if (pivotCount >= 2 || commitGate?.final_decision === "explore_alternatives") return "yellow";
+  return "green";
+}
+
+export class BdProcessTracker {
+  constructor(private db: D1Database) {}
+
+  async getItemProgress(bizItemId: string, orgId: string): Promise<ProcessProgress | null> {
+    // Pipeline stage
+    const pipelineRow = await this.db
+      .prepare(
+        `SELECT ps.biz_item_id, ps.stage, ps.entered_at, bi.title, bi.status
+         FROM pipeline_stages ps
+         JOIN biz_items bi ON bi.id = ps.biz_item_id
+         WHERE ps.biz_item_id = ? AND ps.org_id = ? AND ps.exited_at IS NULL`,
+      )
+      .bind(bizItemId, orgId)
+      .first<PipelineRow>();
+
+    if (!pipelineRow) return null;
+
+    // Checkpoints
+    const { results: checkpoints } = await this.db
+      .prepare(
+        "SELECT biz_item_id, stage, decision, decided_at FROM ax_viability_checkpoints WHERE biz_item_id = ? ORDER BY stage",
+      )
+      .bind(bizItemId)
+      .all<CheckpointRow>();
+
+    // Commit gate
+    const commitGateRow = await this.db
+      .prepare(
+        "SELECT biz_item_id, final_decision, decided_at FROM ax_commit_gates WHERE biz_item_id = ?",
+      )
+      .bind(bizItemId)
+      .first<CommitGateRow>();
+
+    // Artifact counts by stage
+    const { results: artifactCounts } = await this.db
+      .prepare(
+        "SELECT biz_item_id, stage_id, COUNT(*) as cnt FROM bd_artifacts WHERE biz_item_id = ? AND status = 'completed' GROUP BY stage_id",
+      )
+      .bind(bizItemId)
+      .all<ArtifactCountRow>();
+
+    // Latest decision
+    const latestDecision = await this.db
+      .prepare(
+        "SELECT biz_item_id, decision, stage, comment, created_at FROM decisions WHERE biz_item_id = ? AND org_id = ? ORDER BY created_at DESC LIMIT 1",
+      )
+      .bind(bizItemId, orgId)
+      .first<DecisionRow>();
+
+    const checkpointMap = new Map(checkpoints.map((c) => [c.stage, c]));
+    const artifactMap = new Map(artifactCounts.map((a) => [a.stage_id, a.cnt]));
+
+    return this.assembleProgress(
+      pipelineRow,
+      checkpointMap,
+      commitGateRow ?? undefined,
+      artifactMap,
+      latestDecision ?? undefined,
+    );
+  }
+
+  async getPortfolioProgress(
+    orgId: string,
+    filters?: { signal?: string; pipelineStage?: string; page?: number; limit?: number },
+  ): Promise<{ items: ProcessProgress[]; summary: PortfolioSummary; total: number }> {
+    const page = filters?.page ?? 1;
+    const limit = filters?.limit ?? 20;
+
+    // Batch 1: All active pipeline items
+    const { results: pipelineRows } = await this.db
+      .prepare(
+        `SELECT ps.biz_item_id, ps.stage, ps.entered_at, bi.title, bi.status
+         FROM pipeline_stages ps
+         JOIN biz_items bi ON bi.id = ps.biz_item_id
+         WHERE ps.org_id = ? AND ps.exited_at IS NULL
+         ORDER BY ps.entered_at DESC`,
+      )
+      .bind(orgId)
+      .all<PipelineRow>();
+
+    if (pipelineRows.length === 0) {
+      return {
+        items: [],
+        summary: {
+          totalItems: 0,
+          bySignal: { green: 0, yellow: 0, red: 0 },
+          byPipelineStage: {},
+          avgCompletionRate: 0,
+          bottleneck: null,
+        },
+        total: 0,
+      };
+    }
+
+    // Batch 2: All checkpoints
+    const { results: allCheckpoints } = await this.db
+      .prepare(
+        "SELECT biz_item_id, stage, decision, decided_at FROM ax_viability_checkpoints WHERE org_id = ? ORDER BY stage",
+      )
+      .bind(orgId)
+      .all<CheckpointRow>();
+
+    // Batch 3: All commit gates
+    const bizItemIds = pipelineRows.map((r) => r.biz_item_id);
+    const placeholders = bizItemIds.map(() => "?").join(",");
+    const { results: allCommitGates } = await this.db
+      .prepare(
+        `SELECT cg.biz_item_id, cg.final_decision, cg.decided_at
+         FROM ax_commit_gates cg
+         WHERE cg.biz_item_id IN (${placeholders})`,
+      )
+      .bind(...bizItemIds)
+      .all<CommitGateRow>();
+
+    // Batch 4: Artifact counts
+    const { results: allArtifactCounts } = await this.db
+      .prepare(
+        `SELECT biz_item_id, stage_id, COUNT(*) as cnt
+         FROM bd_artifacts WHERE org_id = ? AND status = 'completed'
+         GROUP BY biz_item_id, stage_id`,
+      )
+      .bind(orgId)
+      .all<ArtifactCountRow>();
+
+    // Batch 5: Latest decisions (one per item)
+    const { results: allDecisions } = await this.db
+      .prepare(
+        `SELECT d.biz_item_id, d.decision, d.stage, d.comment, d.created_at
+         FROM decisions d
+         INNER JOIN (
+           SELECT biz_item_id, MAX(created_at) as max_created
+           FROM decisions WHERE org_id = ?
+           GROUP BY biz_item_id
+         ) latest ON d.biz_item_id = latest.biz_item_id AND d.created_at = latest.max_created
+         WHERE d.org_id = ?`,
+      )
+      .bind(orgId, orgId)
+      .all<DecisionRow>();
+
+    // Group by biz_item_id
+    const checkpointsByItem = this.groupBy(allCheckpoints, "biz_item_id");
+    const commitGateByItem = new Map(allCommitGates.map((g) => [g.biz_item_id, g]));
+    const artifactsByItem = this.groupBy(allArtifactCounts, "biz_item_id");
+    const decisionByItem = new Map(allDecisions.map((d) => [d.biz_item_id, d]));
+
+    // Assemble all progress items
+    const allItems: ProcessProgress[] = pipelineRows.map((row) => {
+      const itemCheckpoints = checkpointsByItem.get(row.biz_item_id) ?? [];
+      const checkpointMap = new Map(itemCheckpoints.map((c) => [c.stage, c]));
+      const commitGate = commitGateByItem.get(row.biz_item_id);
+      const artifactCounts = artifactsByItem.get(row.biz_item_id) ?? [];
+      const artifactMap = new Map(artifactCounts.map((a) => [a.stage_id, a.cnt]));
+      const latestDecision = decisionByItem.get(row.biz_item_id);
+
+      return this.assembleProgress(row, checkpointMap, commitGate, artifactMap, latestDecision);
+    });
+
+    // Compute summary from ALL items (before filtering)
+    const summary = this.computeSummary(allItems);
+
+    // Apply filters
+    let filtered = allItems;
+    if (filters?.signal) {
+      filtered = filtered.filter((i) => i.trafficLight.overallSignal === filters.signal);
+    }
+    if (filters?.pipelineStage) {
+      filtered = filtered.filter((i) => i.pipelineStage === filters.pipelineStage);
+    }
+
+    const total = filtered.length;
+    const offset = (page - 1) * limit;
+    const paginated = filtered.slice(offset, offset + limit);
+
+    return { items: paginated, summary, total };
+  }
+
+  async getPortfolioSummary(orgId: string): Promise<PortfolioSummary> {
+    const { summary } = await this.getPortfolioProgress(orgId);
+    return summary;
+  }
+
+  private assembleProgress(
+    pipelineRow: PipelineRow,
+    checkpointMap: Map<string, CheckpointRow>,
+    commitGate: CommitGateRow | undefined,
+    artifactMap: Map<string, number>,
+    latestDecision: DecisionRow | undefined,
+  ): ProcessProgress {
+    const discoveryStages: DiscoveryStageProgress[] = DISCOVERY_STAGES.map((s) => {
+      const artCount = artifactMap.get(s.id) ?? 0;
+      const checkpoint = checkpointMap.get(s.id);
+      return {
+        stageId: s.id,
+        stageName: s.name,
+        hasArtifacts: artCount > 0,
+        artifactCount: artCount,
+        ...(checkpoint
+          ? { checkpoint: { decision: checkpoint.decision, decidedAt: checkpoint.decided_at } }
+          : {}),
+      };
+    });
+
+    const completedStageCount = discoveryStages.filter((s) => s.hasArtifacts).length;
+
+    // Current discovery stage = highest stage with artifacts
+    let currentDiscoveryStage = "2-0";
+    for (let i = DISCOVERY_STAGES.length - 1; i >= 0; i--) {
+      const ds = discoveryStages[i];
+      if (ds && ds.hasArtifacts) {
+        currentDiscoveryStage = DISCOVERY_STAGES[i]!.id;
+        break;
+      }
+    }
+
+    const checkpoints = Array.from(checkpointMap.values());
+    const completedCheckpointStages = new Set(checkpoints.map((c) => c.stage));
+    const pendingCount = ALL_CHECKPOINT_STAGES.filter((s) => !completedCheckpointStages.has(s)).length;
+
+    return {
+      bizItemId: pipelineRow.biz_item_id,
+      title: pipelineRow.title,
+      status: pipelineRow.status,
+      pipelineStage: pipelineRow.stage,
+      pipelineEnteredAt: pipelineRow.entered_at,
+      currentDiscoveryStage,
+      discoveryStages,
+      completedStageCount,
+      totalStageCount: DISCOVERY_STAGES.length,
+      trafficLight: {
+        overallSignal: computeSignal(checkpoints, commitGate),
+        go: checkpoints.filter((c) => c.decision === "go").length,
+        pivot: checkpoints.filter((c) => c.decision === "pivot").length,
+        drop: checkpoints.filter((c) => c.decision === "drop").length,
+        pending: pendingCount,
+      },
+      commitGate: commitGate
+        ? { decision: commitGate.final_decision, decidedAt: commitGate.decided_at }
+        : null,
+      lastDecision: latestDecision
+        ? {
+            decision: latestDecision.decision,
+            stage: latestDecision.stage,
+            comment: latestDecision.comment,
+            decidedAt: latestDecision.created_at,
+          }
+        : null,
+    };
+  }
+
+  private computeSummary(items: ProcessProgress[]): PortfolioSummary {
+    const bySignal = { green: 0, yellow: 0, red: 0 };
+    const byPipelineStage: Record<string, number> = {};
+    let totalCompletionRate = 0;
+    const stageItemCount: Record<string, number> = {};
+
+    for (const item of items) {
+      bySignal[item.trafficLight.overallSignal]++;
+      byPipelineStage[item.pipelineStage] = (byPipelineStage[item.pipelineStage] ?? 0) + 1;
+      totalCompletionRate += item.completedStageCount / item.totalStageCount;
+
+      // Track items stuck at each discovery stage for bottleneck detection
+      stageItemCount[item.currentDiscoveryStage] =
+        (stageItemCount[item.currentDiscoveryStage] ?? 0) + 1;
+    }
+
+    // Bottleneck = discovery stage with most items stuck
+    let bottleneck: PortfolioSummary["bottleneck"] = null;
+    let maxCount = 0;
+    for (const [stageId, count] of Object.entries(stageItemCount)) {
+      if (count > maxCount) {
+        maxCount = count;
+        const stageDef = DISCOVERY_STAGES.find((s) => s.id === stageId);
+        bottleneck = {
+          stageId,
+          stageName: stageDef?.name ?? stageId,
+          itemCount: count,
+        };
+      }
+    }
+
+    return {
+      totalItems: items.length,
+      bySignal,
+      byPipelineStage,
+      avgCompletionRate: items.length > 0 ? Math.round((totalCompletionRate / items.length) * 100) : 0,
+      bottleneck,
+    };
+  }
+
+  private groupBy<T extends { biz_item_id: string }>(
+    rows: T[],
+    _key: "biz_item_id",
+  ): Map<string, T[]> {
+    const map = new Map<string, T[]>();
+    for (const row of rows) {
+      const k = row.biz_item_id;
+      const arr = map.get(k) ?? [];
+      arr.push(row);
+      map.set(k, arr);
+    }
+    return map;
+  }
+}

--- a/packages/fx-shaping/src/services/bd-skill-executor.ts
+++ b/packages/fx-shaping/src/services/bd-skill-executor.ts
@@ -1,0 +1,176 @@
+/**
+ * F260: BD 스킬 실행 엔진
+ * 스킬 ID → 프롬프트 조합 → Anthropic Messages API 직접 호출 → 산출물 생성.
+ * PromptGatewayService로 입력 sanitize, 커스텀 system prompt로 LLM 호출.
+ */
+
+import { PromptGatewayService } from "../agent/services/prompt-gateway.js";
+import { BdArtifactService } from "./bd-artifact-service.js";
+import { getSkillPrompt } from "./bd-skill-prompts.js";
+import { SkillMetricsService } from "../agent/services/skill-metrics.js";
+import type { ExecuteSkillInput, SkillExecutionResult } from "@foundry-x/shared";
+
+const MODEL = "claude-haiku-4-5-20250714";
+
+export class BdSkillExecutor {
+  private gateway: PromptGatewayService;
+  private artifactService: BdArtifactService;
+
+  constructor(private db: D1Database, private apiKey: string) {
+    this.gateway = new PromptGatewayService(db);
+    this.artifactService = new BdArtifactService(db);
+  }
+
+  async execute(
+    orgId: string,
+    userId: string,
+    skillId: string,
+    input: ExecuteSkillInput,
+  ): Promise<SkillExecutionResult> {
+    const promptDef = getSkillPrompt(skillId);
+    if (!promptDef) {
+      throw new Error(`Unsupported skill: ${skillId}`);
+    }
+
+    const version = await this.artifactService.getNextVersion(input.bizItemId, skillId);
+
+    const artifactId = generateId();
+    await this.artifactService.create({
+      id: artifactId,
+      orgId,
+      bizItemId: input.bizItemId,
+      skillId,
+      stageId: input.stageId,
+      version,
+      inputText: input.inputText,
+      model: MODEL,
+      createdBy: userId,
+    });
+
+    await this.artifactService.updateStatus(artifactId, "running");
+
+    const startTime = Date.now();
+
+    try {
+      const sanitized = await this.gateway.sanitizePrompt(input.inputText, orgId);
+      const bizContext = await this.loadBizItemContext(input.bizItemId);
+
+      const userPrompt = bizContext
+        ? `## 사업 아이템 컨텍스트\n${bizContext}\n\n## 분석 요청\n${sanitized.sanitizedContent}`
+        : sanitized.sanitizedContent;
+
+      const res = await fetch("https://api.anthropic.com/v1/messages", {
+        method: "POST",
+        headers: {
+          "x-api-key": this.apiKey,
+          "anthropic-version": "2023-06-01",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: MODEL,
+          max_tokens: promptDef.maxTokens,
+          system: promptDef.systemPrompt,
+          messages: [{ role: "user", content: userPrompt }],
+        }),
+      });
+
+      const durationMs = Date.now() - startTime;
+
+      if (!res.ok) {
+        const errorMsg = `Anthropic API error: ${res.status} ${res.statusText}`;
+        await this.artifactService.updateStatus(artifactId, "failed", {
+          outputText: errorMsg,
+          tokensUsed: 0,
+          durationMs,
+        });
+        return { artifactId, skillId, version, outputText: errorMsg, model: MODEL, tokensUsed: 0, durationMs, status: "failed" };
+      }
+
+      const data = (await res.json()) as {
+        content: Array<{ type: string; text: string }>;
+        usage: { input_tokens: number; output_tokens: number };
+      };
+
+      const outputText = data.content
+        .filter((c) => c.type === "text")
+        .map((c) => c.text)
+        .join("");
+      const tokensUsed = data.usage.input_tokens + data.usage.output_tokens;
+
+      await this.artifactService.updateStatus(artifactId, "completed", {
+        outputText,
+        tokensUsed,
+        durationMs,
+      });
+
+      // F274: 스킬 실행 메트릭 기록
+      await this.recordMetrics(orgId, skillId, version, artifactId, input.bizItemId, userId, "completed", data.usage.input_tokens, data.usage.output_tokens, durationMs);
+
+      return { artifactId, skillId, version, outputText, model: MODEL, tokensUsed, durationMs, status: "completed" };
+    } catch (err) {
+      const durationMs = Date.now() - startTime;
+      const errorMsg = err instanceof Error ? err.message : "Unknown error";
+      await this.artifactService.updateStatus(artifactId, "failed", {
+        outputText: errorMsg,
+        tokensUsed: 0,
+        durationMs,
+      });
+
+      // F274: 실패 메트릭도 기록
+      await this.recordMetrics(orgId, skillId, version, artifactId, input.bizItemId, userId, "failed", 0, 0, durationMs, errorMsg);
+
+      return { artifactId, skillId, version, outputText: errorMsg, model: MODEL, tokensUsed: 0, durationMs, status: "failed" };
+    }
+  }
+
+  private async recordMetrics(
+    orgId: string, skillId: string, version: number, artifactId: string,
+    bizItemId: string, userId: string, status: "completed" | "failed",
+    inputTokens: number, outputTokens: number, durationMs: number, errorMessage?: string,
+  ): Promise<void> {
+    try {
+      const metricsService = new SkillMetricsService(this.db);
+      await metricsService.recordExecution({
+        tenantId: orgId,
+        skillId,
+        version,
+        bizItemId,
+        artifactId,
+        model: MODEL,
+        status,
+        inputTokens,
+        outputTokens,
+        costUsd: estimateCost(MODEL, inputTokens, outputTokens),
+        durationMs,
+        executedBy: userId,
+        errorMessage,
+      });
+    } catch {
+      // 메트릭 기록 실패는 스킬 실행 결과에 영향 주지 않음
+    }
+  }
+
+  private async loadBizItemContext(bizItemId: string): Promise<string | null> {
+    const row = await this.db
+      .prepare("SELECT title, description, status FROM biz_items WHERE id = ?")
+      .bind(bizItemId)
+      .first<{ title: string; description: string | null; status: string }>();
+    if (!row) return null;
+    return `- 제목: ${row.title}\n- 설명: ${row.description ?? "(없음)"}\n- 상태: ${row.status}`;
+  }
+}
+
+function generateId(): string {
+  const t = Date.now().toString(36);
+  const r = Math.random().toString(36).substring(2, 10);
+  return `art_${t}${r}`;
+}
+
+function estimateCost(model: string, inputTokens: number, outputTokens: number): number {
+  // Haiku 4.5 pricing: $0.80/1M input, $4.00/1M output
+  if (model.includes("haiku")) {
+    return (inputTokens * 0.8 + outputTokens * 4.0) / 1_000_000;
+  }
+  // Sonnet: $3/1M input, $15/1M output
+  return (inputTokens * 3 + outputTokens * 15) / 1_000_000;
+}

--- a/packages/fx-shaping/src/services/bd-skill-prompts.ts
+++ b/packages/fx-shaping/src/services/bd-skill-prompts.ts
@@ -1,0 +1,193 @@
+/**
+ * F260: BD 스킬별 프롬프트 매핑
+ * 각 스킬 ID → system prompt + output format + maxTokens 정의.
+ * 프롬프트는 서버에서만 관리 (클라이언트 미노출).
+ */
+
+export interface SkillPromptDef {
+  systemPrompt: string;
+  outputFormat: "markdown" | "json" | "table";
+  maxTokens: number;
+}
+
+const BASE_SYSTEM = `당신은 AX 사업개발 전문 AI 어시스턴트입니다. 사업 아이템 발굴·분석·검증 과정에서 전문적인 산출물을 생성합니다.
+응답은 항상 한국어로, 구조화된 마크다운 형식으로 작성합니다.
+분석은 객관적 근거 기반이어야 하며, 모호한 표현 대신 구체적인 수치나 사례를 제시합니다.`;
+
+export const SKILL_PROMPT_MAP: Record<string, SkillPromptDef> = {
+  // === ai-biz (11) ===
+  "ai-biz:ecosystem-map": {
+    systemPrompt: `${BASE_SYSTEM}
+당신의 역할: AI 생태계 맵 전문가.
+밸류체인, 경쟁구도, 보완재 등 산업 생태계를 분석하고 시각적으로 정리합니다.
+산출물: ## 생태계 맵 / ## 핵심 플레이어 / ## 기회 포인트 / ## 위협 요소 섹션으로 구성.`,
+    outputFormat: "markdown",
+    maxTokens: 4096,
+  },
+  "ai-biz:moat-analysis": {
+    systemPrompt: `${BASE_SYSTEM}
+당신의 역할: 경쟁 해자(Moat) 분석 전문가.
+데이터/기술/네트워크 효과/전환비용/브랜드 등 지속가능 경쟁우위를 평가합니다.
+산출물: ## 해자 강도 스코어 (1~10) / ## 해자 유형별 분석 / ## 모방 난이도 / ## 강화 전략 섹션으로 구성.`,
+    outputFormat: "markdown",
+    maxTokens: 4096,
+  },
+  "ai-biz:partner-scorecard": {
+    systemPrompt: `${BASE_SYSTEM}
+당신의 역할: 기술 파트너 평가 전문가.
+파트너 후보들을 기술력/안정성/비용/전략적 적합성 기준으로 비교 평가합니다.
+산출물: ## 평가 기준 / ## 파트너별 스코어카드 (표) / ## 종합 추천 / ## 리스크 섹션으로 구성.`,
+    outputFormat: "markdown",
+    maxTokens: 4096,
+  },
+  "ai-biz:feasibility-study": {
+    systemPrompt: `${BASE_SYSTEM}
+당신의 역할: AI 사업 타당성 분석 전문가.
+기술·시장·재무·조직 4축으로 타당성을 종합 평가합니다.
+산출물: ## 기술 타당성 / ## 시장 타당성 / ## 재무 타당성 / ## 조직 타당성 / ## Go/No-Go 권고 섹션으로 구성.`,
+    outputFormat: "markdown",
+    maxTokens: 4096,
+  },
+  "ai-biz:build-vs-buy": {
+    systemPrompt: `${BASE_SYSTEM}
+당신의 역할: Build vs Buy vs Partner 의사결정 전문가.
+자체 개발/구매/파트너십 옵션을 비용·시간·리스크·전략적 가치 관점에서 비교합니다.
+산출물: ## 옵션별 분석 (표) / ## 의사결정 매트릭스 / ## 추천 / ## 실행 로드맵 섹션으로 구성.`,
+    outputFormat: "markdown",
+    maxTokens: 4096,
+  },
+  "ai-biz:data-strategy": {
+    systemPrompt: `${BASE_SYSTEM}
+당신의 역할: 데이터 전략 전문가.
+데이터 확보/품질관리/파이프라인 구축/거버넌스 전략을 수립합니다.
+산출물: ## 현황 진단 / ## 데이터 확보 전략 / ## 파이프라인 설계 / ## 로드맵 섹션으로 구성.`,
+    outputFormat: "markdown",
+    maxTokens: 4096,
+  },
+  "ai-biz:cost-model": {
+    systemPrompt: `${BASE_SYSTEM}
+당신의 역할: AI 원가 분석 전문가.
+데이터·학습·추론·인프라 원가 구조를 상세 분석하고 마진을 시뮬레이션합니다.
+산출물: ## 원가 구조 (표) / ## 시나리오별 시뮬레이션 / ## 손익분기점 / ## 최적화 방안 섹션으로 구성.`,
+    outputFormat: "markdown",
+    maxTokens: 4096,
+  },
+  "ai-biz:regulation-check": {
+    systemPrompt: `${BASE_SYSTEM}
+당신의 역할: AI 규제/컴플라이언스 전문가.
+AI기본법, 산업별 규제, 윤리 가이드라인 준수 여부를 점검합니다.
+산출물: ## 적용 규제 목록 / ## 리스크 수준 (표) / ## 대응 방안 / ## 타임라인 섹션으로 구성.`,
+    outputFormat: "markdown",
+    maxTokens: 4096,
+  },
+  "ai-biz:ir-deck": {
+    systemPrompt: `${BASE_SYSTEM}
+당신의 역할: IR/경영진 보고서 전문가.
+투자심의 또는 경영진 보고용 핵심 요약을 구조화합니다.
+산출물: ## Executive Summary / ## 시장 기회 / ## 솔루션 / ## 비즈니스 모델 / ## 재무 전망 / ## Ask 섹션으로 구성.`,
+    outputFormat: "markdown",
+    maxTokens: 4096,
+  },
+  "ai-biz:pilot-design": {
+    systemPrompt: `${BASE_SYSTEM}
+당신의 역할: PoC/파일럿 설계 전문가.
+핵심 가설 검증을 위한 실험 설계와 성공 기준을 정의합니다.
+산출물: ## 핵심 가설 / ## 실험 설계 / ## 성공 기준 (KPI) / ## 타임라인 / ## 리소스 섹션으로 구성.`,
+    outputFormat: "markdown",
+    maxTokens: 4096,
+  },
+  "ai-biz:gtm-playbook": {
+    systemPrompt: `${BASE_SYSTEM}
+당신의 역할: Go-to-Market 전략가.
+타겟 고객·채널·가격·런칭 전략을 포함한 GTM 플레이북을 작성합니다.
+산출물: ## 타겟 시장 / ## 포지셔닝 / ## 채널 전략 / ## 가격 전략 / ## 런칭 계획 섹션으로 구성.`,
+    outputFormat: "markdown",
+    maxTokens: 4096,
+  },
+
+  // === pm-skills (대표 6개) ===
+  "pm:persona": {
+    systemPrompt: `${BASE_SYSTEM}
+당신의 역할: 사용자 페르소나 전문가.
+타겟 사용자 그룹의 특성·행동·니즈·Pain Point를 구체적 페르소나로 정의합니다.
+산출물: ## 페르소나 프로필 / ## 행동 패턴 / ## 니즈 & Pain Point / ## 시나리오 섹션으로 구성.`,
+    outputFormat: "markdown",
+    maxTokens: 4096,
+  },
+  "pm:journey-map": {
+    systemPrompt: `${BASE_SYSTEM}
+당신의 역할: 고객 여정 맵 전문가.
+고객 경험의 단계별 터치포인트·감정·Pain Point·기회를 시각화합니다.
+산출물: ## 여정 단계 (표) / ## 터치포인트 / ## 감정 곡선 / ## 개선 기회 섹션으로 구성.`,
+    outputFormat: "markdown",
+    maxTokens: 4096,
+  },
+  "pm:jtbd": {
+    systemPrompt: `${BASE_SYSTEM}
+당신의 역할: JTBD (Jobs to Be Done) 전문가.
+고객이 해결하려는 핵심 Job을 Functional/Emotional/Social 차원에서 도출합니다.
+산출물: ## 핵심 Job 정의 / ## Job Map (단계별) / ## 미충족 니즈 / ## 기회 영역 섹션으로 구성.`,
+    outputFormat: "markdown",
+    maxTokens: 4096,
+  },
+  "pm:value-proposition": {
+    systemPrompt: `${BASE_SYSTEM}
+당신의 역할: Value Proposition Canvas 전문가.
+고객 세그먼트의 Job/Pain/Gain과 제품의 Pain Reliever/Gain Creator를 매핑합니다.
+산출물: ## Customer Profile / ## Value Map / ## Fit 분석 / ## 차별화 포인트 섹션으로 구성.`,
+    outputFormat: "markdown",
+    maxTokens: 4096,
+  },
+  "pm:lean-canvas": {
+    systemPrompt: `${BASE_SYSTEM}
+당신의 역할: Lean Canvas 전문가.
+9블록 Lean Canvas를 작성하여 비즈니스 모델 가설을 구조화합니다.
+산출물: Lean Canvas 9블록 (Problem/Solution/Key Metrics/UVP/Unfair Advantage/Channels/Customer Segments/Cost Structure/Revenue Streams) 각각을 상세 작성.`,
+    outputFormat: "markdown",
+    maxTokens: 4096,
+  },
+  "pm:market-sizing": {
+    systemPrompt: `${BASE_SYSTEM}
+당신의 역할: 시장 규모 분석 전문가.
+TAM/SAM/SOM을 Top-down과 Bottom-up 방식으로 추정합니다.
+산출물: ## TAM / ## SAM / ## SOM / ## 성장률 전망 / ## 추정 근거 섹션으로 구성.`,
+    outputFormat: "markdown",
+    maxTokens: 4096,
+  },
+
+  // === management (대표 3개) ===
+  "mgmt:swot": {
+    systemPrompt: `${BASE_SYSTEM}
+당신의 역할: SWOT 분석 전문가.
+내부 강점/약점과 외부 기회/위협을 체계적으로 분석합니다.
+산출물: ## SWOT 매트릭스 (표) / ## SO 전략 / ## WO 전략 / ## ST 전략 / ## WT 전략 섹션으로 구성.`,
+    outputFormat: "markdown",
+    maxTokens: 4096,
+  },
+  "mgmt:porter-five": {
+    systemPrompt: `${BASE_SYSTEM}
+당신의 역할: Porter's Five Forces 분석 전문가.
+산업 경쟁 구조를 5가지 힘(신규진입/대체재/공급자교섭/구매자교섭/기존경쟁)으로 분석합니다.
+산출물: ## 5 Forces 요약 (표) / ## 각 Force 상세 분석 / ## 산업 매력도 / ## 전략 시사점 섹션으로 구성.`,
+    outputFormat: "markdown",
+    maxTokens: 4096,
+  },
+  "mgmt:pestel": {
+    systemPrompt: `${BASE_SYSTEM}
+당신의 역할: PESTEL 분석 전문가.
+정치·경제·사회·기술·환경·법률 6가지 거시환경 요소를 분석합니다.
+산출물: ## PESTEL 요약 (표) / ## 각 요소 상세 분석 / ## 핵심 영향 요인 / ## 시사점 섹션으로 구성.`,
+    outputFormat: "markdown",
+    maxTokens: 4096,
+  },
+};
+
+/** 지원되는 스킬 ID 목록 반환 */
+export function getSupportedSkillIds(): string[] {
+  return Object.keys(SKILL_PROMPT_MAP);
+}
+
+/** 스킬 ID로 프롬프트 정의 조회. 미지원 스킬이면 null 반환. */
+export function getSkillPrompt(skillId: string): SkillPromptDef | null {
+  return SKILL_PROMPT_MAP[skillId] ?? null;
+}

--- a/packages/fx-shaping/src/services/biz-persona-evaluator.ts
+++ b/packages/fx-shaping/src/services/biz-persona-evaluator.ts
@@ -1,0 +1,407 @@
+/**
+ * Sprint 51 F178: 멀티 페르소나 사업성 평가기 (BizPersonaEvaluator)
+ * 8개 KT DS 역할 페르소나가 Promise.allSettled로 병렬 평가.
+ * 최소 5/8 성공 시 판정 가능. G/K/R 비즈니스 규칙으로 최종 판정.
+ */
+import type { AgentRunner } from "../agent/services/agent-runner.js";
+import type { AgentExecutionResult } from "../agent/services/execution-types.js";
+import {
+  type BizItem,
+  type Classification,
+  type BizPersona,
+  BIZ_PERSONAS,
+  buildEvaluationPrompt,
+  buildPrdEvaluationPrompt,
+} from "./biz-persona-prompts.js";
+
+export type { BizItem, Classification } from "./biz-persona-prompts.js";
+
+export type Verdict = "green" | "keep" | "red";
+
+const SCORE_KEYS = [
+  "businessViability",
+  "strategicFit",
+  "customerValue",
+  "techMarket",
+  "execution",
+  "financialFeasibility",
+  "competitiveDiff",
+  "scalability",
+] as const;
+
+export interface EvaluationScoreData {
+  personaId: string;
+  personaName: string;
+  businessViability: number;
+  strategicFit: number;
+  customerValue: number;
+  techMarket: number;
+  execution: number;
+  financialFeasibility: number;
+  competitiveDiff: number;
+  scalability: number;
+  summary: string;
+  concerns: string[];
+}
+
+export interface EvaluationResult {
+  verdict: Verdict;
+  avgScore: number;
+  totalConcerns: number;
+  scores: EvaluationScoreData[];
+  warnings: string[];
+}
+
+export const MIN_SUCCESS_COUNT = 5;
+
+export class BizPersonaEvaluator {
+  constructor(
+    private runner: AgentRunner,
+    private db: D1Database,
+  ) {}
+
+  async evaluate(item: BizItem, classification: Classification): Promise<EvaluationResult> {
+    const settled = await Promise.allSettled(
+      BIZ_PERSONAS.map((persona) => this.evaluateWithPersona(persona, item, classification)),
+    );
+
+    const scores: EvaluationScoreData[] = [];
+    const failures: string[] = [];
+
+    for (let i = 0; i < settled.length; i++) {
+      const result = settled[i]!;
+      const persona = BIZ_PERSONAS[i]!;
+      if (result.status === "fulfilled") {
+        scores.push(result.value);
+      } else {
+        failures.push(
+          `${persona.name}(${persona.id}): ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`,
+        );
+      }
+    }
+
+    if (scores.length < MIN_SUCCESS_COUNT) {
+      throw new EvaluationError(
+        `Insufficient successful evaluations: ${scores.length}/${BIZ_PERSONAS.length} (minimum ${MIN_SUCCESS_COUNT} required). Failures: ${failures.join("; ")}`,
+        "INSUFFICIENT_EVALUATIONS",
+      );
+    }
+
+    const { verdict, avgScore, totalConcerns, warnings } = this.aggregateAndVerdict(scores);
+
+    return { verdict, avgScore, totalConcerns, scores, warnings };
+  }
+
+  private async evaluateWithPersona(
+    persona: BizPersona,
+    item: BizItem,
+    classification: Classification,
+  ): Promise<EvaluationScoreData> {
+    const prompt = buildEvaluationPrompt(persona, item, classification);
+
+    const result: AgentExecutionResult = await this.runner.execute({
+      taskId: `eval-${persona.id}-${item.id}`,
+      agentId: `biz-persona-${persona.id}`,
+      taskType: "policy-evaluation",
+      context: {
+        repoUrl: "",
+        branch: "",
+        instructions: prompt,
+        systemPromptOverride: persona.systemPrompt,
+      },
+      constraints: [],
+    });
+
+    if (result.status === "failed") {
+      throw new Error(`Persona ${persona.id} execution failed`);
+    }
+
+    const rawText = result.output.analysis ?? "";
+    return this.parseScoreResponse(rawText, persona);
+  }
+
+  private parseScoreResponse(rawText: string, persona: BizPersona): EvaluationScoreData {
+    let jsonStr = rawText.trim();
+    const codeBlockMatch = jsonStr.match(/```(?:json)?\s*([\s\S]*?)```/);
+    if (codeBlockMatch) {
+      jsonStr = codeBlockMatch[1]!.trim();
+    }
+
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(jsonStr);
+    } catch {
+      throw new Error(`Failed to parse ${persona.id} response as JSON`);
+    }
+
+    const scoreData: EvaluationScoreData = {
+      personaId: persona.id,
+      personaName: persona.name,
+      businessViability: this.clampScore(parsed.businessViability),
+      strategicFit: this.clampScore(parsed.strategicFit),
+      customerValue: this.clampScore(parsed.customerValue),
+      techMarket: this.clampScore(parsed.techMarket),
+      execution: this.clampScore(parsed.execution),
+      financialFeasibility: this.clampScore(parsed.financialFeasibility),
+      competitiveDiff: this.clampScore(parsed.competitiveDiff),
+      scalability: this.clampScore(parsed.scalability),
+      summary: String(parsed.summary ?? ""),
+      concerns: Array.isArray(parsed.concerns)
+        ? parsed.concerns.map(String)
+        : [],
+    };
+
+    return scoreData;
+  }
+
+  private clampScore(value: unknown): number {
+    const num = Number(value);
+    if (isNaN(num)) return 5; // fallback to neutral
+    return Math.max(1, Math.min(10, Math.round(num)));
+  }
+
+  private aggregateAndVerdict(scores: EvaluationScoreData[]): {
+    verdict: Verdict;
+    avgScore: number;
+    totalConcerns: number;
+    warnings: string[];
+  } {
+    // Calculate average across all personas and all 8 axes
+    let totalScore = 0;
+    let scoreCount = 0;
+    let totalConcerns = 0;
+    const warnings: string[] = [];
+
+    // Track per-axis scores for warning detection
+    const axisScores: Record<string, number[]> = {};
+    for (const key of SCORE_KEYS) {
+      axisScores[key] = [];
+    }
+
+    for (const score of scores) {
+      for (const key of SCORE_KEYS) {
+        const val = score[key];
+        totalScore += val;
+        scoreCount++;
+        axisScores[key]!.push(val);
+      }
+      totalConcerns += score.concerns.length;
+    }
+
+    const avgScore = scoreCount > 0 ? Math.round((totalScore / scoreCount) * 100) / 100 : 0;
+
+    // Warning: 3+ personas scored <= 3 on a specific axis
+    for (const key of SCORE_KEYS) {
+      const lowCount = axisScores[key]!.filter((v) => v <= 3).length;
+      if (lowCount >= 3) {
+        warnings.push(`${key}: ${lowCount}개 페르소나가 3점 이하 평가`);
+      }
+    }
+
+    // G/K/R base verdict
+    let verdict: Verdict;
+    if (avgScore < 5.0 || totalConcerns >= 6) {
+      verdict = "red";
+    } else if (avgScore >= 7.0 && totalConcerns <= 2) {
+      verdict = "green";
+    } else {
+      verdict = "keep";
+    }
+
+    // Override: if both strategy and finance scored < 5 avg, downgrade to keep
+    if (verdict === "green") {
+      const strategyScore = scores.find((s) => s.personaId === "strategy");
+      const financeScore = scores.find((s) => s.personaId === "finance");
+      if (strategyScore && financeScore) {
+        const stratAvg = this.personaAvg(strategyScore);
+        const finAvg = this.personaAvg(financeScore);
+        if (stratAvg < 5 && finAvg < 5) {
+          verdict = "keep";
+          warnings.push("전략기획+경영기획 평균 5점 미만으로 Green→Keep 하향 조정");
+        }
+      }
+    }
+
+    return { verdict, avgScore, totalConcerns, warnings };
+  }
+
+  async evaluatePrd(
+    item: BizItem,
+    prdContent: string,
+  ): Promise<EvaluationResult> {
+    const settled = await Promise.allSettled(
+      BIZ_PERSONAS.map((persona) => this.evaluatePersonaWithPrd(persona, item, prdContent)),
+    );
+
+    const scores: EvaluationScoreData[] = [];
+    const failures: string[] = [];
+
+    for (let i = 0; i < settled.length; i++) {
+      const result = settled[i]!;
+      const persona = BIZ_PERSONAS[i]!;
+      if (result.status === "fulfilled") {
+        scores.push(result.value);
+      } else {
+        failures.push(
+          `${persona.name}(${persona.id}): ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`,
+        );
+      }
+    }
+
+    if (scores.length < MIN_SUCCESS_COUNT) {
+      throw new EvaluationError(
+        `Insufficient PRD evaluations: ${scores.length}/${BIZ_PERSONAS.length} (minimum ${MIN_SUCCESS_COUNT} required). Failures: ${failures.join("; ")}`,
+        "INSUFFICIENT_EVALUATIONS",
+      );
+    }
+
+    const { verdict, avgScore, totalConcerns, warnings } = this.aggregateAndVerdict(scores);
+    return { verdict, avgScore, totalConcerns, scores, warnings };
+  }
+
+  private async evaluatePersonaWithPrd(
+    persona: BizPersona,
+    item: BizItem,
+    prdContent: string,
+  ): Promise<EvaluationScoreData> {
+    const prompt = buildPrdEvaluationPrompt(persona, item, prdContent);
+
+    const result: AgentExecutionResult = await this.runner.execute({
+      taskId: `prd-eval-${persona.id}-${item.id}`,
+      agentId: `biz-persona-${persona.id}`,
+      taskType: "policy-evaluation",
+      context: {
+        repoUrl: "",
+        branch: "",
+        instructions: prompt,
+        systemPromptOverride: persona.systemPrompt,
+      },
+      constraints: [],
+    });
+
+    if (result.status === "failed") {
+      throw new Error(`Persona ${persona.id} PRD evaluation failed`);
+    }
+
+    const rawText = result.output.analysis ?? "";
+    return this.parseScoreResponse(rawText, persona);
+  }
+
+  private personaAvg(score: EvaluationScoreData): number {
+    let total = 0;
+    for (const key of SCORE_KEYS) {
+      total += score[key];
+    }
+    return total / SCORE_KEYS.length;
+  }
+}
+
+export class EvaluationError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+  ) {
+    super(message);
+    this.name = "EvaluationError";
+  }
+}
+
+function generateId(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes).map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+export async function savePrdPersonaEvaluations(
+  db: D1Database,
+  prdId: string,
+  bizItemId: string,
+  orgId: string,
+  result: EvaluationResult,
+): Promise<string> {
+  for (const score of result.scores) {
+    const id = generateId();
+    await db
+      .prepare(
+        `INSERT INTO prd_persona_evaluations
+         (id, prd_id, biz_item_id, persona_id, persona_name,
+          business_viability, strategic_fit, customer_value, tech_market,
+          execution, financial_feasibility, competitive_diff, scalability,
+          summary, concerns, org_id)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        id, prdId, bizItemId, score.personaId, score.personaName,
+        score.businessViability, score.strategicFit, score.customerValue,
+        score.techMarket, score.execution, score.financialFeasibility,
+        score.competitiveDiff, score.scalability,
+        score.summary, JSON.stringify(score.concerns), orgId,
+      )
+      .run();
+  }
+
+  const verdictId = generateId();
+  await db
+    .prepare(
+      `INSERT INTO prd_persona_verdicts
+       (id, prd_id, verdict, avg_score, total_concerns, warnings, evaluation_count)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(
+      verdictId, prdId, result.verdict, result.avgScore,
+      result.totalConcerns, JSON.stringify(result.warnings),
+      result.scores.length,
+    )
+    .run();
+
+  return verdictId;
+}
+
+export async function getPrdPersonaEvaluations(
+  db: D1Database,
+  prdId: string,
+): Promise<{
+  evaluations: EvaluationScoreData[];
+  verdict: { verdict: string; avgScore: number; totalConcerns: number; warnings: string[] } | null;
+}> {
+  const { results: evalRows } = await db
+    .prepare(
+      `SELECT persona_id, persona_name,
+              business_viability, strategic_fit, customer_value, tech_market,
+              execution, financial_feasibility, competitive_diff, scalability,
+              summary, concerns
+       FROM prd_persona_evaluations WHERE prd_id = ? ORDER BY persona_id`,
+    )
+    .bind(prdId)
+    .all();
+
+  const verdictRow = await db
+    .prepare("SELECT verdict, avg_score, total_concerns, warnings FROM prd_persona_verdicts WHERE prd_id = ? ORDER BY created_at DESC LIMIT 1")
+    .bind(prdId)
+    .first<{ verdict: string; avg_score: number; total_concerns: number; warnings: string }>();
+
+  return {
+    evaluations: evalRows.map((r: Record<string, unknown>) => ({
+      personaId: r.persona_id as string,
+      personaName: r.persona_name as string,
+      businessViability: r.business_viability as number,
+      strategicFit: r.strategic_fit as number,
+      customerValue: r.customer_value as number,
+      techMarket: r.tech_market as number,
+      execution: r.execution as number,
+      financialFeasibility: r.financial_feasibility as number,
+      competitiveDiff: r.competitive_diff as number,
+      scalability: r.scalability as number,
+      summary: r.summary as string,
+      concerns: JSON.parse(r.concerns as string),
+    })),
+    verdict: verdictRow
+      ? {
+          verdict: verdictRow.verdict,
+          avgScore: verdictRow.avg_score,
+          totalConcerns: verdictRow.total_concerns,
+          warnings: JSON.parse(verdictRow.warnings),
+        }
+      : null,
+  };
+}

--- a/packages/fx-shaping/src/services/biz-persona-prompts.ts
+++ b/packages/fx-shaping/src/services/biz-persona-prompts.ts
@@ -1,0 +1,186 @@
+/**
+ * Sprint 51 F178: 8개 KT DS 역할 페르소나 정의 + 평가 프롬프트 빌더
+ */
+
+export interface BizPersona {
+  id: string;
+  name: string;
+  role: string;
+  focus: string[];
+  systemPrompt: string;
+}
+
+export interface BizItem {
+  id: string;
+  title: string;
+  description: string | null;
+  source: string;
+  status: string;
+  orgId: string;
+  createdBy: string;
+}
+
+export interface Classification {
+  itemType: "type_a" | "type_b" | "type_c";
+  confidence: number;
+  analysisWeights: Record<string, number>;
+}
+
+export const BIZ_PERSONAS: BizPersona[] = [
+  {
+    id: "strategy",
+    name: "전략기획팀장",
+    role: "KT DS 전략기획팀장 (15년차)",
+    focus: ["전략적합성", "시장규모", "성장잠재력"],
+    systemPrompt: `당신은 KT DS 전략기획팀장입니다. 15년간 SI/SM 사업의 전략 수립과 신사업 기획을 담당해왔습니다.
+평가 관점: KT DS의 중장기 전략과의 정합성, 시장 규모와 성장성, 기존 사업과의 시너지.
+주요 질문: "이 사업이 KT DS의 3개년 전략 방향과 맞는가?", "시장이 충분히 크고 성장하는가?"`,
+  },
+  {
+    id: "sales",
+    name: "영업총괄부장",
+    role: "KT DS 영업총괄부장 (20년차)",
+    focus: ["수주확보 가능성", "기존고객 확장", "영업난이도"],
+    systemPrompt: `당신은 KT DS 영업총괄부장입니다. 20년간 B2B/B2G 영업 현장에서 일해왔습니다.
+평가 관점: 실제 수주 가능성, 기존 고객 확장 여부, 영업 사이클과 난이도.
+주요 질문: "지금 파이프라인에 이걸 넣을 고객이 있는가?", "단가와 계약 구조가 현실적인가?"`,
+  },
+  {
+    id: "ap_biz",
+    name: "AP사업본부장",
+    role: "KT DS AP사업본부장 (18년차)",
+    focus: ["기술실현 가능성", "자원투입비", "타임라인"],
+    systemPrompt: `당신은 KT DS AP사업본부장입니다. 18년간 어플리케이션 개발 사업을 총괄해왔습니다.
+평가 관점: 기술적 실현 가능성, 필요 인력과 비용, 개발 타임라인.
+주요 질문: "우리 기술 역량으로 만들 수 있는가?", "필요 인력과 기간이 현실적인가?"`,
+  },
+  {
+    id: "ai_tech",
+    name: "AI기술본부장",
+    role: "KT DS AI기술본부장 (12년차)",
+    focus: ["기술차별성", "AI 적합성", "데이터 확보"],
+    systemPrompt: `당신은 KT DS AI기술본부장입니다. 12년간 AI/ML 연구개발과 사업화를 이끌어왔습니다.
+평가 관점: AI 기술 차별성, 데이터 확보 가능성, 기술 성숙도.
+주요 질문: "AI가 정말 핵심 가치인가 장식인가?", "학습 데이터를 확보할 수 있는가?"`,
+  },
+  {
+    id: "finance",
+    name: "경영기획팀장",
+    role: "KT DS 경영기획팀장 (15년차)",
+    focus: ["재무타당성", "ROI", "투자회수기간"],
+    systemPrompt: `당신은 KT DS 경영기획팀장입니다. 15년간 사업 투자 심의와 손익 관리를 담당해왔습니다.
+평가 관점: 투자 대비 수익성, BEP 도달 시점, 리스크 대비 기대 수익.
+주요 질문: "투자금 회수까지 몇 년인가?", "손익분기점이 현실적인가?"`,
+  },
+  {
+    id: "security",
+    name: "보안전략팀장",
+    role: "KT DS 보안전략팀장 (13년차)",
+    focus: ["보안위험", "컴플라이언스", "데이터 거버넌스"],
+    systemPrompt: `당신은 KT DS 보안전략팀장입니다. 13년간 정보보안 전략과 컴플라이언스를 관리해왔습니다.
+평가 관점: 보안 위험, 개인정보 처리, 규제 준수, 고객 데이터 관리.
+주요 질문: "개인정보 이슈가 있는가?", "보안 인증이 필요한가?"`,
+  },
+  {
+    id: "partnership",
+    name: "대외협력팀장",
+    role: "KT DS 대외협력팀장 (14년차)",
+    focus: ["파트너십", "규제환경", "시장진입 장벽"],
+    systemPrompt: `당신은 KT DS 대외협력팀장입니다. 14년간 파트너 발굴, 제휴, 규제 대응을 총괄해왔습니다.
+평가 관점: 파트너십 필요성, 규제 환경, 진입 장벽, 생태계 구축 가능성.
+주요 질문: "핵심 파트너가 있는가?", "규제나 인허가 이슈는?"`,
+  },
+  {
+    id: "product",
+    name: "기술사업화PM",
+    role: "KT DS 기술사업화PM (10년차)",
+    focus: ["사업화 실행력", "리스크", "MVP 가능성"],
+    systemPrompt: `당신은 KT DS 기술사업화PM입니다. 10년간 기술을 사업으로 전환하는 일을 해왔습니다.
+평가 관점: MVP 구축 가능성, Go-to-Market 실행력, 리스크 관리.
+주요 질문: "3개월 내 MVP를 만들 수 있는가?", "첫 고객을 어떻게 확보하는가?"`,
+  },
+];
+
+export function buildEvaluationPrompt(
+  persona: BizPersona,
+  item: BizItem,
+  classification: Classification,
+): string {
+  return `${persona.systemPrompt}
+
+다음 사업 아이템을 평가해주세요.
+
+[사업 아이템]
+제목: ${item.title}
+설명: ${item.description ?? "(설명 없음)"}
+유형: ${classification.itemType} (신뢰도: ${classification.confidence})
+
+[평가 기준 - 각 항목 1~10점]
+1. 사업성/사업타당성 (businessViability)
+2. 전략적합성 (strategicFit)
+3. 고객가치 (customerValue)
+4. 기술시장성 (techMarket)
+5. 실행력/리스크 (execution)
+6. 재무타당성 (financialFeasibility)
+7. 경쟁차별화 (competitiveDiff)
+8. 확장가능성 (scalability)
+
+[출력 형식] 반드시 아래 JSON 형식으로만 응답하세요. JSON 외 텍스트를 포함하지 마세요.
+{
+  "businessViability": <1-10>,
+  "strategicFit": <1-10>,
+  "customerValue": <1-10>,
+  "techMarket": <1-10>,
+  "execution": <1-10>,
+  "financialFeasibility": <1-10>,
+  "competitiveDiff": <1-10>,
+  "scalability": <1-10>,
+  "summary": "<200자 이내 핵심 소견>",
+  "concerns": ["<주요 쟁점 1>", "<주요 쟁점 2>"]
+}`;
+}
+
+export function buildPrdEvaluationPrompt(
+  persona: BizPersona,
+  item: BizItem,
+  prdContent: string,
+): string {
+  const trimmedPrd = prdContent.length > 6000
+    ? prdContent.slice(0, 3000) + "\n\n[...중략...]\n\n" + prdContent.slice(-3000)
+    : prdContent;
+
+  return `${persona.systemPrompt}
+
+다음 사업 아이템의 PRD를 검토하고 평가해주세요.
+
+[사업 아이템]
+제목: ${item.title}
+설명: ${item.description ?? "(설명 없음)"}
+
+[PRD 전문]
+${trimmedPrd}
+
+[평가 기준 - 각 항목 1~10점]
+1. 사업성/사업타당성 (businessViability)
+2. 전략적합성 (strategicFit)
+3. 고객가치 (customerValue)
+4. 기술시장성 (techMarket)
+5. 실행력/리스크 (execution)
+6. 재무타당성 (financialFeasibility)
+7. 경쟁차별화 (competitiveDiff)
+8. 확장가능성 (scalability)
+
+[출력 형식] 반드시 아래 JSON 형식으로만 응답하세요. JSON 외 텍스트를 포함하지 마세요.
+{
+  "businessViability": <1-10>,
+  "strategicFit": <1-10>,
+  "customerValue": <1-10>,
+  "techMarket": <1-10>,
+  "execution": <1-10>,
+  "financialFeasibility": <1-10>,
+  "competitiveDiff": <1-10>,
+  "scalability": <1-10>,
+  "summary": "<200자 이내 핵심 소견>",
+  "concerns": ["<주요 쟁점 1>", "<주요 쟁점 2>"]
+}`;
+}

--- a/packages/fx-shaping/src/services/bmc-agent.ts
+++ b/packages/fx-shaping/src/services/bmc-agent.ts
@@ -1,0 +1,134 @@
+/**
+ * F199: BMCAgent — 아이디어 텍스트를 받아 BMC 9개 블록 초안을 LLM으로 생성
+ */
+import { PromptGatewayService } from "../agent/services/prompt-gateway.js";
+import { ModelRouter } from "../agent/services/model-router.js";
+import { BMC_BLOCK_TYPES } from "./bmc-service.js";
+
+export interface BmcDraftResult {
+  draft: Record<string, string>;
+  processingTimeMs: number;
+  model: string;
+  masked: boolean;
+}
+
+const SYSTEM_PROMPT = `You are a Business Model Canvas (BMC) expert. Given a business idea, generate content for all 9 BMC blocks.
+
+Return ONLY a valid JSON object with these exact keys:
+- customer_segments
+- value_propositions
+- channels
+- customer_relationships
+- revenue_streams
+- key_resources
+- key_activities
+- key_partnerships
+- cost_structure
+
+Each value must be a string of max 200 characters describing the block for the given idea.
+Write in the same language as the input. Return ONLY the JSON object, no markdown or explanation.`;
+
+export class BmcAgentService {
+  private db: D1Database;
+  private anthropicApiKey: string;
+
+  constructor(db: D1Database, anthropicApiKey: string) {
+    this.db = db;
+    this.anthropicApiKey = anthropicApiKey;
+  }
+
+  async generateDraft(
+    idea: string,
+    context?: string,
+    tenantId?: string,
+  ): Promise<BmcDraftResult> {
+    const startTime = Date.now();
+
+    // 1. Sanitize prompt via PromptGateway
+    const gateway = new PromptGatewayService(this.db);
+    const userPrompt = context
+      ? `Idea: ${idea}\nContext: ${context}`
+      : `Idea: ${idea}`;
+    const sanitizeResult = await gateway.sanitizePrompt(userPrompt, tenantId);
+
+    if (!sanitizeResult.sanitizedContent) {
+      throw new Error("GATEWAY_NOT_PROCESSED");
+    }
+
+    // 2. Determine model via ModelRouter
+    const router = new ModelRouter(this.db);
+    const routingRule = await router.getModelForTask("bmc-generation");
+    const modelId = routingRule.modelId.replace("anthropic/", "");
+
+    // 3. Call Anthropic Messages API with 15s timeout
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 15_000);
+
+    let response: Response;
+    try {
+      response = await fetch("https://api.anthropic.com/v1/messages", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-api-key": this.anthropicApiKey,
+          "anthropic-version": "2023-06-01",
+        },
+        body: JSON.stringify({
+          model: modelId,
+          max_tokens: 1024,
+          system: SYSTEM_PROMPT,
+          messages: [{ role: "user", content: sanitizeResult.sanitizedContent }],
+        }),
+        signal: controller.signal,
+      });
+    } catch (err: unknown) {
+      clearTimeout(timeout);
+      if (err instanceof Error && err.name === "AbortError") {
+        throw new Error("LLM_TIMEOUT");
+      }
+      throw err;
+    }
+    clearTimeout(timeout);
+
+    if (!response.ok) {
+      throw new Error("LLM_PARSE_ERROR");
+    }
+
+    // 4. Parse response
+    const body = await response.json() as {
+      content?: Array<{ type: string; text?: string }>;
+    };
+
+    const textBlock = body.content?.find((c) => c.type === "text");
+    if (!textBlock?.text) {
+      throw new Error("LLM_PARSE_ERROR");
+    }
+
+    const draft = parseBlocks(textBlock.text);
+
+    return {
+      draft,
+      processingTimeMs: Date.now() - startTime,
+      model: routingRule.modelId,
+      masked: sanitizeResult.appliedRules.length > 0,
+    };
+  }
+}
+
+/** Parse LLM JSON output into 9 BMC blocks, trimming each to 200 chars */
+export function parseBlocks(text: string): Record<string, string> {
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error("LLM_PARSE_ERROR");
+  }
+
+  const result: Record<string, string> = {};
+  for (const key of BMC_BLOCK_TYPES) {
+    const value = parsed[key];
+    const str = typeof value === "string" ? value : "";
+    result[key] = str.slice(0, 200);
+  }
+  return result;
+}

--- a/packages/fx-shaping/src/services/bmc-comment-service.ts
+++ b/packages/fx-shaping/src/services/bmc-comment-service.ts
@@ -1,0 +1,165 @@
+import { BMC_BLOCK_TYPES } from "./bmc-service.js";
+
+// ─── DB Row 타입 ───
+interface CommentRow {
+  id: string;
+  bmc_id: string;
+  block_type: string | null;
+  author_id: string;
+  content: string;
+  created_at: number;
+}
+
+// ─── API 타입 ───
+export interface BmcComment {
+  id: string;
+  bmcId: string;
+  blockType: string | null;
+  authorId: string;
+  content: string;
+  createdAt: number;
+}
+
+// ─── 변환 헬퍼 ───
+function toComment(row: CommentRow): BmcComment {
+  return {
+    id: row.id,
+    bmcId: row.bmc_id,
+    blockType: row.block_type,
+    authorId: row.author_id,
+    content: row.content,
+    createdAt: row.created_at,
+  };
+}
+
+export class BmcCommentService {
+  constructor(private db: D1Database) {}
+
+  async createComment(
+    bmcId: string,
+    authorId: string,
+    content: string,
+    blockType?: string
+  ): Promise<BmcComment> {
+    // BMC 존재 확인
+    const bmc = await this.db
+      .prepare("SELECT id FROM ax_bmcs WHERE id = ? AND is_deleted = 0")
+      .bind(bmcId)
+      .first();
+    if (!bmc) throw new NotFoundError("BMC not found");
+
+    // blockType 유효성 검증
+    if (blockType && !(BMC_BLOCK_TYPES as readonly string[]).includes(blockType)) {
+      throw new ValidationError(`Invalid block type: ${blockType}`);
+    }
+
+    const id = crypto.randomUUID();
+    const now = Date.now();
+
+    await this.db
+      .prepare(
+        `INSERT INTO ax_bmc_comments (id, bmc_id, block_type, author_id, content, created_at)
+         VALUES (?, ?, ?, ?, ?, ?)`
+      )
+      .bind(id, bmcId, blockType ?? null, authorId, content, now)
+      .run();
+
+    // @멘션 파싱 (알림 연동은 Phase 1 scope 외 — 추후 NotificationService 연동)
+    const _mentions = this.parseMentions(content);
+
+    return { id, bmcId, blockType: blockType ?? null, authorId, content, createdAt: now };
+  }
+
+  async getComments(
+    bmcId: string,
+    blockType?: string,
+    limit = 20,
+    offset = 0
+  ): Promise<{ comments: BmcComment[]; total: number }> {
+    const whereClause = blockType
+      ? "WHERE bmc_id = ? AND block_type = ?"
+      : "WHERE bmc_id = ?";
+
+    const binds = blockType ? [bmcId, blockType] : [bmcId];
+
+    const stmt = this.db.prepare(
+      `SELECT * FROM ax_bmc_comments ${whereClause} ORDER BY created_at DESC LIMIT ? OFFSET ?`
+    );
+    const { results } = await stmt.bind(...binds, limit, offset).all<CommentRow>();
+
+    const countStmt = this.db.prepare(
+      `SELECT COUNT(*) as total FROM ax_bmc_comments ${whereClause}`
+    );
+    const countRow = await countStmt.bind(...binds).first<{ total: number }>();
+
+    return {
+      comments: (results ?? []).map(toComment),
+      total: countRow?.total ?? 0,
+    };
+  }
+
+  async deleteComment(commentId: string, userId: string): Promise<void> {
+    const row = await this.db
+      .prepare("SELECT * FROM ax_bmc_comments WHERE id = ?")
+      .bind(commentId)
+      .first<CommentRow>();
+
+    if (!row) throw new NotFoundError("Comment not found");
+    if (row.author_id !== userId) throw new ForbiddenError("Cannot delete another user's comment");
+
+    await this.db
+      .prepare("DELETE FROM ax_bmc_comments WHERE id = ?")
+      .bind(commentId)
+      .run();
+  }
+
+  async getCommentCounts(bmcId: string): Promise<Record<string, number>> {
+    const { results } = await this.db
+      .prepare(
+        `SELECT block_type, COUNT(*) as count FROM ax_bmc_comments
+         WHERE bmc_id = ? GROUP BY block_type`
+      )
+      .bind(bmcId)
+      .all<{ block_type: string | null; count: number }>();
+
+    const counts: Record<string, number> = {};
+    let total = 0;
+
+    for (const row of results ?? []) {
+      const key = row.block_type ?? "_general";
+      counts[key] = row.count;
+      total += row.count;
+    }
+
+    counts._total = total;
+    return counts;
+  }
+
+  private parseMentions(content: string): string[] {
+    const matches = content.match(/@(\w+)/g);
+    if (!matches) return [];
+    return matches.map((m) => m.slice(1));
+  }
+}
+
+// ─── 에러 클래스 ───
+export class NotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NotFoundError";
+  }
+}
+
+export class ForbiddenError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ForbiddenError";
+  }
+}
+
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ValidationError";
+  }
+}

--- a/packages/fx-shaping/src/services/bmc-history.ts
+++ b/packages/fx-shaping/src/services/bmc-history.ts
@@ -1,0 +1,80 @@
+import type { BmcVersion, BmcSnapshot } from "../schemas/bmc-history.schema.js";
+
+// ─── DB Row 타입 ───
+interface BmcVersionRow {
+  id: string;
+  bmc_id: string;
+  commit_sha: string;
+  author_id: string;
+  message: string;
+  snapshot: string;
+  created_at: string;
+}
+
+// ─── 변환 헬퍼 ───
+function toVersion(row: BmcVersionRow): BmcVersion {
+  return {
+    id: row.id,
+    bmcId: row.bmc_id,
+    commitSha: row.commit_sha,
+    authorId: row.author_id,
+    message: row.message,
+    createdAt: row.created_at,
+  };
+}
+
+export class BmcHistoryService {
+  constructor(private db: D1Database) {}
+
+  async recordVersion(
+    bmcId: string,
+    authorId: string,
+    message: string,
+    blocks: Record<string, string | null>,
+    commitSha?: string
+  ): Promise<BmcVersion> {
+    const id = crypto.randomUUID();
+    const sha = commitSha ?? crypto.randomUUID().slice(0, 8);
+    const snapshot = JSON.stringify(blocks);
+    const createdAt = new Date().toISOString().replace("T", " ").slice(0, 19);
+
+    await this.db
+      .prepare(
+        `INSERT INTO ax_bmc_versions (id, bmc_id, commit_sha, author_id, message, snapshot, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(id, bmcId, sha, authorId, message, snapshot, createdAt)
+      .run();
+
+    return { id, bmcId, commitSha: sha, authorId, message, createdAt };
+  }
+
+  async getHistory(bmcId: string, limit = 20): Promise<BmcVersion[]> {
+    const { results } = await this.db
+      .prepare(
+        "SELECT * FROM ax_bmc_versions WHERE bmc_id = ? ORDER BY created_at DESC, rowid DESC LIMIT ?"
+      )
+      .bind(bmcId, limit)
+      .all<BmcVersionRow>();
+
+    return (results ?? []).map(toVersion);
+  }
+
+  async getVersion(bmcId: string, commitSha: string): Promise<BmcSnapshot | null> {
+    const row = await this.db
+      .prepare(
+        "SELECT * FROM ax_bmc_versions WHERE bmc_id = ? AND commit_sha = ?"
+      )
+      .bind(bmcId, commitSha)
+      .first<BmcVersionRow>();
+
+    if (!row) return null;
+
+    const blocks = JSON.parse(row.snapshot) as Record<string, string | null>;
+    return { version: toVersion(row), blocks };
+  }
+
+  async restoreVersion(bmcId: string, commitSha: string): Promise<BmcSnapshot | null> {
+    return this.getVersion(bmcId, commitSha);
+  }
+}

--- a/packages/fx-shaping/src/services/bmc-insight-service.ts
+++ b/packages/fx-shaping/src/services/bmc-insight-service.ts
@@ -1,0 +1,143 @@
+/**
+ * F201: BMC Block Insights — BMC 블록별 개선 인사이트를 LLM으로 생성
+ */
+import { PromptGatewayService } from "../agent/services/prompt-gateway.js";
+import { ModelRouter } from "../agent/services/model-router.js";
+import type { AgentTaskType } from "../agent/services/execution-types.js";
+
+export interface BlockInsight {
+  title: string;
+  description: string;
+  suggestedContent: string;
+}
+
+export interface InsightResult {
+  insights: BlockInsight[];
+  processingTimeMs: number;
+  model: string;
+  masked: boolean;
+}
+
+const SYSTEM_PROMPT = `You are a Business Model Canvas (BMC) expert. Given a specific BMC block type and its current content, suggest 3 improvements.
+
+Return ONLY a valid JSON array with exactly 3 objects, each having:
+- "title": short improvement title (max 50 chars)
+- "description": why this improvement matters (max 200 chars)
+- "suggestedContent": improved content for the block (max 300 chars)
+
+Write in the same language as the input. Return ONLY the JSON array, no markdown or explanation.`;
+
+export class BmcInsightService {
+  private db: D1Database;
+  private anthropicApiKey: string;
+
+  constructor(db: D1Database, anthropicApiKey: string) {
+    this.db = db;
+    this.anthropicApiKey = anthropicApiKey;
+  }
+
+  async generateInsights(
+    blockType: string,
+    currentContent: string,
+    bmcContext?: Record<string, string>,
+    tenantId?: string,
+  ): Promise<InsightResult> {
+    const startTime = Date.now();
+
+    // 1. Sanitize prompt via PromptGateway
+    const gateway = new PromptGatewayService(this.db);
+    let userPrompt = `Block type: ${blockType}\nCurrent content: ${currentContent}`;
+    if (bmcContext) {
+      userPrompt += `\nBMC Context: ${JSON.stringify(bmcContext)}`;
+    }
+    const sanitizeResult = await gateway.sanitizePrompt(userPrompt, tenantId);
+
+    if (!sanitizeResult.sanitizedContent) {
+      throw new Error("GATEWAY_NOT_PROCESSED");
+    }
+
+    // 2. Determine model via ModelRouter
+    const router = new ModelRouter(this.db);
+    const taskType = "bmc-insight" as AgentTaskType;
+    let routingRule;
+    try {
+      routingRule = await router.getModelForTask(taskType);
+    } catch {
+      routingRule = await router.getModelForTask("bmc-generation");
+    }
+    const modelId = routingRule.modelId.replace("anthropic/", "");
+
+    // 3. Call Anthropic Messages API with 15s timeout
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 15_000);
+
+    let response: Response;
+    try {
+      response = await fetch("https://api.anthropic.com/v1/messages", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-api-key": this.anthropicApiKey,
+          "anthropic-version": "2023-06-01",
+        },
+        body: JSON.stringify({
+          model: modelId,
+          max_tokens: 1024,
+          system: SYSTEM_PROMPT,
+          messages: [{ role: "user", content: sanitizeResult.sanitizedContent }],
+        }),
+        signal: controller.signal,
+      });
+    } catch (err: unknown) {
+      clearTimeout(timeout);
+      if (err instanceof Error && err.name === "AbortError") {
+        throw new Error("LLM_TIMEOUT");
+      }
+      throw err;
+    }
+    clearTimeout(timeout);
+
+    if (!response.ok) {
+      throw new Error("LLM_PARSE_ERROR");
+    }
+
+    // 4. Parse response
+    const body = (await response.json()) as {
+      content?: Array<{ type: string; text?: string }>;
+    };
+
+    const textBlock = body.content?.find((c) => c.type === "text");
+    if (!textBlock?.text) {
+      throw new Error("LLM_PARSE_ERROR");
+    }
+
+    const insights = parseInsights(textBlock.text);
+
+    return {
+      insights,
+      processingTimeMs: Date.now() - startTime,
+      model: routingRule.modelId,
+      masked: sanitizeResult.appliedRules.length > 0,
+    };
+  }
+}
+
+/** Parse LLM JSON output into BlockInsight array */
+export function parseInsights(text: string): BlockInsight[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error("LLM_PARSE_ERROR");
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new Error("LLM_PARSE_ERROR");
+  }
+
+  return parsed.map((item: Record<string, unknown>) => ({
+    title: typeof item.title === "string" ? item.title.slice(0, 50) : "",
+    description: typeof item.description === "string" ? item.description.slice(0, 200) : "",
+    suggestedContent: typeof item.suggestedContent === "string" ? item.suggestedContent.slice(0, 300) : "",
+  }));
+}

--- a/packages/fx-shaping/src/services/bmc-service.ts
+++ b/packages/fx-shaping/src/services/bmc-service.ts
@@ -1,0 +1,209 @@
+// ─── DB Row 타입 ───
+interface BmcRow {
+  id: string;
+  idea_id: string | null;
+  title: string;
+  git_ref: string;
+  author_id: string;
+  org_id: string;
+  sync_status: "synced" | "pending" | "failed";
+  is_deleted: number; // 0 | 1
+  created_at: number;
+  updated_at: number;
+}
+
+interface BmcBlockRow {
+  bmc_id: string;
+  block_type: string;
+  content: string | null;
+  updated_at: number;
+}
+
+// ─── API 타입 ───
+export interface Bmc {
+  id: string;
+  ideaId: string | null;
+  title: string;
+  gitRef: string;
+  authorId: string;
+  orgId: string;
+  syncStatus: "synced" | "pending" | "failed";
+  blocks: BmcBlock[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface BmcBlock {
+  blockType: string;
+  content: string | null;
+  updatedAt: number;
+}
+
+// ─── 9개 블록 타입 상수 ───
+export const BMC_BLOCK_TYPES = [
+  "customer_segments",
+  "value_propositions",
+  "channels",
+  "customer_relationships",
+  "revenue_streams",
+  "key_resources",
+  "key_activities",
+  "key_partnerships",
+  "cost_structure",
+] as const;
+
+// ─── 변환 헬퍼 ───
+function toBmc(row: BmcRow, blocks: BmcBlockRow[]): Bmc {
+  return {
+    id: row.id,
+    ideaId: row.idea_id,
+    title: row.title,
+    gitRef: row.git_ref,
+    authorId: row.author_id,
+    orgId: row.org_id,
+    syncStatus: row.sync_status as Bmc["syncStatus"],
+    blocks: blocks.map((b) => ({
+      blockType: b.block_type,
+      content: b.content,
+      updatedAt: b.updated_at,
+    })),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export class BmcService {
+  constructor(private db: D1Database) {}
+
+  async create(orgId: string, userId: string, data: { title: string; ideaId?: string }): Promise<Bmc> {
+    const id = crypto.randomUUID();
+    const now = Date.now();
+    const gitRef = "pending"; // Git 커밋 전 상태
+
+    // 1) BMC 메타 INSERT
+    await this.db
+      .prepare(
+        `INSERT INTO ax_bmcs (id, idea_id, title, git_ref, author_id, org_id, sync_status, is_deleted, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, 'pending', 0, ?, ?)`
+      )
+      .bind(id, data.ideaId ?? null, data.title, gitRef, userId, orgId, now, now)
+      .run();
+
+    // 2) 9개 블록 빈 초기화
+    for (const type of BMC_BLOCK_TYPES) {
+      await this.db
+        .prepare(
+          `INSERT INTO ax_bmc_blocks (bmc_id, block_type, content, updated_at)
+           VALUES (?, ?, '', ?)`
+        )
+        .bind(id, type, now)
+        .run();
+    }
+
+    return this.getById(orgId, id) as Promise<Bmc>;
+  }
+
+  async getById(orgId: string, id: string): Promise<Bmc | null> {
+    const row = await this.db
+      .prepare("SELECT * FROM ax_bmcs WHERE id = ? AND org_id = ? AND is_deleted = 0")
+      .bind(id, orgId)
+      .first<BmcRow>();
+    if (!row) return null;
+
+    const { results: blocks } = await this.db
+      .prepare("SELECT * FROM ax_bmc_blocks WHERE bmc_id = ?")
+      .bind(id)
+      .all<BmcBlockRow>();
+
+    return toBmc(row, blocks ?? []);
+  }
+
+  async list(orgId: string, opts: { page: number; limit: number; sort: string }) {
+    const offset = (opts.page - 1) * opts.limit;
+    const orderBy = opts.sort === "created_at_asc" ? "created_at ASC" : "updated_at DESC";
+
+    const { results } = await this.db
+      .prepare(`SELECT * FROM ax_bmcs WHERE org_id = ? AND is_deleted = 0 ORDER BY ${orderBy} LIMIT ? OFFSET ?`)
+      .bind(orgId, opts.limit, offset)
+      .all<BmcRow>();
+
+    const countRow = await this.db
+      .prepare("SELECT COUNT(*) as total FROM ax_bmcs WHERE org_id = ? AND is_deleted = 0")
+      .bind(orgId)
+      .first<{ total: number }>();
+
+    // 각 BMC의 블록도 가져오기 (N+1 최적화는 Phase 1 후)
+    const items = await Promise.all(
+      (results ?? []).map(async (row) => {
+        const { results: blocks } = await this.db
+          .prepare("SELECT * FROM ax_bmc_blocks WHERE bmc_id = ?")
+          .bind(row.id)
+          .all<BmcBlockRow>();
+        return toBmc(row, blocks ?? []);
+      })
+    );
+
+    return { items, total: countRow?.total ?? 0, page: opts.page, limit: opts.limit };
+  }
+
+  async update(
+    orgId: string,
+    id: string,
+    userId: string,
+    data: { title?: string; blocks?: Array<{ blockType: string; content: string }> }
+  ): Promise<Bmc | null> {
+    const existing = await this.getById(orgId, id);
+    if (!existing) return null;
+
+    const now = Date.now();
+
+    // 타이틀 업데이트
+    if (data.title) {
+      await this.db
+        .prepare("UPDATE ax_bmcs SET title = ?, updated_at = ?, sync_status = 'pending' WHERE id = ?")
+        .bind(data.title, now, id)
+        .run();
+    }
+
+    // 블록 업데이트
+    if (data.blocks) {
+      for (const b of data.blocks) {
+        await this.db
+          .prepare(
+            `UPDATE ax_bmc_blocks SET content = ?, updated_at = ? WHERE bmc_id = ? AND block_type = ?`
+          )
+          .bind(b.content, now, id, b.blockType)
+          .run();
+      }
+
+      // BMC 메타 업데이트 시간도 갱신
+      await this.db
+        .prepare("UPDATE ax_bmcs SET updated_at = ?, sync_status = 'pending' WHERE id = ?")
+        .bind(now, id)
+        .run();
+    }
+
+    return this.getById(orgId, id);
+  }
+
+  async softDelete(orgId: string, id: string): Promise<boolean> {
+    const result = await this.db
+      .prepare("UPDATE ax_bmcs SET is_deleted = 1, updated_at = ? WHERE id = ? AND org_id = ?")
+      .bind(Date.now(), id, orgId)
+      .run();
+    return (result.meta?.changes ?? 0) > 0;
+  }
+
+  async stage(orgId: string, id: string, userId: string): Promise<{ staged: true; bmcId: string } | null> {
+    const existing = await this.getById(orgId, id);
+    if (!existing) return null;
+
+    // sync_status를 'pending'으로 유지 — 프론트엔드가 커밋 요청을 보내기 전까지 대기
+    await this.db
+      .prepare("UPDATE ax_bmcs SET sync_status = 'pending', updated_at = ? WHERE id = ?")
+      .bind(Date.now(), id)
+      .run();
+
+    return { staged: true, bmcId: id };
+  }
+}

--- a/packages/fx-shaping/src/services/commit-gate-service.ts
+++ b/packages/fx-shaping/src/services/commit-gate-service.ts
@@ -1,0 +1,125 @@
+/**
+ * Sprint 69: Commit Gate 서비스 (F213)
+ * 2-5 핵심 아이템 선정 후 4개 질문 심화 논의 + 최종 판정
+ */
+
+export interface CommitGateInput {
+  bizItemId: string;
+  question1Answer?: string;
+  question2Answer?: string;
+  question3Answer?: string;
+  question4Answer?: string;
+  finalDecision: string;
+  reason?: string;
+}
+
+export interface CommitGate {
+  id: string;
+  bizItemId: string;
+  orgId: string;
+  question1Answer: string | null;
+  question2Answer: string | null;
+  question3Answer: string | null;
+  question4Answer: string | null;
+  finalDecision: string;
+  reason: string | null;
+  decidedBy: string;
+  decidedAt: string;
+  createdAt: string;
+}
+
+interface CommitGateRow {
+  id: string;
+  biz_item_id: string;
+  org_id: string;
+  question_1_answer: string | null;
+  question_2_answer: string | null;
+  question_3_answer: string | null;
+  question_4_answer: string | null;
+  final_decision: string;
+  reason: string | null;
+  decided_by: string;
+  decided_at: string;
+  created_at: string;
+}
+
+function generateId(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function toCommitGate(row: CommitGateRow): CommitGate {
+  return {
+    id: row.id,
+    bizItemId: row.biz_item_id,
+    orgId: row.org_id,
+    question1Answer: row.question_1_answer,
+    question2Answer: row.question_2_answer,
+    question3Answer: row.question_3_answer,
+    question4Answer: row.question_4_answer,
+    finalDecision: row.final_decision,
+    reason: row.reason,
+    decidedBy: row.decided_by,
+    decidedAt: row.decided_at,
+    createdAt: row.created_at,
+  };
+}
+
+export class CommitGateService {
+  constructor(private db: D1Database) {}
+
+  async create(orgId: string, userId: string, input: CommitGateInput): Promise<CommitGate> {
+    const id = generateId();
+    const now = new Date().toISOString();
+
+    // UPSERT: one commit gate per biz_item
+    await this.db
+      .prepare(
+        `INSERT INTO ax_commit_gates (id, biz_item_id, org_id, question_1_answer, question_2_answer, question_3_answer, question_4_answer, final_decision, reason, decided_by, decided_at, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(biz_item_id) DO UPDATE SET
+           question_1_answer = excluded.question_1_answer,
+           question_2_answer = excluded.question_2_answer,
+           question_3_answer = excluded.question_3_answer,
+           question_4_answer = excluded.question_4_answer,
+           final_decision = excluded.final_decision,
+           reason = excluded.reason,
+           decided_by = excluded.decided_by,
+           decided_at = excluded.decided_at`,
+      )
+      .bind(
+        id,
+        input.bizItemId,
+        orgId,
+        input.question1Answer ?? null,
+        input.question2Answer ?? null,
+        input.question3Answer ?? null,
+        input.question4Answer ?? null,
+        input.finalDecision,
+        input.reason ?? null,
+        userId,
+        now,
+        now,
+      )
+      .run();
+
+    const row = await this.db
+      .prepare("SELECT * FROM ax_commit_gates WHERE biz_item_id = ?")
+      .bind(input.bizItemId)
+      .first<CommitGateRow>();
+
+    return toCommitGate(row!);
+  }
+
+  async getByItem(bizItemId: string): Promise<CommitGate | null> {
+    const row = await this.db
+      .prepare("SELECT * FROM ax_commit_gates WHERE biz_item_id = ?")
+      .bind(bizItemId)
+      .first<CommitGateRow>();
+
+    return row ? toCommitGate(row) : null;
+  }
+}

--- a/packages/fx-shaping/src/services/idea-bmc-link-service.ts
+++ b/packages/fx-shaping/src/services/idea-bmc-link-service.ts
@@ -1,0 +1,181 @@
+import { IdeaService, type Idea } from "../collection/services/idea-service.js";
+import { BmcService, type Bmc } from "./bmc-service.js";
+
+// ─── Summary 타입 ───
+export interface BmcSummary {
+  id: string;
+  title: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface IdeaSummary {
+  id: string;
+  title: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export class IdeaBmcLinkService {
+  private ideaService: IdeaService;
+  private bmcService: BmcService;
+
+  constructor(private db: D1Database) {
+    this.ideaService = new IdeaService(db);
+    this.bmcService = new BmcService(db);
+  }
+
+  async createBmcFromIdea(
+    ideaId: string,
+    tenantId: string,
+    userId: string,
+    title?: string
+  ): Promise<{ bmc: Bmc; linkId: string }> {
+    const idea = await this.ideaService.getById(tenantId, ideaId);
+    if (!idea) throw new NotFoundError("Idea not found");
+
+    const bmcTitle = title ?? `BMC: ${idea.title}`;
+    const bmc = await this.bmcService.create(tenantId, userId, {
+      title: bmcTitle,
+      ideaId,
+    });
+
+    const linkId = crypto.randomUUID();
+    const now = Date.now();
+
+    await this.db
+      .prepare(
+        `INSERT INTO ax_idea_bmc_links (id, idea_id, bmc_id, created_at)
+         VALUES (?, ?, ?, ?)`
+      )
+      .bind(linkId, ideaId, bmc.id, now)
+      .run();
+
+    return { bmc, linkId };
+  }
+
+  async linkBmc(
+    ideaId: string,
+    bmcId: string,
+    tenantId: string
+  ): Promise<{ linkId: string }> {
+    const idea = await this.ideaService.getById(tenantId, ideaId);
+    if (!idea) throw new NotFoundError("Idea not found");
+
+    const bmc = await this.bmcService.getById(tenantId, bmcId);
+    if (!bmc) throw new NotFoundError("BMC not found");
+
+    // UNIQUE 제약으로 중복 검사
+    const existing = await this.db
+      .prepare(
+        "SELECT id FROM ax_idea_bmc_links WHERE idea_id = ? AND bmc_id = ?"
+      )
+      .bind(ideaId, bmcId)
+      .first<{ id: string }>();
+
+    if (existing) throw new ConflictError("Already linked");
+
+    const linkId = crypto.randomUUID();
+    const now = Date.now();
+
+    await this.db
+      .prepare(
+        `INSERT INTO ax_idea_bmc_links (id, idea_id, bmc_id, created_at)
+         VALUES (?, ?, ?, ?)`
+      )
+      .bind(linkId, ideaId, bmcId, now)
+      .run();
+
+    return { linkId };
+  }
+
+  async unlinkBmc(
+    ideaId: string,
+    bmcId: string,
+    tenantId: string
+  ): Promise<void> {
+    // 존재 확인 (tenantId 격리)
+    const idea = await this.ideaService.getById(tenantId, ideaId);
+    if (!idea) throw new NotFoundError("Idea not found");
+
+    const result = await this.db
+      .prepare(
+        "DELETE FROM ax_idea_bmc_links WHERE idea_id = ? AND bmc_id = ?"
+      )
+      .bind(ideaId, bmcId)
+      .run();
+
+    if ((result.meta?.changes ?? 0) === 0) {
+      throw new NotFoundError("Link not found");
+    }
+  }
+
+  async getBmcsByIdea(
+    ideaId: string,
+    tenantId: string
+  ): Promise<BmcSummary[]> {
+    const idea = await this.ideaService.getById(tenantId, ideaId);
+    if (!idea) throw new NotFoundError("Idea not found");
+
+    const { results } = await this.db
+      .prepare(
+        `SELECT b.id, b.title, b.created_at, b.updated_at
+         FROM ax_idea_bmc_links l
+         JOIN ax_bmcs b ON l.bmc_id = b.id
+         WHERE l.idea_id = ? AND b.org_id = ? AND b.is_deleted = 0
+         ORDER BY l.created_at DESC`
+      )
+      .bind(ideaId, tenantId)
+      .all<{ id: string; title: string; created_at: number; updated_at: number }>();
+
+    return (results ?? []).map((r) => ({
+      id: r.id,
+      title: r.title,
+      createdAt: r.created_at,
+      updatedAt: r.updated_at,
+    }));
+  }
+
+  async getIdeaByBmc(
+    bmcId: string,
+    tenantId: string
+  ): Promise<IdeaSummary | null> {
+    const bmc = await this.bmcService.getById(tenantId, bmcId);
+    if (!bmc) throw new NotFoundError("BMC not found");
+
+    const row = await this.db
+      .prepare(
+        `SELECT i.id, i.title, i.created_at, i.updated_at
+         FROM ax_idea_bmc_links l
+         JOIN ax_ideas i ON l.idea_id = i.id
+         WHERE l.bmc_id = ? AND i.org_id = ? AND i.is_deleted = 0
+         LIMIT 1`
+      )
+      .bind(bmcId, tenantId)
+      .first<{ id: string; title: string; created_at: number; updated_at: number }>();
+
+    if (!row) return null;
+
+    return {
+      id: row.id,
+      title: row.title,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+}
+
+// ─── Error 클래스 ───
+export class NotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NotFoundError";
+  }
+}
+
+export class ConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConflictError";
+  }
+}

--- a/packages/fx-shaping/src/services/persona-config-service.ts
+++ b/packages/fx-shaping/src/services/persona-config-service.ts
@@ -1,0 +1,132 @@
+/**
+ * Sprint 154+155 F342+F344: PersonaConfigService — 페르소나 가중치/맥락 CRUD
+ */
+import type { PersonaConfigInput } from "../schemas/persona-config.js";
+import type { UpsertPersonaConfigInput } from "../schemas/persona-config-schema.js";
+import { BIZ_PERSONAS } from "./biz-persona-prompts.js";
+
+export interface PersonaConfigRow {
+  id: string;
+  item_id: string;
+  org_id: string;
+  persona_id: string;
+  persona_name: string;
+  persona_role: string;
+  weights: string;
+  context_json: string;
+  created_at: string;
+  updated_at: string;
+}
+
+function generateId(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes).map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+export class PersonaConfigService {
+  constructor(private db: D1Database) {}
+
+  async getByItemId(itemId: string, orgId: string): Promise<PersonaConfigRow[]> {
+    const result = await this.db
+      .prepare("SELECT * FROM ax_persona_configs WHERE item_id = ? AND org_id = ? ORDER BY persona_id")
+      .bind(itemId, orgId)
+      .all<PersonaConfigRow>();
+    return result.results;
+  }
+
+  /** 아이템 ID로 전체 설정 조회 (orgId 불필요) */
+  async getByItem(itemId: string): Promise<PersonaConfigRow[]> {
+    const result = await this.db
+      .prepare("SELECT * FROM ax_persona_configs WHERE item_id = ? ORDER BY persona_id")
+      .bind(itemId)
+      .all<PersonaConfigRow>();
+    return result.results;
+  }
+
+  /** 8인 기본 페르소나 시딩 — 이미 있으면 0 반환 */
+  async initDefaults(itemId: string, orgId: string): Promise<number> {
+    const existing = await this.getByItem(itemId);
+    if (existing.length > 0) return 0;
+
+    const defaultWeights = JSON.stringify({
+      strategic_fit: 15, market_potential: 15, technical_feasibility: 15,
+      financial_viability: 15, competitive_advantage: 10, risk_assessment: 15, team_readiness: 15,
+    });
+
+    const sql = `INSERT INTO ax_persona_configs (id, item_id, org_id, persona_id, persona_name, persona_role, weights, context_json)
+       VALUES (?, ?, ?, ?, ?, ?, ?, '{}')`;
+
+    const batch = BIZ_PERSONAS.map((p) =>
+      this.db.prepare(sql).bind(generateId(), itemId, orgId, p.id, p.name, p.role, defaultWeights),
+    );
+
+    await this.db.batch(batch);
+    return BIZ_PERSONAS.length;
+  }
+
+  /** 단일 페르소나 설정 upsert */
+  async upsert(itemId: string, orgId: string, data: UpsertPersonaConfigInput): Promise<PersonaConfigRow> {
+    const id = generateId();
+    await this.db
+      .prepare(
+        `INSERT INTO ax_persona_configs (id, item_id, org_id, persona_id, persona_name, persona_role, weights, context_json, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+         ON CONFLICT(item_id, persona_id) DO UPDATE SET
+           persona_name = excluded.persona_name,
+           persona_role = excluded.persona_role,
+           weights = excluded.weights,
+           context_json = excluded.context_json,
+           updated_at = datetime('now')`,
+      )
+      .bind(
+        id, itemId, orgId, data.personaId,
+        data.personaName, data.personaRole,
+        JSON.stringify(data.weights), JSON.stringify(data.contextJson),
+      )
+      .run();
+
+    const result = await this.db
+      .prepare("SELECT * FROM ax_persona_configs WHERE item_id = ? AND persona_id = ?")
+      .bind(itemId, data.personaId)
+      .first<PersonaConfigRow>();
+    return result!;
+  }
+
+  /** 가중치만 변경 */
+  async updateWeights(itemId: string, personaId: string, weights: Record<string, number>): Promise<void> {
+    await this.db
+      .prepare(
+        "UPDATE ax_persona_configs SET weights = ?, updated_at = datetime('now') WHERE item_id = ? AND persona_id = ?",
+      )
+      .bind(JSON.stringify(weights), itemId, personaId)
+      .run();
+  }
+
+  /** 벌크 설정 upsert (SSE 평가용) */
+  async upsertConfigs(
+    itemId: string,
+    orgId: string,
+    configs: PersonaConfigInput[],
+  ): Promise<void> {
+    const sql = `INSERT INTO ax_persona_configs (id, item_id, org_id, persona_id, weights, context_json, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, datetime('now'))
+       ON CONFLICT(item_id, persona_id) DO UPDATE SET
+         weights = excluded.weights,
+         context_json = excluded.context_json,
+         updated_at = datetime('now')`;
+
+    const batch = configs.map((c) =>
+      this.db.prepare(sql).bind(
+        generateId(),
+        itemId,
+        orgId,
+        c.personaId,
+        JSON.stringify(c.weights),
+        JSON.stringify(c.context),
+      ),
+    );
+
+    await this.db.batch(batch);
+  }
+}

--- a/packages/fx-shaping/src/services/persona-eval-demo.ts
+++ b/packages/fx-shaping/src/services/persona-eval-demo.ts
@@ -1,0 +1,102 @@
+/**
+ * Sprint 155 F345: 데모 모드 — 하드코딩 평가 결과
+ * API 키 없이 전체 UI 플로우를 체험할 수 있는 fallback 데이터
+ */
+
+export interface DemoEvalResult {
+  personaId: string;
+  scores: Record<string, number>;
+  verdict: "green" | "keep" | "red";
+  summary: string;
+  concerns: string[];
+}
+
+export const DEMO_EVAL_DATA: Record<string, DemoEvalResult> = {
+  strategy: {
+    personaId: "strategy",
+    scores: { businessViability: 8.5, strategicFit: 9.0, customerValue: 7.5, techMarket: 8.0, execution: 7.0, financialFeasibility: 7.5, competitiveDiff: 8.5, scalability: 8.0 },
+    verdict: "green",
+    summary: "KT DS 중장기 전략 방향과 높은 정합성. AI 헬스케어는 성장 시장이며 기존 SI 역량 활용 가능.",
+    concerns: ["시장 진입 타이밍이 경쟁사 대비 다소 늦을 수 있음"],
+  },
+  sales: {
+    personaId: "sales",
+    scores: { businessViability: 7.0, strategicFit: 6.5, customerValue: 8.0, techMarket: 7.0, execution: 6.0, financialFeasibility: 7.0, competitiveDiff: 6.5, scalability: 7.5 },
+    verdict: "keep",
+    summary: "기존 헬스케어 고객사(병원 SI) 확장 가능성 있으나, AI 솔루션 영업 경험 부족으로 초기 수주 난이도 높음.",
+    concerns: ["AI 솔루션 영업 레퍼런스 부재", "고객 PoC 요구 가능성 높음"],
+  },
+  ap_biz: {
+    personaId: "ap_biz",
+    scores: { businessViability: 7.5, strategicFit: 7.0, customerValue: 7.0, techMarket: 8.5, execution: 8.0, financialFeasibility: 6.5, competitiveDiff: 7.0, scalability: 7.0 },
+    verdict: "green",
+    summary: "기술적 실현 가능. 기존 헬스케어 SI 경험과 AI 역량 조합으로 6개월 내 MVP 가능.",
+    concerns: ["의료 데이터 규제(개인정보보호법) 대응 필요"],
+  },
+  ai_tech: {
+    personaId: "ai_tech",
+    scores: { businessViability: 8.0, strategicFit: 8.5, customerValue: 8.0, techMarket: 9.0, execution: 7.5, financialFeasibility: 7.0, competitiveDiff: 9.0, scalability: 8.5 },
+    verdict: "green",
+    summary: "AI 기술 차별성 높음. 의료 영상 분석 + NLP 기반 진료 지원은 시장 수요 강함.",
+    concerns: ["학습 데이터 확보에 병원 협력 필수"],
+  },
+  finance: {
+    personaId: "finance",
+    scores: { businessViability: 6.5, strategicFit: 7.0, customerValue: 6.0, techMarket: 6.5, execution: 5.5, financialFeasibility: 6.0, competitiveDiff: 7.0, scalability: 6.5 },
+    verdict: "keep",
+    summary: "BEP 3년 예상. 초기 투자 3억 수준이나 매출 불확실성으로 ROI 검증 필요.",
+    concerns: ["투자 회수 기간 불확실", "경쟁사 가격 경쟁 리스크"],
+  },
+  security: {
+    personaId: "security",
+    scores: { businessViability: 7.0, strategicFit: 7.5, customerValue: 7.5, techMarket: 7.0, execution: 6.5, financialFeasibility: 7.0, competitiveDiff: 7.0, scalability: 6.0 },
+    verdict: "keep",
+    summary: "의료 데이터 보안 이슈 관리 가능하나, HIPAA/개인정보보호법 컴플라이언스 추가 비용 발생.",
+    concerns: ["의료 데이터 보안 인증 필요", "데이터 거버넌스 체계 구축 선행"],
+  },
+  customer: {
+    personaId: "customer",
+    scores: { businessViability: 8.0, strategicFit: 7.5, customerValue: 9.0, techMarket: 8.0, execution: 7.0, financialFeasibility: 7.5, competitiveDiff: 8.0, scalability: 8.0 },
+    verdict: "green",
+    summary: "고객 관점에서 높은 가치. 진료 효율 30% 향상, 오진율 감소 기대.",
+    concerns: ["의료진 AI 도구 수용성 검증 필요"],
+  },
+  innovation: {
+    personaId: "innovation",
+    scores: { businessViability: 9.0, strategicFit: 8.5, customerValue: 8.5, techMarket: 9.0, execution: 7.5, financialFeasibility: 7.0, competitiveDiff: 9.5, scalability: 9.0 },
+    verdict: "green",
+    summary: "혁신성 매우 높음. AI 기반 의료 의사결정 지원은 차세대 핵심 사업 후보.",
+    concerns: ["기술 성숙도 vs 시장 기대치 갭 관리 필요"],
+  },
+};
+
+export interface DemoFinalResult {
+  verdict: "green" | "keep" | "red";
+  avgScore: number;
+  totalConcerns: number;
+  scores: Array<DemoEvalResult & { index: number }>;
+  warnings: string[];
+}
+
+export function getDemoFinalResult(): DemoFinalResult {
+  const entries = Object.values(DEMO_EVAL_DATA);
+  const allScoreValues = entries.flatMap((e) => Object.values(e.scores));
+  const avgScore = Math.round((allScoreValues.reduce((a, b) => a + b, 0) / allScoreValues.length) * 10) / 10;
+  const totalConcerns = entries.reduce((s, e) => s + e.concerns.length, 0);
+
+  // 판정: green 5+/8 → green, red 3+/8 → red, else keep
+  const verdictCounts = { green: 0, keep: 0, red: 0 };
+  for (const e of entries) verdictCounts[e.verdict]++;
+
+  let verdict: "green" | "keep" | "red" = "keep";
+  if (verdictCounts.green >= 5) verdict = "green";
+  else if (verdictCounts.red >= 3) verdict = "red";
+
+  return {
+    verdict,
+    avgScore,
+    totalConcerns,
+    scores: entries.map((e, i) => ({ ...e, index: i })),
+    warnings: [],
+  };
+}

--- a/packages/fx-shaping/src/services/persona-eval-service.ts
+++ b/packages/fx-shaping/src/services/persona-eval-service.ts
@@ -1,0 +1,340 @@
+/**
+ * Sprint 155 F345: PersonaEvalService — 멀티 페르소나 AI 평가 실행 + SSE 스트림
+ */
+import { BIZ_PERSONAS } from "./biz-persona-prompts.js";
+import { DEMO_EVAL_DATA, getDemoFinalResult } from "./persona-eval-demo.js";
+import type { PersonaConfigInput } from "../schemas/persona-config.js";
+
+function generateId(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes).map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+export interface PersonaEvalRow {
+  id: string;
+  item_id: string;
+  org_id: string;
+  persona_id: string;
+  scores: string;
+  verdict: string;
+  summary: string | null;
+  concerns: string | null;
+  condition: string | null;
+  eval_metadata: string | null;
+  created_at: string;
+}
+
+const SCORE_KEYS = [
+  "businessViability", "strategicFit", "customerValue", "techMarket",
+  "execution", "financialFeasibility", "competitiveDiff", "scalability",
+] as const;
+
+export class PersonaEvalService {
+  constructor(
+    private db: D1Database,
+    private apiKey?: string,
+  ) {}
+
+  async getByItemId(itemId: string, orgId: string): Promise<PersonaEvalRow[]> {
+    const result = await this.db
+      .prepare("SELECT * FROM ax_persona_evals WHERE item_id = ? AND org_id = ? ORDER BY persona_id")
+      .bind(itemId, orgId)
+      .all<PersonaEvalRow>();
+    return result.results;
+  }
+
+  /** 아이템 ID로 전체 평가 조회 (orgId 불필요) */
+  async getByItem(itemId: string): Promise<PersonaEvalRow[]> {
+    const result = await this.db
+      .prepare("SELECT * FROM ax_persona_evals WHERE item_id = ? ORDER BY persona_id")
+      .bind(itemId)
+      .all<PersonaEvalRow>();
+    return result.results;
+  }
+
+  /** 단일 평가 결과 저장 (upsert) */
+  async save(
+    itemId: string,
+    orgId: string,
+    data: {
+      personaId: string;
+      scores: Record<string, number>;
+      verdict: string;
+      summary: string;
+      concern?: string | null;
+      condition?: string | null;
+      evalModel?: string;
+      evalDurationMs?: number;
+      evalCostUsd?: number;
+    },
+  ): Promise<PersonaEvalRow> {
+    const id = generateId();
+    await this.db
+      .prepare(
+        `INSERT INTO ax_persona_evals (id, item_id, org_id, persona_id, scores, verdict, summary, concern, condition, eval_model, eval_duration_ms, eval_cost_usd)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(item_id, persona_id) DO UPDATE SET
+           scores = excluded.scores,
+           verdict = excluded.verdict,
+           summary = excluded.summary,
+           concern = excluded.concern,
+           condition = excluded.condition,
+           eval_model = excluded.eval_model,
+           eval_duration_ms = excluded.eval_duration_ms,
+           eval_cost_usd = excluded.eval_cost_usd`,
+      )
+      .bind(
+        id, itemId, orgId, data.personaId,
+        JSON.stringify(data.scores), data.verdict, data.summary,
+        data.concern ?? null, data.condition ?? null,
+        data.evalModel ?? null, data.evalDurationMs ?? null, data.evalCostUsd ?? null,
+      )
+      .run();
+
+    return (await this.db
+      .prepare("SELECT * FROM ax_persona_evals WHERE item_id = ? AND persona_id = ?")
+      .bind(itemId, data.personaId)
+      .first<PersonaEvalRow>())!;
+  }
+
+  /** 종합 판정 — 다수결 기반 */
+  async getOverallVerdict(itemId: string): Promise<{
+    verdict: string;
+    go: number;
+    conditional: number;
+    noGo: number;
+    avgScore: number;
+    totalEvals: number;
+  }> {
+    const evals = await this.getByItem(itemId);
+
+    if (evals.length === 0) {
+      return { verdict: "Conditional", go: 0, conditional: 0, noGo: 0, avgScore: 0, totalEvals: 0 };
+    }
+
+    const counts = { Go: 0, Conditional: 0, NoGo: 0 };
+    let scoreSum = 0;
+    let scoreCount = 0;
+
+    for (const e of evals) {
+      if (e.verdict in counts) counts[e.verdict as keyof typeof counts]++;
+      const scores = JSON.parse(e.scores) as Record<string, number>;
+      const vals = Object.values(scores);
+      scoreSum += vals.reduce((a, b) => a + b, 0);
+      scoreCount += vals.length;
+    }
+
+    let verdict = "Conditional";
+    if (counts.Go > counts.NoGo && counts.Go > counts.Conditional) verdict = "Go";
+    else if (counts.NoGo >= counts.Go && counts.NoGo > 0) verdict = "NoGo";
+
+    return {
+      verdict,
+      go: counts.Go,
+      conditional: counts.Conditional,
+      noGo: counts.NoGo,
+      avgScore: scoreCount > 0 ? Math.round((scoreSum / scoreCount) * 10) / 10 : 0,
+      totalEvals: evals.length,
+    };
+  }
+
+  createEvalStream(
+    itemId: string,
+    orgId: string,
+    configs: PersonaConfigInput[],
+    briefing: string,
+    demoMode: boolean,
+  ): ReadableStream {
+    const encoder = new TextEncoder();
+    const db = this.db;
+    const apiKey = this.apiKey;
+
+    return new ReadableStream({
+      async start(controller) {
+        const send = (event: string, data: unknown) => {
+          controller.enqueue(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`));
+        };
+
+        try {
+          const results: Array<{ personaId: string; scores: Record<string, number>; verdict: string; summary: string | null; concerns: string[]; index: number }> = [];
+
+          for (let i = 0; i < configs.length; i++) {
+            const config = configs[i]!;
+            const persona = BIZ_PERSONAS.find((p) => p.id === config.personaId);
+            const personaName = persona?.name ?? config.personaId;
+
+            send("eval_start", {
+              personaId: config.personaId,
+              personaName,
+              index: i,
+              total: configs.length,
+            });
+
+            let evalResult: {
+              scores: Record<string, number>;
+              verdict: string;
+              summary: string | null;
+              concerns: string[];
+            };
+
+            if (demoMode) {
+              await new Promise((r) => setTimeout(r, 500));
+              const demo = DEMO_EVAL_DATA[config.personaId];
+              evalResult = demo
+                ? { scores: demo.scores, verdict: demo.verdict, summary: demo.summary, concerns: demo.concerns }
+                : { scores: Object.fromEntries(SCORE_KEYS.map((k) => [k, 7.0])), verdict: "keep", summary: "데모 데이터", concerns: [] };
+            } else {
+              evalResult = await evaluateWithClaude(config, briefing, apiKey!, itemId);
+            }
+
+            // DB에 결과 저장
+            await db
+              .prepare(
+                `INSERT INTO ax_persona_evals (item_id, org_id, persona_id, scores, verdict, summary, concerns)
+                 VALUES (?, ?, ?, ?, ?, ?, ?)
+                 ON CONFLICT(item_id, persona_id) DO UPDATE SET
+                   scores = excluded.scores,
+                   verdict = excluded.verdict,
+                   summary = excluded.summary,
+                   concerns = excluded.concerns`,
+              )
+              .bind(
+                itemId,
+                orgId,
+                config.personaId,
+                JSON.stringify(evalResult.scores),
+                evalResult.verdict,
+                evalResult.summary,
+                JSON.stringify(evalResult.concerns),
+              )
+              .run();
+
+            const resultEntry = { ...evalResult, personaId: config.personaId, index: i };
+            results.push(resultEntry);
+            send("eval_complete", resultEntry);
+          }
+
+          // 종합 판정
+          if (demoMode) {
+            send("final_result", getDemoFinalResult());
+          } else {
+            send("final_result", computeFinalVerdict(results));
+          }
+
+          send("done", {});
+        } catch (err) {
+          send("error", { message: err instanceof Error ? err.message : "Unknown error" });
+        } finally {
+          controller.close();
+        }
+      },
+    });
+  }
+}
+
+/** Claude API로 단일 페르소나 평가 */
+async function evaluateWithClaude(
+  config: PersonaConfigInput,
+  briefing: string,
+  apiKey: string,
+  itemId: string,
+): Promise<{ scores: Record<string, number>; verdict: string; summary: string | null; concerns: string[] }> {
+  const persona = BIZ_PERSONAS.find((p) => p.id === config.personaId);
+  if (!persona) {
+    return { scores: Object.fromEntries(SCORE_KEYS.map((k) => [k, 5.0])), verdict: "keep", summary: "Unknown persona", concerns: [] };
+  }
+
+  const systemPrompt = persona.systemPrompt;
+  const userPrompt = `다음 사업 아이템에 대해 평가해주세요.
+
+## 브리핑
+${briefing || "(브리핑 없음)"}
+
+## 평가 맥락
+- 상황: ${config.context.situation || "일반"}
+- 우선순위: ${config.context.priorities?.join(", ") || "없음"}
+- 평가 스타일: ${config.context.style || "neutral"}
+- Red Lines: ${config.context.redLines?.join(", ") || "없음"}
+
+## 가중치 (참고용)
+${Object.entries(config.weights).map(([k, v]) => `- ${k}: ${v}`).join("\n")}
+
+## 응답 형식 (반드시 JSON으로만 응답)
+{
+  "scores": {
+    "businessViability": 0-10,
+    "strategicFit": 0-10,
+    "customerValue": 0-10,
+    "techMarket": 0-10,
+    "execution": 0-10,
+    "financialFeasibility": 0-10,
+    "competitiveDiff": 0-10,
+    "scalability": 0-10
+  },
+  "verdict": "green|keep|red",
+  "summary": "2-3문장 요약",
+  "concerns": ["우려사항1", "우려사항2"]
+}`;
+
+  const response = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model: "claude-sonnet-4-20250514",
+      max_tokens: 1024,
+      system: systemPrompt,
+      messages: [{ role: "user", content: userPrompt }],
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Claude API error: ${response.status}`);
+  }
+
+  const data = (await response.json()) as { content: Array<{ type: string; text: string }> };
+  const text = data.content[0]?.text ?? "{}";
+
+  try {
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    const parsed = JSON.parse(jsonMatch?.[0] ?? "{}");
+    return {
+      scores: parsed.scores ?? Object.fromEntries(SCORE_KEYS.map((k) => [k, 5.0])),
+      verdict: parsed.verdict ?? "keep",
+      summary: parsed.summary ?? null,
+      concerns: Array.isArray(parsed.concerns) ? parsed.concerns : [],
+    };
+  } catch {
+    return { scores: Object.fromEntries(SCORE_KEYS.map((k) => [k, 5.0])), verdict: "keep", summary: text.slice(0, 200), concerns: [] };
+  }
+}
+
+/** 종합 판정 계산 */
+function computeFinalVerdict(
+  results: Array<{ personaId: string; scores: Record<string, number>; verdict: string; summary: string | null; concerns: string[] }>,
+) {
+  const allScores = results.flatMap((r) => Object.values(r.scores));
+  const avgScore = Math.round((allScores.reduce((a, b) => a + b, 0) / allScores.length) * 10) / 10;
+  const totalConcerns = results.reduce((s, r) => s + r.concerns.length, 0);
+
+  const verdictCounts = { green: 0, keep: 0, red: 0 };
+  for (const r of results) {
+    if (r.verdict in verdictCounts) verdictCounts[r.verdict as keyof typeof verdictCounts]++;
+  }
+
+  let verdict: "green" | "keep" | "red" = "keep";
+  if (verdictCounts.green >= 5) verdict = "green";
+  else if (verdictCounts.red >= 3) verdict = "red";
+
+  return {
+    verdict,
+    avgScore,
+    totalConcerns,
+    scores: results,
+    warnings: totalConcerns > 10 ? ["다수의 우려사항이 제기되었습니다. 면밀한 검토가 필요합니다."] : [],
+  };
+}

--- a/packages/fx-shaping/src/services/shaping-orchestrator-service.ts
+++ b/packages/fx-shaping/src/services/shaping-orchestrator-service.ts
@@ -1,0 +1,189 @@
+/**
+ * F312: ShapingOrchestratorService — 형상화 Phase A~F 자동 순차 실행 오케스트레이터
+ *
+ * 발굴 완료 → 산출물 수집 → shaping_runs 생성 → Phase A~F 순차 실행
+ */
+import { ShapingService } from "./shaping-service.js";
+import { PipelineStateMachine } from "../launch/services/pipeline-state-machine.js";
+import type { TriggerShapingInput } from "@foundry-x/shared";
+
+const SHAPING_PHASES = ["A", "B", "C", "D", "E", "F"] as const;
+
+interface ArtifactBundle {
+  bizItemId: string;
+  artifacts: Array<{
+    skillId: string;
+    stageId: string;
+    version: number;
+    outputText: string;
+    createdAt: string;
+  }>;
+  summary: string;
+}
+
+export class ShapingOrchestratorService {
+  private shapingService: ShapingService;
+  private fsm: PipelineStateMachine;
+
+  constructor(private db: D1Database) {
+    this.shapingService = new ShapingService(db);
+    this.fsm = new PipelineStateMachine(db);
+  }
+
+  /**
+   * 발굴 완료 후 형상화 자동 시작
+   * 1. 발굴 산출물 수집
+   * 2. shaping_runs 생성 (mode=auto)
+   * 3. pipeline 상태 shaping_queued → shaping_running
+   * 4. Phase A 시작
+   */
+  async startAutoShaping(
+    pipelineRunId: string,
+    bizItemId: string,
+    orgId: string,
+    options: TriggerShapingInput = { mode: "auto", maxIterations: 3 },
+  ): Promise<string> {
+    // 1. 발굴 산출물 수집
+    const artifacts = await this.collectDiscoveryArtifacts(bizItemId);
+
+    // 2. shaping_runs 생성
+    const shapingRun = await this.shapingService.createRun(orgId, {
+      discoveryPrdId: bizItemId,
+      mode: options.mode,
+      maxIterations: options.maxIterations ?? 3,
+      tokenLimit: 500000,
+    });
+
+    if (!shapingRun) {
+      throw new Error("Failed to create shaping run");
+    }
+
+    // 3. pipeline에 shaping_run_id 연결 + shaping_queued → shaping_running
+    await this.db
+      .prepare(
+        `UPDATE discovery_pipeline_runs
+         SET shaping_run_id = ?, updated_at = datetime('now')
+         WHERE id = ?`,
+      )
+      .bind(shapingRun.id, pipelineRunId)
+      .run();
+
+    await this.fsm.transition(pipelineRunId, "START", { stepId: "phase-A" });
+
+    // 4. Phase A 시작 로그
+    await this.shapingService.addPhaseLog(shapingRun.id, {
+      phase: "A",
+      round: 0,
+      inputSnapshot: JSON.stringify({
+        artifactCount: artifacts.artifacts.length,
+        summary: artifacts.summary,
+      }),
+    });
+
+    return shapingRun.id;
+  }
+
+  /**
+   * Phase 진행 — 현재 Phase 완료 → 다음 Phase 시작
+   */
+  async advancePhase(
+    shapingRunId: string,
+    pipelineRunId: string,
+    currentPhase: string,
+    verdict?: string,
+    qualityScore?: number,
+  ): Promise<{ nextPhase: string | null; completed: boolean }> {
+    const phaseIdx = SHAPING_PHASES.indexOf(currentPhase as typeof SHAPING_PHASES[number]);
+    if (phaseIdx === -1) {
+      throw new Error(`Invalid phase: ${currentPhase}`);
+    }
+
+    // 현재 Phase 완료 로그 갱신
+    await this.db
+      .prepare(
+        `UPDATE shaping_phase_logs
+         SET verdict = ?, quality_score = ?
+         WHERE run_id = ? AND phase = ?`,
+      )
+      .bind(verdict ?? "PASS", qualityScore ?? null, shapingRunId, currentPhase)
+      .run();
+
+    // shaping_runs 현재 Phase 갱신 — ShapingService.updateRun requires (tenantId, runId, params)
+    // We read tenant_id from the run
+    const runRow = await this.db
+      .prepare("SELECT tenant_id FROM shaping_runs WHERE id = ?")
+      .bind(shapingRunId)
+      .first<{ tenant_id: string }>();
+    const tenantId = runRow?.tenant_id ?? "";
+    await this.shapingService.updateRun(tenantId, shapingRunId, { currentPhase: currentPhase as "A" | "B" | "C" | "D" | "E" | "F" });
+
+    const isLastPhase = phaseIdx === SHAPING_PHASES.length - 1;
+
+    if (isLastPhase) {
+      // Phase F 완료 → 파이프라인 완료
+      await this.shapingService.updateRun(tenantId, shapingRunId, { status: "completed" });
+
+      const stepId = currentPhase === "F" ? "phase-F" : `phase-${currentPhase}`;
+      await this.fsm.transition(pipelineRunId, "SHAPING_PHASE_COMPLETE", { stepId });
+
+      return { nextPhase: null, completed: true };
+    }
+
+    // 다음 Phase
+    const nextPhase = SHAPING_PHASES[phaseIdx + 1]!;
+
+    // 파이프라인 이벤트
+    await this.fsm.transition(pipelineRunId, "SHAPING_PHASE_COMPLETE", { stepId: `phase-${currentPhase}` });
+
+    // 다음 Phase 로그 생성
+    await this.shapingService.addPhaseLog(shapingRunId, {
+      phase: nextPhase,
+      round: 0,
+    });
+
+    // shaping_runs 갱신
+    await this.shapingService.updateRun(tenantId, shapingRunId, { currentPhase: nextPhase });
+
+    return { nextPhase, completed: false };
+  }
+
+  /**
+   * 발굴 산출물 수집 — bd_artifacts에서 해당 biz_item의 산출물 집계
+   */
+  async collectDiscoveryArtifacts(bizItemId: string): Promise<ArtifactBundle> {
+    const rows = await this.db
+      .prepare(
+        `SELECT skill_id, stage_id, version, output_text, created_at
+         FROM bd_artifacts
+         WHERE biz_item_id = ? AND status = 'completed'
+         ORDER BY stage_id, version DESC`,
+      )
+      .bind(bizItemId)
+      .all<{
+        skill_id: string;
+        stage_id: string;
+        version: number;
+        output_text: string | null;
+        created_at: string;
+      }>();
+
+    const artifacts = (rows.results ?? []).map((r) => ({
+      skillId: r.skill_id,
+      stageId: r.stage_id,
+      version: r.version,
+      outputText: r.output_text ?? "",
+      createdAt: r.created_at,
+    }));
+
+    // 요약 생성 (단계별 최신 산출물 수)
+    const stageMap = new Map<string, number>();
+    for (const a of artifacts) {
+      stageMap.set(a.stageId, (stageMap.get(a.stageId) ?? 0) + 1);
+    }
+    const summary = Array.from(stageMap.entries())
+      .map(([stage, count]) => `${stage}: ${count}건`)
+      .join(", ");
+
+    return { bizItemId, artifacts, summary };
+  }
+}

--- a/packages/fx-shaping/src/services/shaping-review-service.ts
+++ b/packages/fx-shaping/src/services/shaping-review-service.ts
@@ -1,0 +1,104 @@
+/**
+ * F286: ShapingReviewService — HITL 섹션별 승인/수정/반려 + 자동 모드 AI 3 페르소나
+ */
+
+import type { ReviewSectionInput } from "../schemas/shaping.js";
+import { ShapingService } from "./shaping-service.js";
+
+export class ShapingReviewService {
+  private shapingSvc: ShapingService;
+
+  constructor(private db: D1Database) {
+    this.shapingSvc = new ShapingService(db);
+  }
+
+  async reviewSection(
+    tenantId: string,
+    runId: string,
+    params: ReviewSectionInput,
+    reviewerId: string,
+  ) {
+    const run = await this.shapingSvc.getRun(tenantId, runId);
+    if (!run) return null;
+
+    // Log the review as a phase log entry
+    await this.shapingSvc.addPhaseLog(runId, {
+      phase: "F",
+      round: 0,
+      verdict: params.action === "approved" ? "PASS" : params.action === "rejected" ? "MAJOR_ISSUE" : "MINOR_FIX",
+      findings: JSON.stringify({ section: params.section, action: params.action, comment: params.comment, reviewerId }),
+    });
+
+    // Determine new status based on action
+    let newStatus = run.status;
+    if (params.action === "approved") {
+      newStatus = "completed";
+    } else if (params.action === "rejected") {
+      newStatus = "failed";
+    }
+    // revision_requested keeps status as-is (running)
+
+    if (newStatus !== run.status) {
+      await this.shapingSvc.updateRun(tenantId, runId, { status: newStatus as "running" | "completed" | "failed" | "escalated" });
+    }
+
+    return {
+      runId,
+      section: params.section,
+      action: params.action,
+      newStatus,
+    };
+  }
+
+  async autoReview(tenantId: string, runId: string) {
+    const run = await this.shapingSvc.getRun(tenantId, runId);
+    if (!run) return null;
+
+    // 3 AI personas evaluate the PRD
+    const personas = [
+      { persona: "product-owner", pass: true, reasoning: "사업 KPI 달성 경로가 명확하고 현실적" },
+      { persona: "tech-lead", pass: true, reasoning: "기술적 모호함 없이 개발팀이 즉시 착수 가능" },
+      { persona: "end-user", pass: true, reasoning: "핵심 가치가 직관적으로 이해되고 매력적" },
+    ];
+
+    // Log each persona review
+    for (const p of personas) {
+      await this.shapingSvc.addPhaseLog(runId, {
+        phase: "F",
+        round: 0,
+        verdict: p.pass ? "PASS" : "MAJOR_ISSUE",
+        findings: JSON.stringify({ persona: p.persona, pass: p.pass, reasoning: p.reasoning }),
+      });
+    }
+
+    // Consensus: 3/3 Pass → completed, 1+ Fail → escalated
+    const allPass = personas.every((p) => p.pass);
+    const consensus = allPass ? "approved" as const : "escalated" as const;
+    const newStatus = allPass ? "completed" : "escalated";
+
+    await this.shapingSvc.updateRun(tenantId, runId, { status: newStatus as "running" | "completed" | "failed" | "escalated" });
+
+    return {
+      runId,
+      results: personas,
+      consensus,
+      newStatus,
+    };
+  }
+
+  async getDiff(tenantId: string, runId: string) {
+    const run = await this.shapingSvc.getRun(tenantId, runId);
+    if (!run) return null;
+
+    // In a real implementation, this would fetch the original PRD from discovery_prd_id
+    // and compare with the shaped version. For now, return a structured diff placeholder.
+    return {
+      runId,
+      discoveryPrdId: run.discoveryPrdId,
+      sections: [
+        { name: "사업 타당성", changed: true, additions: 3, deletions: 1 },
+        { name: "기술 실현성", changed: false, additions: 0, deletions: 0 },
+      ],
+    };
+  }
+}

--- a/packages/fx-shaping/src/services/shaping-service.ts
+++ b/packages/fx-shaping/src/services/shaping-service.ts
@@ -1,0 +1,270 @@
+/**
+ * F287: ShapingService — 형상화 실행 이력 CRUD + 조인
+ */
+
+import type { CreateShapingRunInput, UpdateShapingRunInput, ListShapingRunsQuery, CreatePhaseLogInput, CreateExpertReviewInput, CreateSixHatsInput } from "../schemas/shaping.js";
+
+interface ShapingRunRow {
+  id: string;
+  tenant_id: string;
+  discovery_prd_id: string;
+  status: string;
+  mode: string;
+  current_phase: string;
+  total_iterations: number;
+  max_iterations: number;
+  quality_score: number | null;
+  token_cost: number;
+  token_limit: number;
+  git_path: string | null;
+  created_at: string;
+  completed_at: string | null;
+}
+
+function mapRun(row: ShapingRunRow) {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    discoveryPrdId: row.discovery_prd_id,
+    status: row.status,
+    mode: row.mode,
+    currentPhase: row.current_phase,
+    totalIterations: row.total_iterations,
+    maxIterations: row.max_iterations,
+    qualityScore: row.quality_score,
+    tokenCost: row.token_cost,
+    tokenLimit: row.token_limit,
+    gitPath: row.git_path,
+    createdAt: row.created_at,
+    completedAt: row.completed_at,
+  };
+}
+
+function mapPhaseLog(row: Record<string, unknown>) {
+  return {
+    id: row.id as string,
+    runId: row.run_id as string,
+    phase: row.phase as string,
+    round: row.round as number,
+    inputSnapshot: row.input_snapshot as string | null,
+    outputSnapshot: row.output_snapshot as string | null,
+    verdict: row.verdict as string | null,
+    qualityScore: row.quality_score as number | null,
+    findings: row.findings as string | null,
+    durationMs: row.duration_ms as number | null,
+    createdAt: row.created_at as string,
+  };
+}
+
+function mapExpertReview(row: Record<string, unknown>) {
+  return {
+    id: row.id as string,
+    runId: row.run_id as string,
+    expertRole: row.expert_role as string,
+    reviewBody: row.review_body as string,
+    findings: row.findings as string | null,
+    qualityScore: row.quality_score as number | null,
+    createdAt: row.created_at as string,
+  };
+}
+
+function mapSixHats(row: Record<string, unknown>) {
+  return {
+    id: row.id as string,
+    runId: row.run_id as string,
+    hatColor: row.hat_color as string,
+    round: row.round as number,
+    opinion: row.opinion as string,
+    verdict: row.verdict as string | null,
+    createdAt: row.created_at as string,
+  };
+}
+
+export class ShapingService {
+  constructor(private db: D1Database) {}
+
+  // ── shaping_runs CRUD ──
+
+  async createRun(tenantId: string, params: CreateShapingRunInput) {
+    const id = crypto.randomUUID();
+    await this.db
+      .prepare(
+        `INSERT INTO shaping_runs (id, tenant_id, discovery_prd_id, mode, max_iterations, token_limit, git_path)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(id, tenantId, params.discoveryPrdId, params.mode, params.maxIterations, params.tokenLimit, params.gitPath ?? null)
+      .run();
+
+    return this.getRun(tenantId, id);
+  }
+
+  async listRuns(tenantId: string, query: ListShapingRunsQuery) {
+    const conditions = ["tenant_id = ?"];
+    const binds: unknown[] = [tenantId];
+
+    if (query.status) {
+      conditions.push("status = ?");
+      binds.push(query.status);
+    }
+    if (query.mode) {
+      conditions.push("mode = ?");
+      binds.push(query.mode);
+    }
+
+    const where = conditions.join(" AND ");
+
+    const countRow = await this.db
+      .prepare(`SELECT COUNT(*) as cnt FROM shaping_runs WHERE ${where}`)
+      .bind(...binds)
+      .first<{ cnt: number }>();
+    const total = countRow?.cnt ?? 0;
+
+    const rows = await this.db
+      .prepare(
+        `SELECT * FROM shaping_runs WHERE ${where} ORDER BY created_at DESC LIMIT ? OFFSET ?`,
+      )
+      .bind(...binds, query.limit, query.offset)
+      .all<ShapingRunRow>();
+
+    return { items: (rows.results ?? []).map(mapRun), total };
+  }
+
+  async getRun(tenantId: string, runId: string) {
+    const row = await this.db
+      .prepare("SELECT * FROM shaping_runs WHERE id = ? AND tenant_id = ?")
+      .bind(runId, tenantId)
+      .first<ShapingRunRow>();
+    return row ? mapRun(row) : null;
+  }
+
+  async getRunDetail(tenantId: string, runId: string) {
+    const run = await this.getRun(tenantId, runId);
+    if (!run) return null;
+
+    const [logs, reviews, hats] = await Promise.all([
+      this.listPhaseLogs(runId),
+      this.listExpertReviews(runId),
+      this.listSixHats(runId),
+    ]);
+
+    return { ...run, phaseLogs: logs, expertReviews: reviews, sixHats: hats };
+  }
+
+  async updateRun(tenantId: string, runId: string, params: UpdateShapingRunInput) {
+    const existing = await this.getRun(tenantId, runId);
+    if (!existing) return null;
+
+    const sets: string[] = [];
+    const binds: unknown[] = [];
+
+    if (params.status !== undefined) {
+      sets.push("status = ?");
+      binds.push(params.status);
+      if (params.status === "completed" || params.status === "failed") {
+        sets.push("completed_at = datetime('now')");
+      }
+    }
+    if (params.currentPhase !== undefined) {
+      sets.push("current_phase = ?");
+      binds.push(params.currentPhase);
+    }
+    if (params.qualityScore !== undefined) {
+      sets.push("quality_score = ?");
+      binds.push(params.qualityScore);
+    }
+    if (params.tokenCost !== undefined) {
+      sets.push("token_cost = ?");
+      binds.push(params.tokenCost);
+    }
+    if (params.gitPath !== undefined) {
+      sets.push("git_path = ?");
+      binds.push(params.gitPath);
+    }
+
+    if (sets.length === 0) return existing;
+
+    await this.db
+      .prepare(`UPDATE shaping_runs SET ${sets.join(", ")} WHERE id = ? AND tenant_id = ?`)
+      .bind(...binds, runId, tenantId)
+      .run();
+
+    return this.getRun(tenantId, runId);
+  }
+
+  // ── shaping_phase_logs ──
+
+  async addPhaseLog(runId: string, params: CreatePhaseLogInput) {
+    const id = crypto.randomUUID();
+    await this.db
+      .prepare(
+        `INSERT INTO shaping_phase_logs (id, run_id, phase, round, input_snapshot, output_snapshot, verdict, quality_score, findings, duration_ms)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        id, runId, params.phase, params.round,
+        params.inputSnapshot ?? null, params.outputSnapshot ?? null,
+        params.verdict ?? null, params.qualityScore ?? null,
+        params.findings ?? null, params.durationMs ?? null,
+      )
+      .run();
+
+    const row = await this.db.prepare("SELECT * FROM shaping_phase_logs WHERE id = ?").bind(id).first();
+    return mapPhaseLog(row as Record<string, unknown>);
+  }
+
+  async listPhaseLogs(runId: string) {
+    const rows = await this.db
+      .prepare("SELECT * FROM shaping_phase_logs WHERE run_id = ? ORDER BY created_at ASC")
+      .bind(runId)
+      .all();
+    return (rows.results ?? []).map((r) => mapPhaseLog(r as Record<string, unknown>));
+  }
+
+  // ── shaping_expert_reviews ──
+
+  async addExpertReview(runId: string, params: CreateExpertReviewInput) {
+    const id = crypto.randomUUID();
+    await this.db
+      .prepare(
+        `INSERT INTO shaping_expert_reviews (id, run_id, expert_role, review_body, findings, quality_score)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(id, runId, params.expertRole, params.reviewBody, params.findings ?? null, params.qualityScore ?? null)
+      .run();
+
+    const row = await this.db.prepare("SELECT * FROM shaping_expert_reviews WHERE id = ?").bind(id).first();
+    return mapExpertReview(row as Record<string, unknown>);
+  }
+
+  async listExpertReviews(runId: string) {
+    const rows = await this.db
+      .prepare("SELECT * FROM shaping_expert_reviews WHERE run_id = ? ORDER BY created_at ASC")
+      .bind(runId)
+      .all();
+    return (rows.results ?? []).map((r) => mapExpertReview(r as Record<string, unknown>));
+  }
+
+  // ── shaping_six_hats ──
+
+  async addSixHats(runId: string, params: CreateSixHatsInput) {
+    const id = crypto.randomUUID();
+    await this.db
+      .prepare(
+        `INSERT INTO shaping_six_hats (id, run_id, hat_color, round, opinion, verdict)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(id, runId, params.hatColor, params.round, params.opinion, params.verdict ?? null)
+      .run();
+
+    const row = await this.db.prepare("SELECT * FROM shaping_six_hats WHERE id = ?").bind(id).first();
+    return mapSixHats(row as Record<string, unknown>);
+  }
+
+  async listSixHats(runId: string) {
+    const rows = await this.db
+      .prepare("SELECT * FROM shaping_six_hats WHERE run_id = ? ORDER BY round ASC, created_at ASC")
+      .bind(runId)
+      .all();
+    return (rows.results ?? []).map((r) => mapSixHats(r as Record<string, unknown>));
+  }
+}

--- a/packages/fx-shaping/src/services/sixhats-debate.ts
+++ b/packages/fx-shaping/src/services/sixhats-debate.ts
@@ -1,0 +1,275 @@
+/**
+ * Sprint 56 F188: Six Hats 토론 시뮬레이션 — 20턴 순차 실행 + D1 저장
+ */
+import { createAgentRunner, type AgentRunner } from "../agent/services/agent-runner.js";
+import {
+  TURN_SEQUENCE, HAT_CONFIGS, CONTEXT_WINDOW_TURNS,
+  summarizePrd, buildTurnPrompt,
+  type HatColor,
+} from "./sixhats-prompts.js";
+
+export class SixHatsDebateError extends Error {
+  constructor(message: string, public code: string) {
+    super(message);
+    this.name = "SixHatsDebateError";
+  }
+}
+
+export interface DebateResult {
+  id: string;
+  prdId: string;
+  bizItemId: string;
+  status: "completed" | "failed";
+  totalTurns: number;
+  completedTurns: number;
+  turns: TurnResult[];
+  keyIssues: string[];
+  summary: string;
+  model: string;
+  totalTokens: number;
+  durationSeconds: number;
+}
+
+export interface TurnResult {
+  turnNumber: number;
+  hat: HatColor;
+  hatLabel: string;
+  content: string;
+  tokens: number;
+  durationSeconds: number;
+}
+
+export class SixHatsDebateService {
+  private runner: AgentRunner;
+
+  constructor(private db: D1Database, env: {
+    OPENROUTER_API_KEY?: string;
+    OPENROUTER_DEFAULT_MODEL?: string;
+    ANTHROPIC_API_KEY?: string;
+  }) {
+    this.runner = createAgentRunner(env);
+  }
+
+  async startDebate(
+    prdId: string,
+    bizItemId: string,
+    prdContent: string,
+    orgId: string,
+  ): Promise<DebateResult> {
+    const debateId = generateId();
+    const prdSummary = summarizePrd(prdContent);
+    const model = this.runner.type;
+
+    // Insert debate record (status = 'running')
+    await this.db.prepare(`
+      INSERT INTO sixhats_debates (id, prd_id, biz_item_id, status, total_turns, completed_turns, model, org_id)
+      VALUES (?, ?, ?, 'running', 20, 0, ?, ?)
+    `).bind(debateId, prdId, bizItemId, model, orgId).run();
+
+    const turns: TurnResult[] = [];
+    const startTime = Date.now();
+    let totalTokens = 0;
+
+    try {
+      for (let i = 0; i < TURN_SEQUENCE.length; i++) {
+        const turnNumber = i + 1;
+        const hatColor = TURN_SEQUENCE[i]!;
+        const hat = HAT_CONFIGS[hatColor];
+
+        // 이전 N턴 컨텍스트
+        const recentTurns = turns.slice(-CONTEXT_WINDOW_TURNS).map((t) => ({
+          hat: HAT_CONFIGS[t.hat].label,
+          content: t.content,
+        }));
+
+        const { system, user } = buildTurnPrompt({
+          turnNumber,
+          hat,
+          prdSummary,
+          previousTurns: recentTurns,
+          roundInfo: "",
+        });
+
+        const turnStart = Date.now();
+        const result = await this.runner.execute({
+          taskId: `sixhats-${debateId}-turn-${turnNumber}`,
+          agentId: "sixhats-debate",
+          taskType: "spec-analysis",
+          context: {
+            repoUrl: "",
+            branch: "",
+            instructions: user,
+            systemPromptOverride: system,
+          },
+          constraints: [],
+        });
+
+        const content = result.output?.analysis ?? "";
+        const turnTokens = result.tokensUsed ?? 0;
+        const turnDuration = (Date.now() - turnStart) / 1000;
+
+        const turnResult: TurnResult = {
+          turnNumber,
+          hat: hatColor,
+          hatLabel: `${hat.emoji} ${hat.label}`,
+          content,
+          tokens: turnTokens,
+          durationSeconds: turnDuration,
+        };
+        turns.push(turnResult);
+        totalTokens += turnTokens;
+
+        // Save turn to D1
+        await this.db.prepare(`
+          INSERT INTO sixhats_turns (id, debate_id, turn_number, hat, hat_label, content, tokens, duration_seconds)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        `).bind(
+          generateId(), debateId, turnNumber, hatColor,
+          turnResult.hatLabel, content, turnTokens, turnDuration,
+        ).run();
+
+        // Update progress
+        await this.db.prepare(
+          `UPDATE sixhats_debates SET completed_turns = ? WHERE id = ?`
+        ).bind(turnNumber, debateId).run();
+      }
+
+      // Extract key issues from last Blue Hat turn
+      const lastBlue = turns.filter((t) => t.hat === "blue").pop();
+      const keyIssues = this.extractKeyIssues(lastBlue?.content ?? "");
+      const summary = lastBlue?.content ?? "";
+      const duration = (Date.now() - startTime) / 1000;
+
+      // Update debate as completed
+      await this.db.prepare(`
+        UPDATE sixhats_debates
+        SET status = 'completed', completed_turns = 20, key_issues = ?,
+            summary = ?, total_tokens = ?, duration_seconds = ?,
+            completed_at = datetime('now')
+        WHERE id = ?
+      `).bind(JSON.stringify(keyIssues), summary, totalTokens, duration, debateId).run();
+
+      return {
+        id: debateId,
+        prdId, bizItemId,
+        status: "completed",
+        totalTurns: 20,
+        completedTurns: turns.length,
+        turns, keyIssues, summary,
+        model, totalTokens, durationSeconds: duration,
+      };
+    } catch (err) {
+      const duration = (Date.now() - startTime) / 1000;
+      await this.db.prepare(`
+        UPDATE sixhats_debates SET status = 'failed', duration_seconds = ?, completed_at = datetime('now')
+        WHERE id = ?
+      `).bind(duration, debateId).run();
+
+      throw new SixHatsDebateError(
+        `Debate failed at turn ${turns.length + 1}: ${err instanceof Error ? err.message : String(err)}`,
+        "DEBATE_FAILED",
+      );
+    }
+  }
+
+  async getDebate(debateId: string): Promise<DebateResult | null> {
+    const debate = await this.db.prepare(
+      "SELECT * FROM sixhats_debates WHERE id = ?"
+    ).bind(debateId).first<SixHatsDebateRow>();
+    if (!debate) return null;
+
+    const { results: turnRows } = await this.db.prepare(
+      "SELECT * FROM sixhats_turns WHERE debate_id = ? ORDER BY turn_number"
+    ).bind(debateId).all<SixHatsTurnRow>();
+
+    return toDebateResult(debate, turnRows);
+  }
+
+  async listDebates(prdId: string): Promise<DebateResult[]> {
+    const { results: debates } = await this.db.prepare(
+      "SELECT * FROM sixhats_debates WHERE prd_id = ? ORDER BY created_at DESC"
+    ).bind(prdId).all<SixHatsDebateRow>();
+
+    const results: DebateResult[] = [];
+    for (const debate of debates) {
+      const { results: turnRows } = await this.db.prepare(
+        "SELECT * FROM sixhats_turns WHERE debate_id = ? ORDER BY turn_number"
+      ).bind(debate.id).all<SixHatsTurnRow>();
+      results.push(toDebateResult(debate, turnRows));
+    }
+    return results;
+  }
+
+  private extractKeyIssues(blueHatContent: string): string[] {
+    const lines = blueHatContent.split("\n");
+    const issues: string[] = [];
+    for (const line of lines) {
+      const trimmed = line.replace(/^[\s\-\*\d.]+/, "").trim();
+      if (trimmed.length > 10 && trimmed.length < 500) {
+        issues.push(trimmed);
+      }
+    }
+    return issues.slice(0, 10);
+  }
+}
+
+// ─── D1 Row Types ───
+
+interface SixHatsDebateRow {
+  id: string;
+  prd_id: string;
+  biz_item_id: string;
+  status: string;
+  total_turns: number;
+  completed_turns: number;
+  key_issues: string | null;
+  summary: string | null;
+  model: string;
+  total_tokens: number;
+  duration_seconds: number;
+  created_at: string;
+  completed_at: string | null;
+  org_id: string;
+}
+
+interface SixHatsTurnRow {
+  id: string;
+  debate_id: string;
+  turn_number: number;
+  hat: string;
+  hat_label: string;
+  content: string;
+  tokens: number;
+  duration_seconds: number;
+  created_at: string;
+}
+
+function toDebateResult(row: SixHatsDebateRow, turns: SixHatsTurnRow[]): DebateResult {
+  return {
+    id: row.id,
+    prdId: row.prd_id,
+    bizItemId: row.biz_item_id,
+    status: row.status as "completed" | "failed",
+    totalTurns: row.total_turns,
+    completedTurns: row.completed_turns,
+    turns: turns.map((t) => ({
+      turnNumber: t.turn_number,
+      hat: t.hat as HatColor,
+      hatLabel: t.hat_label,
+      content: t.content,
+      tokens: t.tokens,
+      durationSeconds: t.duration_seconds,
+    })),
+    keyIssues: row.key_issues ? JSON.parse(row.key_issues) : [],
+    summary: row.summary ?? "",
+    model: row.model,
+    totalTokens: row.total_tokens,
+    durationSeconds: row.duration_seconds,
+  };
+}
+
+function generateId(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes).map((b) => b.toString(16).padStart(2, "0")).join("");
+}

--- a/packages/fx-shaping/src/services/sixhats-prompts.ts
+++ b/packages/fx-shaping/src/services/sixhats-prompts.ts
@@ -1,0 +1,132 @@
+/**
+ * Sprint 56 F188: Six Hats 토론 — 프롬프트 정의 + 턴 시퀀스 + PRD 요약
+ */
+
+export type HatColor = "white" | "red" | "black" | "yellow" | "green" | "blue";
+
+export interface HatConfig {
+  color: HatColor;
+  emoji: string;
+  label: string;
+  role: string;
+  systemPrompt: string;
+}
+
+export const HAT_CONFIGS: Record<HatColor, HatConfig> = {
+  white: {
+    color: "white",
+    emoji: "⚪",
+    label: "White Hat (사실·데이터)",
+    role: "사실과 데이터만을 기반으로 PRD를 분석합니다",
+    systemPrompt: `당신은 Edward de Bono의 Six Hats 토론에서 ⚪ White Hat 역할입니다.
+오직 사실, 수치, 데이터, 근거에 기반하여 PRD를 분석하세요.
+감정이나 판단 없이, "무엇이 사실인가?"에만 집중하세요.
+- 정량적 수치의 존재 여부와 신뢰성을 검토
+- 근거 없는 주장을 식별
+- 빠진 데이터나 검증이 필요한 항목을 지적`,
+  },
+  red: {
+    color: "red",
+    emoji: "🔴",
+    label: "Red Hat (감정·직관)",
+    role: "감정적 반응과 직관으로 PRD를 평가합니다",
+    systemPrompt: `당신은 Edward de Bono의 Six Hats 토론에서 🔴 Red Hat 역할입니다.
+논리적 근거 없이, 순수한 감정과 직관으로 PRD를 평가하세요.
+- 이 PRD를 읽었을 때 드는 첫인상과 느낌
+- 팀원들이 어떻게 반응할지 직감적 예측
+- "느낌이 좋은/나쁜" 부분을 솔직하게 표현`,
+  },
+  black: {
+    color: "black",
+    emoji: "⚫",
+    label: "Black Hat (비판·리스크)",
+    role: "비판적 관점에서 약점과 리스크를 찾습니다",
+    systemPrompt: `당신은 Edward de Bono의 Six Hats 토론에서 ⚫ Black Hat 역할입니다.
+비판적·부정적 관점에서 PRD의 약점, 리스크, 실패 가능성을 집중 분석하세요.
+- 왜 이 프로젝트가 실패할 수 있는지
+- 누락된 리스크, 과소평가된 위험 요소
+- 시장/기술/조직적 장벽과 제약사항`,
+  },
+  yellow: {
+    color: "yellow",
+    emoji: "🟡",
+    label: "Yellow Hat (기회·가치)",
+    role: "긍정적 가치와 기회를 탐색합니다",
+    systemPrompt: `당신은 Edward de Bono의 Six Hats 토론에서 🟡 Yellow Hat 역할입니다.
+긍정적·낙관적 관점에서 PRD의 가치, 기회, 잠재력을 분석하세요.
+- 이 프로젝트가 성공하면 어떤 가치를 만드는지
+- 숨겨진 기회와 시너지 효과
+- 최선의 시나리오와 그 달성 조건`,
+  },
+  green: {
+    color: "green",
+    emoji: "🟢",
+    label: "Green Hat (창의·대안)",
+    role: "창의적 대안과 새로운 아이디어를 제시합니다",
+    systemPrompt: `당신은 Edward de Bono의 Six Hats 토론에서 🟢 Green Hat 역할입니다.
+창의적·혁신적 관점에서 기존 PRD를 넘어서는 새로운 아이디어와 대안을 제시하세요.
+- PRD에 없는 새로운 접근법이나 기능
+- 기존 가정을 뒤집는 역발상
+- 다른 산업/분야에서의 유사 성공 패턴 적용`,
+  },
+  blue: {
+    color: "blue",
+    emoji: "🔵",
+    label: "Blue Hat (종합·프로세스)",
+    role: "토론을 종합하고 프로세스를 관리합니다",
+    systemPrompt: `당신은 Edward de Bono의 Six Hats 토론에서 🔵 Blue Hat 역할입니다.
+지금까지의 토론을 종합하고, 핵심 쟁점을 정리하세요.
+- 각 모자 관점에서 나온 핵심 논점 요약
+- 합의된 부분과 여전히 논쟁 중인 부분 분류
+- 다음 논의가 필요한 액션 아이템 정리
+- 최종 권고사항 (Go/Conditional/Reconsider)`,
+  },
+};
+
+// 20턴 순환 패턴: 6모자 × 3라운드 + Green(19) + Blue(20)
+export const TURN_SEQUENCE: HatColor[] = [
+  "white", "red", "black", "yellow", "green", "blue",   // Round 1: 기본 분석
+  "white", "red", "black", "yellow", "green", "blue",   // Round 2: 심화 토론
+  "white", "red", "black", "yellow", "green", "blue",   // Round 3: 합의 수렴
+  "green", "blue",                                       // 마무리: 최종 대안 + 종합
+];
+
+export const MAX_PRD_SUMMARY_LENGTH = 3000;
+export const CONTEXT_WINDOW_TURNS = 3;  // 이전 3턴만 컨텍스트 주입
+
+export function summarizePrd(prdContent: string): string {
+  if (prdContent.length <= MAX_PRD_SUMMARY_LENGTH) return prdContent;
+  const half = Math.floor(MAX_PRD_SUMMARY_LENGTH / 2);
+  return prdContent.slice(0, half) + "\n\n[...중략...]\n\n" + prdContent.slice(-half);
+}
+
+export interface TurnContext {
+  turnNumber: number;
+  hat: HatConfig;
+  prdSummary: string;
+  previousTurns: Array<{ hat: string; content: string }>;
+  roundInfo: string;  // e.g., "라운드 2/3, 심화 토론"
+}
+
+export function buildTurnPrompt(ctx: TurnContext): { system: string; user: string } {
+  const roundLabel = ctx.turnNumber <= 6 ? "기본 분석"
+    : ctx.turnNumber <= 12 ? "심화 토론 — 이전 관점을 반박하거나 보강하세요"
+    : ctx.turnNumber <= 18 ? "합의 수렴 — 핵심 쟁점으로 좁히세요"
+    : ctx.turnNumber === 19 ? "최종 대안 — 모든 논의를 고려한 마지막 창의적 제안"
+    : "최종 종합 — 전체 토론의 핵심 쟁점과 권고사항 정리";
+
+  const prevContext = ctx.previousTurns.length > 0
+    ? `\n\n[이전 토론]\n${ctx.previousTurns.map((t) => `${t.hat}: ${t.content}`).join("\n\n")}`
+    : "";
+
+  return {
+    system: ctx.hat.systemPrompt,
+    user: `[Turn ${ctx.turnNumber}/20 — ${roundLabel}]
+
+[PRD 내용]
+${ctx.prdSummary}
+${prevContext}
+
+${ctx.hat.emoji} ${ctx.hat.label} 관점에서 분석하세요. 300~500자로 작성하세요.`,
+  };
+}

--- a/packages/fx-shaping/src/services/viability-checkpoint-service.ts
+++ b/packages/fx-shaping/src/services/viability-checkpoint-service.ts
@@ -1,0 +1,208 @@
+/**
+ * Sprint 69: 사업성 체크포인트 서비스 (F213)
+ * 2-1~2-7 각 단계 완료 시 Go/Pivot/Drop 판단 CRUD + 트래픽 라이트 집계
+ */
+
+export interface CheckpointInput {
+  bizItemId: string;
+  stage: string;
+  decision: string;
+  question: string;
+  reason?: string;
+}
+
+export interface CheckpointUpdateInput {
+  decision?: string;
+  question?: string;
+  reason?: string;
+}
+
+export interface Checkpoint {
+  id: string;
+  bizItemId: string;
+  orgId: string;
+  stage: string;
+  decision: string;
+  question: string;
+  reason: string | null;
+  decidedBy: string;
+  decidedAt: string;
+  createdAt: string;
+}
+
+export interface TrafficLight {
+  bizItemId: string;
+  summary: { go: number; pivot: number; drop: number; pending: number };
+  commitGate: { decision: string; decidedAt: string } | null;
+  checkpoints: Checkpoint[];
+  overallSignal: "green" | "yellow" | "red";
+}
+
+interface CheckpointRow {
+  id: string;
+  biz_item_id: string;
+  org_id: string;
+  stage: string;
+  decision: string;
+  question: string;
+  reason: string | null;
+  decided_by: string;
+  decided_at: string;
+  created_at: string;
+}
+
+interface CommitGateRow {
+  final_decision: string;
+  decided_at: string;
+}
+
+function generateId(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function toCheckpoint(row: CheckpointRow): Checkpoint {
+  return {
+    id: row.id,
+    bizItemId: row.biz_item_id,
+    orgId: row.org_id,
+    stage: row.stage,
+    decision: row.decision,
+    question: row.question,
+    reason: row.reason,
+    decidedBy: row.decided_by,
+    decidedAt: row.decided_at,
+    createdAt: row.created_at,
+  };
+}
+
+const ALL_STAGES = ["2-1", "2-2", "2-3", "2-4", "2-5", "2-6", "2-7"];
+
+function computeOverallSignal(
+  checkpoints: Checkpoint[],
+  commitGate: { decision: string } | null,
+): "green" | "yellow" | "red" {
+  const dropCount = checkpoints.filter((c) => c.decision === "drop").length;
+  const pivotCount = checkpoints.filter((c) => c.decision === "pivot").length;
+
+  if (dropCount >= 1 || commitGate?.decision === "drop") return "red";
+  if (pivotCount >= 2 || commitGate?.decision === "explore_alternatives") return "yellow";
+  return "green";
+}
+
+export class ViabilityCheckpointService {
+  constructor(private db: D1Database) {}
+
+  async create(orgId: string, userId: string, input: CheckpointInput): Promise<Checkpoint> {
+    const id = generateId();
+    const now = new Date().toISOString();
+
+    // UPSERT: replace if same biz_item_id + stage
+    await this.db
+      .prepare(
+        `INSERT INTO ax_viability_checkpoints (id, biz_item_id, org_id, stage, decision, question, reason, decided_by, decided_at, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(biz_item_id, stage) DO UPDATE SET
+           decision = excluded.decision,
+           question = excluded.question,
+           reason = excluded.reason,
+           decided_by = excluded.decided_by,
+           decided_at = excluded.decided_at`,
+      )
+      .bind(id, input.bizItemId, orgId, input.stage, input.decision, input.question, input.reason ?? null, userId, now, now)
+      .run();
+
+    const row = await this.db
+      .prepare("SELECT * FROM ax_viability_checkpoints WHERE biz_item_id = ? AND stage = ?")
+      .bind(input.bizItemId, input.stage)
+      .first<CheckpointRow>();
+
+    return toCheckpoint(row!);
+  }
+
+  async listByItem(bizItemId: string): Promise<Checkpoint[]> {
+    const { results } = await this.db
+      .prepare("SELECT * FROM ax_viability_checkpoints WHERE biz_item_id = ? ORDER BY stage")
+      .bind(bizItemId)
+      .all<CheckpointRow>();
+
+    return results.map(toCheckpoint);
+  }
+
+  async update(bizItemId: string, stage: string, input: CheckpointUpdateInput): Promise<Checkpoint | null> {
+    const existing = await this.db
+      .prepare("SELECT * FROM ax_viability_checkpoints WHERE biz_item_id = ? AND stage = ?")
+      .bind(bizItemId, stage)
+      .first<CheckpointRow>();
+
+    if (!existing) return null;
+
+    const now = new Date().toISOString();
+    await this.db
+      .prepare(
+        `UPDATE ax_viability_checkpoints
+         SET decision = ?, question = ?, reason = ?, decided_at = ?
+         WHERE biz_item_id = ? AND stage = ?`,
+      )
+      .bind(
+        input.decision ?? existing.decision,
+        input.question ?? existing.question,
+        input.reason !== undefined ? input.reason : existing.reason,
+        now,
+        bizItemId,
+        stage,
+      )
+      .run();
+
+    const row = await this.db
+      .prepare("SELECT * FROM ax_viability_checkpoints WHERE biz_item_id = ? AND stage = ?")
+      .bind(bizItemId, stage)
+      .first<CheckpointRow>();
+
+    return toCheckpoint(row!);
+  }
+
+  async delete(bizItemId: string, stage: string): Promise<boolean> {
+    const result = await this.db
+      .prepare("DELETE FROM ax_viability_checkpoints WHERE biz_item_id = ? AND stage = ?")
+      .bind(bizItemId, stage)
+      .run();
+
+    return (result.meta?.changes ?? 0) > 0;
+  }
+
+  async getTrafficLight(bizItemId: string): Promise<TrafficLight> {
+    const checkpoints = await this.listByItem(bizItemId);
+
+    // Commit Gate 조회
+    const gateRow = await this.db
+      .prepare("SELECT final_decision, decided_at FROM ax_commit_gates WHERE biz_item_id = ?")
+      .bind(bizItemId)
+      .first<CommitGateRow>();
+
+    const commitGate = gateRow
+      ? { decision: gateRow.final_decision, decidedAt: gateRow.decided_at }
+      : null;
+
+    const completedStages = new Set(checkpoints.map((c) => c.stage));
+    const pendingCount = ALL_STAGES.filter((s) => !completedStages.has(s)).length;
+
+    const summary = {
+      go: checkpoints.filter((c) => c.decision === "go").length,
+      pivot: checkpoints.filter((c) => c.decision === "pivot").length,
+      drop: checkpoints.filter((c) => c.decision === "drop").length,
+      pending: pendingCount,
+    };
+
+    return {
+      bizItemId,
+      summary,
+      commitGate,
+      checkpoints,
+      overallSignal: computeOverallSignal(checkpoints, commitGate),
+    };
+  }
+}

--- a/packages/fx-shaping/tsconfig.json
+++ b/packages/fx-shaping/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["@cloudflare/workers-types"],
+    "paths": {
+      "@foundry-x/shared": ["../shared/src/index.ts"]
+    }
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../shared" }
+  ]
+}

--- a/packages/fx-shaping/vitest.config.ts
+++ b/packages/fx-shaping/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+  },
+});

--- a/packages/fx-shaping/wrangler.toml
+++ b/packages/fx-shaping/wrangler.toml
@@ -1,0 +1,41 @@
+name = "fx-shaping"
+account_id = "b6c06059b413892a92f150e5ca496236"
+main = "src/index.ts"
+compatibility_date = "2026-03-17"
+compatibility_flags = ["nodejs_compat"]
+
+# F540: D1 바인딩 (동일 DB 공유, Phase 44에서 독립 DB로 전환 예정)
+[[d1_databases]]
+binding = "DB"
+database_name = "foundry-x-db"
+database_id = "6338688e-b050-4835-98a2-7101f9215c76"
+
+# F540: KV — rate limiting (ax-bd-agent, ax-bd-persona-eval)
+[[kv_namespaces]]
+binding = "CACHE"
+id = "030b30d47a98485ea3af95b3347163d6"
+
+# F540: R2 — prototype HTML 서빙 (ax-bd-prototypes)
+[[r2_buckets]]
+binding = "FILES_BUCKET"
+bucket_name = "foundry-x-files"
+
+[vars]
+ENVIRONMENT = "production"
+
+# Local development
+[env.dev]
+name = "fx-shaping-dev"
+
+[[env.dev.d1_databases]]
+binding = "DB"
+database_name = "foundry-x-db"
+database_id = "6338688e-b050-4835-98a2-7101f9215c76"
+
+[[env.dev.kv_namespaces]]
+binding = "CACHE"
+id = "030b30d47a98485ea3af95b3347163d6"
+
+[[env.dev.r2_buckets]]
+binding = "FILES_BUCKET"
+bucket_name = "foundry-x-files-dev"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,40 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/debug@4.1.13)(@types/node@20.19.37)(jiti@2.6.1)(jsdom@29.0.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.12.12(@types/node@20.19.37)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/fx-shaping:
+    dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.36.3
+        version: 0.36.3
+      '@foundry-x/shared':
+        specifier: workspace:*
+        version: link:../shared
+      '@hono/zod-openapi':
+        specifier: ^0.9.0
+        version: 0.9.10(hono@4.12.8)(zod@3.25.76)
+      hono:
+        specifier: ^4.0.0
+        version: 4.12.8
+      nanoid:
+        specifier: ^5.0.0
+        version: 5.1.7
+      zod:
+        specifier: ^3.23.0
+        version: 3.25.76
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20241218.0
+        version: 4.20260316.1
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.37
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@20.19.37)(jiti@2.6.1)(jsdom@29.0.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.12.12(@types/node@20.19.37)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
+
   packages/gate-x:
     dependencies:
       '@foundry-x/harness-kit':


### PR DESCRIPTION
## Summary

- **packages/fx-shaping** 독립 Cloudflare Worker 신규 생성 (F540: Shaping 도메인 분리)
  - 13 routes (shaping/bmc/agent/comments/history/links/viability/prototypes/skills/persona-eval/progress/persona-configs/evals)
  - 22 services, 15 schemas
  - D1 + KV(CACHE) + R2(FILES_BUCKET) 바인딩
- **fx-gateway** SHAPING Service Binding + `/api/shaping/*`, `/api/ax-bd/*` 라우팅
- **packages/api** shaping 13개 route 마운트 제거
- **deploy.yml** fx-shaping paths-filter + deploy step 추가
- TDD: 4 tests PASS (Match Rate 96%)

## Checklist

- [x] pnpm typecheck (fx-shaping, fx-gateway) PASS
- [x] pnpm test 4/4 PASS
- [x] deploy.yml CI/CD 통합
- [ ] Smoke Reality (배포 후 KOAMI 검증 필요)

## Related

- F539c (PR #597, Sprint 296) ← Discovery 분리 완료
- F541 (Sprint 298) → Offering 분리 예정

🤖 Auto-generated from Sprint autopilot

<!-- fx-pr-enrich -->
### Sprint Metadata
- Sprint: 297
- F-items: F540
- Match Rate: 96%
<!-- /fx-pr-enrich -->