### PR TITLE
fix(fx-discovery): biz-items 정적 경로 3개 fx-gateway 라우팅 충돌 해소

### DIFF
--- a/packages/api/src/core/discovery/routes/biz-items.ts
+++ b/packages/api/src/core/discovery/routes/biz-items.ts
@@ -58,6 +58,9 @@ import { DiscoveryStageService } from "../services/discovery-stage-service.js";
 export const bizItemsRoute = new Hono<{ Bindings: Env; Variables: TenantVariables }>();
 
 // ─── GET /biz-items/summary — 대시보드 ToDo 요약 (F323) ───
+// NOTE: Hotfix(2026-04-16)로 동일 핸들러를 packages/fx-discovery/src/routes/biz-items.ts 로 이전.
+// fx-gateway가 `/api/biz-items/:id` 패턴을 DISCOVERY로 라우팅하므로 이 코드는 현재 호출되지 않는 dead code.
+// Sprint 299 이후 cleanup 대상 (F541 Offering 분리 완료 후 packages/api 슬리밍과 함께).
 
 const STAGE_TO_NUMBER: Record<string, number> = {
   REGISTERED: 1,

--- a/packages/fx-discovery/src/__tests__/biz-items-static-paths.test.ts
+++ b/packages/fx-discovery/src/__tests__/biz-items-static-paths.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Hotfix: /biz-items/summary, /biz-items/portfolio-list, /biz-items/by-artifact
+ *
+ * 배경: F539c에서 fx-gateway가 `/api/biz-items/:id` 패턴을 DISCOVERY로 라우팅하면서,
+ * 정적 경로 3개(summary/portfolio-list/by-artifact)가 `:id`에 매칭되어 fx-discovery로 유입되지만
+ * fx-discovery에 핸들러가 없어 `/biz-items/:id` 핸들러가 id="summary" 등으로 오동작.
+ *
+ * 해법(옵션 B): 정적 경로 3개를 fx-discovery로 이전하여 F539c 의도와 정렬.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { sign } from "hono/jwt";
+import app from "../app.js";
+import type { DiscoveryEnv } from "../env.js";
+
+const TEST_SECRET = "test-secret-biz-items-static";
+
+async function makeAuthHeader(payload: Record<string, unknown> = {}) {
+  const token = await sign(
+    { sub: "user-1", orgId: "org-1", orgRole: "admin", exp: Math.floor(Date.now() / 1000) + 3600, ...payload },
+    TEST_SECRET,
+    "HS256",
+  );
+  return { Authorization: `Bearer ${token}` };
+}
+
+/**
+ * tenantGuard가 통과하도록 org_members 테이블 + 대상 테이블을 SQL별로 분기해서 반환해요.
+ */
+function makeDb(
+  handlers: {
+    summaryRows?: Record<string, unknown>[];
+    coverageRows?: Record<string, unknown>[];
+    lookupRows?: Record<string, unknown>[];
+  },
+): D1Database {
+  return {
+    prepare: vi.fn((sql: string) => {
+      const isOrgMember = sql.includes("org_members");
+      const isSummaryQuery = sql.includes("pipeline_stages") && sql.includes("LEFT JOIN");
+      const isCoverageQuery = sql.includes("biz_evaluations be") || sql.includes("has_evaluation");
+      const isLookupQuery = sql.includes("INNER JOIN") && (sql.includes("business_plan_drafts") || sql.includes("offerings") || sql.includes("prototypes"));
+
+      return {
+        bind: vi.fn().mockReturnValue({
+          all: vi.fn().mockImplementation(async () => {
+            if (isSummaryQuery) return { results: handlers.summaryRows ?? [] };
+            if (isCoverageQuery) return { results: handlers.coverageRows ?? [] };
+            if (isLookupQuery) return { results: handlers.lookupRows ?? [] };
+            return { results: [] };
+          }),
+          first: vi.fn().mockImplementation(async () => {
+            if (isOrgMember) return { role: "admin" };
+            return null;
+          }),
+          run: vi.fn().mockResolvedValue({ success: true }),
+        }),
+        all: vi.fn().mockResolvedValue({ results: [] }),
+        first: vi.fn().mockImplementation(async () => {
+          if (isOrgMember) return { role: "admin" };
+          return null;
+        }),
+        run: vi.fn().mockResolvedValue({ success: true }),
+      };
+    }),
+  } as unknown as D1Database;
+}
+
+const makeEnv = (db: D1Database): DiscoveryEnv => ({
+  DB: db,
+  JWT_SECRET: TEST_SECRET,
+  ANTHROPIC_API_KEY: "test",
+});
+
+describe("biz-items 정적 경로 3개 (fx-discovery 이전)", () => {
+  it("GET /api/biz-items/summary → 200 with items array (ToDo 요약)", async () => {
+    const db = makeDb({
+      summaryRows: [
+        { biz_item_id: "item-1", title: "Item 1", stage: "DISCOVERY" },
+        { biz_item_id: "item-2", title: "Item 2", stage: null },
+      ],
+    });
+    const headers = await makeAuthHeader();
+
+    const res = await app.request("/api/biz-items/summary", { headers }, makeEnv(db));
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as { items: Array<{ bizItemId: string; title: string; currentStage: number }> };
+    expect(Array.isArray(body.items)).toBe(true);
+    expect(body.items).toHaveLength(2);
+    expect(body.items[0]).toMatchObject({ bizItemId: "item-1", title: "Item 1", currentStage: 2 });
+    expect(body.items[1]).toMatchObject({ bizItemId: "item-2", title: "Item 2", currentStage: 1 });
+  });
+
+  it("GET /api/biz-items/portfolio-list → 200 with coverage data", async () => {
+    const db = makeDb({
+      coverageRows: [
+        {
+          id: "item-1",
+          title: "Item 1",
+          status: "draft",
+          created_at: "2026-04-15T00:00:00Z",
+          current_stage: "DISCOVERY",
+          has_evaluation: 1,
+          prd_count: 0,
+          offering_count: 0,
+          prototype_count: 0,
+          criteria_completed: 3,
+          criteria_total: 9,
+        },
+      ],
+    });
+    const headers = await makeAuthHeader();
+
+    const res = await app.request("/api/biz-items/portfolio-list", { headers }, makeEnv(db));
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as { data: { items: unknown[]; total: number } };
+    expect(body.data.total).toBe(1);
+    expect(Array.isArray(body.data.items)).toBe(true);
+  });
+
+  it("GET /api/biz-items/by-artifact?type=prd&id=xxx → 200 with bizItems", async () => {
+    const db = makeDb({
+      lookupRows: [{ id: "item-1", title: "Item 1", status: "draft", current_stage: "DISCOVERY" }],
+    });
+    const headers = await makeAuthHeader();
+
+    const res = await app.request("/api/biz-items/by-artifact?type=prd&id=plan-1", { headers }, makeEnv(db));
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as { data: { artifactType: string; artifactId: string; bizItems: unknown[] } };
+    expect(body.data.artifactType).toBe("prd");
+    expect(body.data.artifactId).toBe("plan-1");
+    expect(body.data.bizItems).toHaveLength(1);
+  });
+
+  it("GET /api/biz-items/by-artifact → 400 without type param", async () => {
+    const db = makeDb({});
+    const headers = await makeAuthHeader();
+
+    const res = await app.request("/api/biz-items/by-artifact?id=plan-1", { headers }, makeEnv(db));
+    expect(res.status).toBe(400);
+  });
+
+  it("GET /api/biz-items/by-artifact → 400 without id param", async () => {
+    const db = makeDb({});
+    const headers = await makeAuthHeader();
+
+    const res = await app.request("/api/biz-items/by-artifact?type=prd", { headers }, makeEnv(db));
+    expect(res.status).toBe(400);
+  });
+
+  it("정적 경로는 /:id 패턴보다 먼저 매칭되어야 함 — summary가 id='summary'로 해석되지 않음", async () => {
+    // summary 쿼리가 호출되면 통과, :id가 먼저 매칭되면 다른 쿼리가 호출됨
+    const db = makeDb({ summaryRows: [] });
+    const headers = await makeAuthHeader();
+
+    const res = await app.request("/api/biz-items/summary", { headers }, makeEnv(db));
+    expect(res.status).toBe(200); // :id가 먼저 잡히면 404가 뜰 것
+    const body = await res.json() as { items: unknown[] };
+    expect(Array.isArray(body.items)).toBe(true);
+  });
+});

--- a/packages/fx-discovery/src/routes/biz-items.ts
+++ b/packages/fx-discovery/src/routes/biz-items.ts
@@ -1,14 +1,89 @@
 /**
  * F539c Group A: biz-items 3 라우트 (FX-REQ-578)
  * GET /api/biz-items, POST /api/biz-items, GET /api/biz-items/:id
+ *
+ * Hotfix: 정적 경로 3개 추가 이전 — summary, portfolio-list, by-artifact.
+ * fx-gateway `/api/biz-items/:id` → DISCOVERY 라우팅 시 정적 경로 3개가 `:id`에 잡혀 오동작하던 문제 해소.
+ * 반드시 `:id` 라우트보다 먼저 등록해야 해요 (Hono 매칭 순서).
  */
 import { Hono } from "hono";
 import type { DiscoveryEnv } from "../env.js";
 import type { TenantVariables } from "../middleware/tenant.js";
 import { CreateBizItemSchema } from "../schemas/biz-item.js";
 import { BizItemCrudService } from "../services/biz-item-crud.service.js";
+import { PortfolioService } from "../services/portfolio.service.js";
+
+const STAGE_TO_NUMBER: Record<string, number> = {
+  REGISTERED: 1,
+  DISCOVERY: 2,
+  FORMALIZATION: 3,
+  REVIEW: 4,
+  DECISION: 5,
+  OFFERING: 6,
+  MVP: 6,
+};
 
 export const bizItemsRoute = new Hono<{ Bindings: DiscoveryEnv; Variables: TenantVariables }>();
+
+// GET /biz-items/summary — 대시보드 ToDo 요약 (F323)
+// 주의: :id 라우트보다 먼저 등록 필수 (정적 경로 우선)
+bizItemsRoute.get("/biz-items/summary", async (c) => {
+  const orgId = c.get("orgId");
+
+  const { results } = await c.env.DB
+    .prepare(
+      `SELECT bi.id AS biz_item_id, bi.title, ps.stage
+       FROM biz_items bi
+       LEFT JOIN pipeline_stages ps
+         ON ps.biz_item_id = bi.id AND ps.exited_at IS NULL
+       WHERE bi.org_id = ?
+       ORDER BY bi.created_at DESC`,
+    )
+    .bind(orgId)
+    .all<{ biz_item_id: string; title: string; stage: string | null }>();
+
+  const items = results.map((r) => ({
+    bizItemId: r.biz_item_id,
+    title: r.title,
+    currentStage: STAGE_TO_NUMBER[r.stage ?? "REGISTERED"] ?? 1,
+  }));
+
+  return c.json({ items });
+});
+
+// GET /biz-items/portfolio-list — 전체 포트폴리오 + coverage (F459)
+bizItemsRoute.get("/biz-items/portfolio-list", async (c) => {
+  const orgId = c.get("orgId");
+  const service = new PortfolioService(c.env.DB);
+  try {
+    const result = await service.listWithCoverage(orgId);
+    return c.json({ data: result });
+  } catch {
+    return c.json({ error: "포트폴리오 목록 조회 중 오류가 발생했어요" }, 500);
+  }
+});
+
+// GET /biz-items/by-artifact — 산출물 ID로 역방향 조회 (F459)
+bizItemsRoute.get("/biz-items/by-artifact", async (c) => {
+  const orgId = c.get("orgId");
+  const type = c.req.query("type") as "prd" | "offering" | "prototype" | undefined;
+  const id = c.req.query("id");
+
+  if (!type || !["prd", "offering", "prototype"].includes(type)) {
+    return c.json({ error: "type 파라미터는 prd | offering | prototype 이어야 해요" }, 400);
+  }
+  if (!id) {
+    return c.json({ error: "id 파라미터가 필요해요" }, 400);
+  }
+
+  const service = new PortfolioService(c.env.DB);
+  try {
+    const result = await service.findByArtifact(type, id, orgId);
+    return c.json({ data: result });
+  } catch {
+    return c.json({ error: "역방향 조회 중 오류가 발생했어요" }, 500);
+  }
+});
 
 // GET /biz-items — 목록 조회
 bizItemsRoute.get("/biz-items", async (c) => {

--- a/packages/fx-discovery/src/services/portfolio.service.ts
+++ b/packages/fx-discovery/src/services/portfolio.service.ts
@@ -1,0 +1,147 @@
+/**
+ * Portfolio Service — fx-discovery (hotfix: biz-items 정적 경로 이전)
+ *
+ * 원본: packages/api/src/core/discovery/services/portfolio-service.ts
+ * 포팅 범위: biz-items/portfolio-list, biz-items/by-artifact 두 라우트가 필요한 메서드만.
+ * (getPortfolioTree 등 다른 메서드는 이전 불필요 — 호출 경로 없음)
+ */
+
+const STAGE_ORDER = ["REGISTERED", "DISCOVERY", "FORMALIZATION", "REVIEW", "DECISION", "OFFERING"];
+
+export interface PortfolioListItem {
+  id: string;
+  title: string;
+  status: string;
+  currentStage: string;
+  hasEvaluation: boolean;
+  prdCount: number;
+  offeringCount: number;
+  prototypeCount: number;
+  overallPercent: number;
+  createdAt: string;
+}
+
+export interface ArtifactLookupResponse {
+  artifactType: "prd" | "offering" | "prototype";
+  artifactId: string;
+  bizItems: Array<{
+    id: string;
+    title: string;
+    status: string;
+    currentStage: string;
+  }>;
+}
+
+interface RawCoverageRow {
+  id: string;
+  title: string;
+  status: string;
+  created_at: string;
+  current_stage: string | null;
+  has_evaluation: number;
+  prd_count: number;
+  offering_count: number;
+  prototype_count: number;
+  criteria_completed: number;
+  criteria_total: number;
+}
+
+interface RawBizItemRef {
+  id: string;
+  title: string;
+  status: string;
+  current_stage: string | null;
+}
+
+export class PortfolioService {
+  constructor(private db: D1Database) {}
+
+  async listWithCoverage(orgId: string): Promise<{ items: PortfolioListItem[]; total: number }> {
+    const { results } = await this.db
+      .prepare(
+        `SELECT
+          b.id,
+          b.title,
+          b.status,
+          b.created_at,
+          (SELECT ps.stage FROM pipeline_stages ps WHERE ps.biz_item_id = b.id ORDER BY ps.entered_at DESC LIMIT 1) AS current_stage,
+          (SELECT COUNT(*) FROM biz_evaluations be WHERE be.biz_item_id = b.id) AS has_evaluation,
+          (SELECT COUNT(*) FROM business_plan_drafts bp WHERE bp.biz_item_id = b.id) AS prd_count,
+          (SELECT COUNT(*) FROM offerings o WHERE o.biz_item_id = b.id) AS offering_count,
+          (SELECT COUNT(*) FROM prototypes p WHERE p.biz_item_id = b.id) AS prototype_count,
+          (SELECT COUNT(*) FROM biz_discovery_criteria dc WHERE dc.biz_item_id = b.id AND dc.status = 'completed') AS criteria_completed,
+          (SELECT COUNT(*) FROM biz_discovery_criteria dc WHERE dc.biz_item_id = b.id) AS criteria_total
+        FROM biz_items b
+        WHERE b.org_id = ?
+        ORDER BY b.created_at DESC`,
+      )
+      .bind(orgId)
+      .all<RawCoverageRow>();
+
+    const items: PortfolioListItem[] = results.map((r) => {
+      const currentStage = r.current_stage ?? "REGISTERED";
+      const stageIdx = STAGE_ORDER.indexOf(currentStage);
+      const completedStagesCount = Math.max(0, stageIdx + 1);
+
+      const stagePercent = (completedStagesCount / STAGE_ORDER.length) * 30;
+      const criteriaPercent = r.criteria_total > 0 ? (r.criteria_completed / 9) * 25 : 0;
+      const planPercent = r.prd_count > 0 ? 15 : 0;
+      const offeringPercent = r.offering_count > 0 ? 15 : 0;
+      const prototypePercent = r.prototype_count > 0 ? 15 : 0;
+
+      return {
+        id: r.id,
+        title: r.title,
+        status: r.status,
+        currentStage,
+        hasEvaluation: r.has_evaluation > 0,
+        prdCount: r.prd_count,
+        offeringCount: r.offering_count,
+        prototypeCount: r.prototype_count,
+        overallPercent: Math.round(stagePercent + criteriaPercent + planPercent + offeringPercent + prototypePercent),
+        createdAt: r.created_at,
+      };
+    });
+
+    return { items, total: items.length };
+  }
+
+  async findByArtifact(
+    type: "prd" | "offering" | "prototype",
+    artifactId: string,
+    orgId: string,
+  ): Promise<ArtifactLookupResponse> {
+    const tableMap = {
+      prd: { table: "business_plan_drafts", fk: "biz_item_id" },
+      offering: { table: "offerings", fk: "biz_item_id" },
+      prototype: { table: "prototypes", fk: "biz_item_id" },
+    } as const;
+
+    const { table, fk } = tableMap[type];
+
+    const { results } = await this.db
+      .prepare(
+        `SELECT DISTINCT
+          b.id,
+          b.title,
+          b.status,
+          (SELECT ps.stage FROM pipeline_stages ps WHERE ps.biz_item_id = b.id ORDER BY ps.entered_at DESC LIMIT 1) AS current_stage
+        FROM biz_items b
+        INNER JOIN ${table} a ON a.${fk} = b.id
+        WHERE a.id = ? AND b.org_id = ?`,
+      )
+      .bind(artifactId, orgId)
+      .all<RawBizItemRef>();
+
+    return {
+      artifactType: type,
+      artifactId,
+      bizItems: results.map((r) => ({
+        id: r.id,
+        title: r.title,
+        status: r.status,
+        currentStage: r.current_stage ?? "REGISTERED",
+      })),
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- fx-gateway `/api/biz-items/:id` → DISCOVERY 라우팅(F539c)에서 `/biz-items/summary`, `/biz-items/portfolio-list`, `/biz-items/by-artifact` 3개 정적 경로가 `:id` 패턴에 매칭되어 fx-discovery로 오유입 → 401/오동작
- **옵션 B**: 정적 경로 3개를 packages/fx-discovery로 이전 (F539c 의도 정렬). `:id` 라우트 앞에 등록하여 정적 경로 우선 매칭
- PortfolioService의 `listWithCoverage` + `findByArtifact` 2개 메서드만 선택 포팅 (다른 메서드는 호출 경로 없음)

## 재현

```bash
curl -I https://fx-gateway.ktds-axbd.workers.dev/api/biz-items/summary
# → HTTP 401 (fx-discovery JWT 미들웨어 — no authorization)
```

브라우저: 로그인 후 대시보드에서 `/api/biz-items/summary 401` 반복

## TDD

- **Red**: `packages/fx-discovery/src/__tests__/biz-items-static-paths.test.ts` 6 tests FAIL
- **Green**: 동일 6 tests PASS
  - summary 200 + items 배열
  - portfolio-list 200 + coverage
  - by-artifact 200 + bizItems
  - by-artifact 400 (type 누락)
  - by-artifact 400 (id 누락)
  - 정적 경로 우선순위 (summary가 `:id`로 해석되지 않음)

## 검증

- `turbo test + typecheck + lint` (12 packages) 전부 PASS

## Test plan

- [x] Red Phase FAIL 확인 (구현 전)
- [x] Green Phase PASS 확인 (구현 후)
- [x] 전체 typecheck PASS
- [x] 전체 lint PASS
- [ ] 배포 후 prod curl `/api/biz-items/summary` (auth 포함) → 200 확인
- [ ] 4/17 09:00 리허설 전 fx.minu.best/dashboard 로그인 → summary 정상 로드

## 후속

- `packages/api/src/core/discovery/routes/biz-items.ts`의 3개 핸들러는 dead code 주석 추가 — Sprint 299 (F541 Offering 이후) cleanup 대상

🤖 Generated with [Claude Code](https://claude.com/claude-code)