### PR TITLE
fix(landing): Sprint 290 → 297 (S297 session-end content sync)

### DIFF
--- a/packages/web/content/landing/hero.md
+++ b/packages/web/content/landing/hero.md
@@ -12,7 +12,7 @@ stats:
     label: "AI 에이전트"
   - value: "63"
     label: "자동화 스킬"
-  - value: "290"
+  - value: "297"
     label: "Sprints"
 ---
 

--- a/packages/web/src/components/landing/footer.tsx
+++ b/packages/web/src/components/landing/footer.tsx
@@ -69,7 +69,7 @@ export function Footer() {
             &copy; {new Date().getFullYear()} KTDS AX BD. All rights reserved.
           </p>
           <p className="font-mono text-xs text-muted-foreground/60">
-            Sprint 290 &middot; Phase 44
+            Sprint 297 &middot; Phase 44
           </p>
         </div>
       </div>

--- a/packages/web/src/routes/landing.tsx
+++ b/packages/web/src/routes/landing.tsx
@@ -69,7 +69,7 @@ function getSectionOrder(section: string): number {
    ═══════════════════════════════════════════════ */
 
 const SITE_META_FALLBACK = {
-  sprint: "Sprint 290",
+  sprint: "Sprint 297",
   phase: "Phase 44",
   phaseTitle: "MSA 2차 분리 + Agent 품질 튜닝",
   tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼",
@@ -79,7 +79,7 @@ const STATS_FALLBACK = [
   { value: "2", label: "BD 파이프라인" },
   { value: "10+", label: "AI 에이전트" },
   { value: "63", label: "자동화 스킬" },
-  { value: "290", label: "Sprints" },
+  { value: "297", label: "Sprints" },
 ];
 
 // Build-time content from TinaCMS-managed Markdown


### PR DESCRIPTION
## Summary

content-sync drift 3파일 해소 (이전 master commit 9828b2dc에서 README+SPEC만 처리, web 3파일 누락):
- hero.md: stats.value 290 → 297
- landing.tsx: SITE_META_FALLBACK.sprint + STATS_FALLBACK.value
- footer.tsx footer: "Sprint 297 · Phase 44"

## Test plan
- [x] content-sync-check.sh PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)