### PR TITLE
feat: Sprint 303 — F552 Dual AI Review D1 + Dashboard

### DIFF
--- a/docs/01-plan/features/sprint-303.plan.md
+++ b/docs/01-plan/features/sprint-303.plan.md
@@ -1,0 +1,85 @@
+# Sprint 303 Plan — F552 Dual AI Review D1 + Dashboard
+
+**F-item:** F552 (FX-REQ-589, P1)
+**Phase:** 46 Dual-AI Verification
+**PRD:** `docs/specs/fx-codex-integration/prd-final.md` FR-06, FR-07
+**선행:** F550/F551/F554 ✅ (Codex 인프라 + Phase 5c 배선)
+
+---
+
+## 목표
+
+Sprint autopilot Phase 5c에서 생성되는 `codex-review.json`을 D1에 영속화하고,
+`/work-management` 대시보드에 "Dual AI Review" 탭을 추가하여 Sprint별 리뷰 결과를 시각화한다.
+
+## 범위
+
+### M1. D1 Migration (`0138_dual_ai_reviews.sql`)
+
+```sql
+CREATE TABLE IF NOT EXISTS dual_ai_reviews (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  sprint_id INTEGER NOT NULL,
+  claude_verdict TEXT,          -- PASS/BLOCK/WARN
+  codex_verdict TEXT,           -- PASS/BLOCK/WARN/PASS-degraded
+  codex_json TEXT NOT NULL,     -- codex-review.json 전문 (JSON string)
+  divergence_score REAL DEFAULT 0.0,
+  decision TEXT,                -- composite verdict: PASS/WARN/BLOCK/PASS-degraded
+  degraded INTEGER DEFAULT 0,  -- 1 = Codex unavailable
+  degraded_reason TEXT,
+  model TEXT,                   -- codex-cli/mock/none
+  created_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_dual_ai_reviews_sprint ON dual_ai_reviews(sprint_id);
+```
+
+### M2. API 엔드포인트 (core/verification/)
+
+MSA 원칙에 따라 `packages/api/src/core/verification/` 신규 도메인:
+
+| Method | Path | 설명 |
+|--------|------|------|
+| POST | `/api/verification/dual-review` | Sprint 리뷰 결과 저장 |
+| GET | `/api/verification/dual-reviews` | 전체 목록 (최근 20건) |
+| GET | `/api/verification/dual-reviews/stats` | 집계: 일치율, BLOCK 사유 Top 5, degraded 비율 |
+
+Zod 스키마로 입력 검증, 서비스 레이어 경유.
+
+### M3. Dashboard 위젯 (work-management.tsx)
+
+기존 7탭에 "AI 검증" 탭 추가 (8번째):
+
+- **요약 카드**: 총 리뷰 수, 일치율(%), BLOCK 비율(%), degraded 비율(%)
+- **리뷰 테이블**: Sprint별 claude_verdict vs codex_verdict + decision + divergence_score
+- **BLOCK 사유 Top 5**: code_issues에서 severity=high 집계
+
+### M4. autopilot 배선
+
+`codex-review.sh` 완료 후 D1 POST 호출 추가:
+- `scripts/autopilot/composite-verify.sh` 또는 autopilot SKILL.md Phase 5c에서 API 호출
+- 기존 JSON 파일 저장은 유지 (로컬 백업)
+
+## 변경 파일 예상
+
+| 패키지 | 파일 | 변경 |
+|--------|------|------|
+| api | `src/db/migrations/0138_dual_ai_reviews.sql` | 신규 |
+| api | `src/core/verification/routes/index.ts` | 신규 |
+| api | `src/core/verification/services/dual-review.service.ts` | 신규 |
+| api | `src/core/verification/schemas.ts` | 신규 |
+| api | `src/core/verification/types.ts` | 신규 |
+| api | `src/app.ts` | sub-app mount 1줄 |
+| web | `src/routes/work-management.tsx` | 탭 추가 |
+| scripts | `scripts/autopilot/composite-verify.sh` | D1 POST 배선 |
+
+## TDD 계획
+
+- **Red**: dual-review.service.test.ts (insert/list/stats), routes.test.ts (POST/GET)
+- **Green**: 서비스 + 라우트 구현
+- **E2E**: work-management Dual AI Review 탭 렌더링 확인
+
+## 리스크
+
+- R1: work-management.tsx가 1265줄로 이미 큰 파일 — 탭 컴포넌트를 별도 파일로 분리 검토
+- R2: autopilot 배선은 WT 내에서 테스트 불가 (Master pane에서 검증)

--- a/docs/02-design/features/sprint-303.design.md
+++ b/docs/02-design/features/sprint-303.design.md
@@ -1,0 +1,167 @@
+# Sprint 303 Design — F552 Dual AI Review D1 + Dashboard
+
+**Plan:** `docs/01-plan/features/sprint-303.plan.md`
+**PRD:** `docs/specs/fx-codex-integration/prd-final.md` FR-06, FR-07
+
+---
+
+## §1 변경 요약
+
+| 구분 | 내용 |
+|------|------|
+| D1 Migration | `0138_dual_ai_reviews.sql` — 테이블 1개 + 인덱스 1개 |
+| API | `core/verification/` 도메인 신규 — 3 라우트, 1 서비스, Zod 스키마 |
+| Web | `work-management.tsx` — "AI 검증" 탭 추가 |
+| Scripts | `scripts/autopilot/save-dual-review.sh` — D1 POST 배선 |
+
+## §2 D1 스키마
+
+```sql
+CREATE TABLE IF NOT EXISTS dual_ai_reviews (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  sprint_id INTEGER NOT NULL,
+  claude_verdict TEXT,
+  codex_verdict TEXT,
+  codex_json TEXT NOT NULL,
+  divergence_score REAL DEFAULT 0.0,
+  decision TEXT,
+  degraded INTEGER DEFAULT 0,
+  degraded_reason TEXT,
+  model TEXT,
+  created_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_dual_ai_reviews_sprint ON dual_ai_reviews(sprint_id);
+```
+
+### 컬럼 설명
+
+| 컬럼 | 타입 | 설명 |
+|------|------|------|
+| sprint_id | INTEGER NOT NULL | Sprint 번호 (예: 303) |
+| claude_verdict | TEXT | Claude code-verify 결과: PASS/BLOCK/WARN |
+| codex_verdict | TEXT | Codex 리뷰 결과: PASS/BLOCK/WARN/PASS-degraded |
+| codex_json | TEXT NOT NULL | codex-review.json 전문 |
+| divergence_score | REAL | 0.0~1.0, 두 모델 의견 차이 |
+| decision | TEXT | 최종 composite: PASS/WARN/BLOCK/PASS-degraded |
+| degraded | INTEGER | 1 = Codex 미사용 |
+| degraded_reason | TEXT | codex_unavailable/codex_empty_response/... |
+| model | TEXT | codex-cli/mock/none |
+| created_at | TEXT | ISO 8601 timestamp |
+
+## §3 API 설계
+
+### 3.1 라우트 (Hono sub-app)
+
+`packages/api/src/core/verification/routes/index.ts`
+
+```typescript
+const app = new Hono<AppEnv>();
+
+// POST /api/verification/dual-review
+app.post("/verification/dual-review", ...);
+
+// GET /api/verification/dual-reviews
+app.get("/verification/dual-reviews", ...);
+
+// GET /api/verification/dual-reviews/stats
+app.get("/verification/dual-reviews/stats", ...);
+```
+
+### 3.2 Zod 스키마
+
+`packages/api/src/core/verification/schemas.ts`
+
+```typescript
+export const DualReviewInsertSchema = z.object({
+  sprint_id: z.number().int().positive(),
+  claude_verdict: z.enum(["PASS", "BLOCK", "WARN"]).nullable().optional(),
+  codex_verdict: z.enum(["PASS", "BLOCK", "WARN", "PASS-degraded"]),
+  codex_json: z.string(),
+  divergence_score: z.number().min(0).max(1).default(0),
+  decision: z.enum(["PASS", "BLOCK", "WARN", "PASS-degraded"]),
+  degraded: z.boolean().default(false),
+  degraded_reason: z.string().nullable().optional(),
+  model: z.string().default("codex-cli"),
+});
+
+export const DualReviewStatsSchema = z.object({
+  total: z.number(),
+  concordance_rate: z.number(),  // 일치율 %
+  block_rate: z.number(),
+  degraded_rate: z.number(),
+  block_reasons: z.array(z.object({
+    reason: z.string(),
+    count: z.number(),
+  })),
+  recent_reviews: z.array(z.object({
+    sprint_id: z.number(),
+    claude_verdict: z.string().nullable(),
+    codex_verdict: z.string(),
+    decision: z.string(),
+    divergence_score: z.number(),
+    degraded: z.boolean(),
+    created_at: z.string(),
+  })),
+});
+```
+
+### 3.3 서비스
+
+`packages/api/src/core/verification/services/dual-review.service.ts`
+
+```typescript
+export class DualReviewService {
+  constructor(private db: D1Database) {}
+
+  async insert(data: DualReviewInsert): Promise<{ id: number }>;
+  async list(limit?: number): Promise<DualReview[]>;
+  async stats(): Promise<DualReviewStats>;
+}
+```
+
+## §4 Web UI 설계
+
+### 4.1 work-management.tsx 변경
+
+탭 배열에 추가:
+```typescript
+{ key: "ai-review", label: "AI 검증" },
+```
+
+### 4.2 DualAiReviewTab 컴포넌트
+
+- **요약 카드 행** (4개): 총 리뷰 / 일치율 / BLOCK율 / Degraded율
+- **리뷰 테이블**: 최근 20건, Sprint별 verdict 비교
+- **BLOCK 사유 Top 5**: 바 차트 또는 목록
+
+API 호출: `GET /api/verification/dual-reviews/stats`
+
+## §5 파일 매핑
+
+| # | 파일 | 변경 유형 | 설명 |
+|---|------|----------|------|
+| 1 | `packages/api/src/db/migrations/0138_dual_ai_reviews.sql` | 신규 | D1 테이블 |
+| 2 | `packages/api/src/core/verification/types.ts` | 신규 | 타입 정의 |
+| 3 | `packages/api/src/core/verification/schemas.ts` | 신규 | Zod 스키마 |
+| 4 | `packages/api/src/core/verification/services/dual-review.service.ts` | 신규 | D1 CRUD |
+| 5 | `packages/api/src/core/verification/routes/index.ts` | 신규 | Hono sub-app |
+| 6 | `packages/api/src/app.ts` | 수정 | sub-app mount 1줄 |
+| 7 | `packages/web/src/routes/work-management.tsx` | 수정 | AI 검증 탭 추가 |
+| 8 | `scripts/autopilot/save-dual-review.sh` | 신규 | autopilot→D1 POST |
+
+### 테스트 파일
+
+| # | 파일 | 대상 |
+|---|------|------|
+| T1 | `packages/api/src/core/verification/services/dual-review.service.test.ts` | 서비스 CRUD |
+| T2 | `packages/api/src/core/verification/routes/index.test.ts` | 라우트 통합 |
+
+## §6 Stage 3 Exit 체크리스트
+
+| # | 항목 | 판정 |
+|---|------|------|
+| D1 | 주입 사이트 전수 — codex-review.sh → save-dual-review.sh → POST /api/verification/dual-review → DualReviewService.insert() → D1 | PASS — 4단계 체인 완전 |
+| D2 | 식별자 계약 — sprint_id (INTEGER, e.g. 303), codex_json (full JSON string) | PASS — sprint 번호는 정수, JSON은 문자열로 저장 |
+| D3 | Breaking change — 신규 테이블/라우트/UI, 기존 영향 없음 | PASS — additive only |
+| D4 | TDD Red 파일 — T1, T2 테스트 파일 FAIL 확인 후 커밋 | 대기 |

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -68,6 +68,7 @@ import { helpAgentRoute } from "./routes/help-agent.js";
 import { eventStatusRoute } from "./routes/event-status.js";
 import { workRoute } from "./routes/work.js";
 import { workPublicRoute } from "./routes/work-public.js";
+import { verificationRoute } from "./core/verification/routes/index.js";
 import { handleScheduled } from "./scheduled.js";
 import { authMiddleware } from "./middleware/auth.js";
 import { piiMaskerMiddleware } from "./middleware/pii-masker.middleware.js";
@@ -433,6 +434,9 @@ app.route("/api", billingRoute);
 app.route("/api", filesRoute);
 
 // Sprint 298: fx-ai-foundry-os Decode-X 연동 (F546) — public mount는 line 220 이전으로 이동됨
+
+// Sprint 303: Dual AI Review (F552)
+app.route("/api", verificationRoute);
 
 // Sprint 261: Work Observability Walking Skeleton (F509)
 app.route("/api", workRoute);

--- a/packages/api/src/core/verification/routes/__tests__/routes.test.ts
+++ b/packages/api/src/core/verification/routes/__tests__/routes.test.ts
@@ -1,0 +1,171 @@
+/**
+ * F552 TDD Red Phase — Verification Routes
+ * Sprint 303 | FX-REQ-589
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { createMockD1 } from "../../../../__tests__/helpers/mock-d1.js";
+import { verificationRoute } from "../index.js";
+import { Hono } from "hono";
+import type { Env } from "../../../../env.js";
+
+const DDL = `
+  CREATE TABLE IF NOT EXISTS dual_ai_reviews (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    sprint_id INTEGER NOT NULL,
+    claude_verdict TEXT,
+    codex_verdict TEXT,
+    codex_json TEXT NOT NULL,
+    divergence_score REAL DEFAULT 0.0,
+    decision TEXT,
+    degraded INTEGER DEFAULT 0,
+    degraded_reason TEXT,
+    model TEXT,
+    created_at TEXT DEFAULT (datetime('now'))
+  );
+  CREATE INDEX IF NOT EXISTS idx_dual_ai_reviews_sprint ON dual_ai_reviews(sprint_id);
+`;
+
+const SAMPLE_BODY = {
+  sprint_id: 303,
+  claude_verdict: "PASS",
+  codex_verdict: "PASS",
+  codex_json: JSON.stringify({ verdict: "PASS", code_issues: [] }),
+  divergence_score: 0.0,
+  decision: "PASS",
+  degraded: false,
+  model: "codex-cli",
+};
+
+function createApp(db: D1Database) {
+  const app = new Hono<{ Bindings: Env }>();
+  app.use("*", async (c, next) => {
+    c.set("orgId" as never, "org_test");
+    c.set("jwtPayload" as never, { sub: "test-user" });
+    await next();
+  });
+  app.route("/api", verificationRoute);
+  return {
+    request: (path: string, init?: RequestInit) =>
+      app.request(path, init, { DB: db } as unknown as Env),
+  };
+}
+
+describe("F552 Verification Routes", () => {
+  let db: D1Database;
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(async () => {
+    const mockDb = createMockD1();
+    await mockDb.exec(DDL);
+    db = mockDb as unknown as D1Database;
+    app = createApp(db);
+  });
+
+  describe("POST /api/verification/dual-review", () => {
+    it("creates a review and returns 201 with id", async () => {
+      const res = await app.request("/api/verification/dual-review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(SAMPLE_BODY),
+      });
+      expect(res.status).toBe(201);
+      const json = await res.json();
+      expect(json).toHaveProperty("id");
+      expect(json.id).toBeGreaterThan(0);
+    });
+
+    it("returns 400 on invalid body (missing sprint_id)", async () => {
+      const { sprint_id: _removed, ...invalid } = SAMPLE_BODY;
+      const res = await app.request("/api/verification/dual-review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(invalid),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 on invalid codex_verdict enum", async () => {
+      const res = await app.request("/api/verification/dual-review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...SAMPLE_BODY, codex_verdict: "INVALID" }),
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("GET /api/verification/dual-reviews", () => {
+    it("returns 200 with empty array initially", async () => {
+      const res = await app.request("/api/verification/dual-reviews");
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json).toHaveProperty("reviews");
+      expect(json.reviews).toEqual([]);
+    });
+
+    it("returns inserted reviews", async () => {
+      await app.request("/api/verification/dual-review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(SAMPLE_BODY),
+      });
+      const res = await app.request("/api/verification/dual-reviews");
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.reviews.length).toBe(1);
+      expect(json.reviews[0].sprint_id).toBe(303);
+    });
+
+    it("supports ?limit query parameter", async () => {
+      await app.request("/api/verification/dual-review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(SAMPLE_BODY),
+      });
+      await app.request("/api/verification/dual-review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...SAMPLE_BODY, sprint_id: 304 }),
+      });
+      const res = await app.request("/api/verification/dual-reviews?limit=1");
+      const json = await res.json();
+      expect(json.reviews.length).toBe(1);
+    });
+  });
+
+  describe("GET /api/verification/dual-reviews/stats", () => {
+    it("returns 200 with stats structure", async () => {
+      const res = await app.request("/api/verification/dual-reviews/stats");
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json).toHaveProperty("total");
+      expect(json).toHaveProperty("concordance_rate");
+      expect(json).toHaveProperty("block_rate");
+      expect(json).toHaveProperty("degraded_rate");
+      expect(json).toHaveProperty("block_reasons");
+      expect(json).toHaveProperty("recent_reviews");
+    });
+
+    it("returns correct stats after inserting reviews", async () => {
+      await app.request("/api/verification/dual-review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(SAMPLE_BODY),
+      });
+      await app.request("/api/verification/dual-review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...SAMPLE_BODY,
+          sprint_id: 304,
+          codex_verdict: "BLOCK",
+          decision: "BLOCK",
+        }),
+      });
+      const res = await app.request("/api/verification/dual-reviews/stats");
+      const json = await res.json();
+      expect(json.total).toBe(2);
+      expect(json.block_rate).toBe(50);
+    });
+  });
+});

--- a/packages/api/src/core/verification/routes/__tests__/routes.test.ts
+++ b/packages/api/src/core/verification/routes/__tests__/routes.test.ts
@@ -69,7 +69,8 @@ describe("F552 Verification Routes", () => {
         body: JSON.stringify(SAMPLE_BODY),
       });
       expect(res.status).toBe(201);
-      const json = await res.json();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const json = await res.json() as any;
       expect(json).toHaveProperty("id");
       expect(json.id).toBeGreaterThan(0);
     });
@@ -98,7 +99,8 @@ describe("F552 Verification Routes", () => {
     it("returns 200 with empty array initially", async () => {
       const res = await app.request("/api/verification/dual-reviews");
       expect(res.status).toBe(200);
-      const json = await res.json();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const json = await res.json() as any;
       expect(json).toHaveProperty("reviews");
       expect(json.reviews).toEqual([]);
     });
@@ -111,7 +113,8 @@ describe("F552 Verification Routes", () => {
       });
       const res = await app.request("/api/verification/dual-reviews");
       expect(res.status).toBe(200);
-      const json = await res.json();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const json = await res.json() as any;
       expect(json.reviews.length).toBe(1);
       expect(json.reviews[0].sprint_id).toBe(303);
     });
@@ -128,7 +131,8 @@ describe("F552 Verification Routes", () => {
         body: JSON.stringify({ ...SAMPLE_BODY, sprint_id: 304 }),
       });
       const res = await app.request("/api/verification/dual-reviews?limit=1");
-      const json = await res.json();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const json = await res.json() as any;
       expect(json.reviews.length).toBe(1);
     });
   });
@@ -137,7 +141,8 @@ describe("F552 Verification Routes", () => {
     it("returns 200 with stats structure", async () => {
       const res = await app.request("/api/verification/dual-reviews/stats");
       expect(res.status).toBe(200);
-      const json = await res.json();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const json = await res.json() as any;
       expect(json).toHaveProperty("total");
       expect(json).toHaveProperty("concordance_rate");
       expect(json).toHaveProperty("block_rate");
@@ -163,7 +168,8 @@ describe("F552 Verification Routes", () => {
         }),
       });
       const res = await app.request("/api/verification/dual-reviews/stats");
-      const json = await res.json();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const json = await res.json() as any;
       expect(json.total).toBe(2);
       expect(json.block_rate).toBe(50);
     });

--- a/packages/api/src/core/verification/routes/index.ts
+++ b/packages/api/src/core/verification/routes/index.ts
@@ -1,6 +1,34 @@
-// F552: Dual AI Review routes — stub (TDD Red phase)
+// F552: Dual AI Review routes (Hono sub-app)
 import { Hono } from "hono";
+import { DualReviewService } from "../services/dual-review.service.js";
+import { DualReviewInsertSchema } from "../schemas.js";
+import type { Env } from "../../../env.js";
 
-const app = new Hono();
+const app = new Hono<{ Bindings: Env }>();
+
+app.post("/verification/dual-review", async (c) => {
+  const body = await c.req.json();
+  const parsed = DualReviewInsertSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: parsed.error.issues }, 400);
+  }
+
+  const svc = new DualReviewService(c.env.DB);
+  const result = await svc.insert(parsed.data);
+  return c.json(result, 201);
+});
+
+app.get("/verification/dual-reviews", async (c) => {
+  const limit = Number(c.req.query("limit") || 20);
+  const svc = new DualReviewService(c.env.DB);
+  const reviews = await svc.list(limit);
+  return c.json({ reviews });
+});
+
+app.get("/verification/dual-reviews/stats", async (c) => {
+  const svc = new DualReviewService(c.env.DB);
+  const stats = await svc.stats();
+  return c.json(stats);
+});
 
 export { app as verificationRoute };

--- a/packages/api/src/core/verification/routes/index.ts
+++ b/packages/api/src/core/verification/routes/index.ts
@@ -1,0 +1,6 @@
+// F552: Dual AI Review routes — stub (TDD Red phase)
+import { Hono } from "hono";
+
+const app = new Hono();
+
+export { app as verificationRoute };

--- a/packages/api/src/core/verification/schemas.ts
+++ b/packages/api/src/core/verification/schemas.ts
@@ -1,0 +1,16 @@
+// F552: Dual AI Review Zod schemas
+import { z } from "zod";
+
+export const DualReviewInsertSchema = z.object({
+  sprint_id: z.number().int().positive(),
+  claude_verdict: z.enum(["PASS", "BLOCK", "WARN"]).nullable().optional(),
+  codex_verdict: z.enum(["PASS", "BLOCK", "WARN", "PASS-degraded"]),
+  codex_json: z.string().min(2),
+  divergence_score: z.number().min(0).max(1).default(0),
+  decision: z.enum(["PASS", "BLOCK", "WARN", "PASS-degraded"]),
+  degraded: z.boolean().default(false),
+  degraded_reason: z.string().nullable().optional(),
+  model: z.string().default("codex-cli"),
+});
+
+export type DualReviewInsertInput = z.infer<typeof DualReviewInsertSchema>;

--- a/packages/api/src/core/verification/services/__tests__/dual-review.service.test.ts
+++ b/packages/api/src/core/verification/services/__tests__/dual-review.service.test.ts
@@ -1,0 +1,204 @@
+/**
+ * F552 TDD Red Phase — DualReviewService
+ * Sprint 303 | FX-REQ-589
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { createMockD1 } from "../../../../__tests__/helpers/mock-d1.js";
+import { DualReviewService } from "../dual-review.service.js";
+import type { DualReviewInsert } from "../../types.js";
+
+const DDL = `
+  CREATE TABLE IF NOT EXISTS dual_ai_reviews (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    sprint_id INTEGER NOT NULL,
+    claude_verdict TEXT,
+    codex_verdict TEXT,
+    codex_json TEXT NOT NULL,
+    divergence_score REAL DEFAULT 0.0,
+    decision TEXT,
+    degraded INTEGER DEFAULT 0,
+    degraded_reason TEXT,
+    model TEXT,
+    created_at TEXT DEFAULT (datetime('now'))
+  );
+  CREATE INDEX IF NOT EXISTS idx_dual_ai_reviews_sprint ON dual_ai_reviews(sprint_id);
+`;
+
+const SAMPLE_CODEX_JSON = JSON.stringify({
+  verdict: "PASS",
+  prd_coverage: { covered: ["FX-REQ-589"], missing: [] },
+  phase_exit_checklist: { D1: "PASS", D2: "PASS", D3: "PASS", D4: "PASS" },
+  code_issues: [],
+  over_engineering: [],
+  divergence_score: 0.0,
+  model: "codex-cli",
+  timestamp: "2026-04-16T12:00:00Z",
+  degraded: false,
+  summary_ko: "모든 항목 PASS",
+});
+
+function makeSample(overrides: Partial<DualReviewInsert> = {}): DualReviewInsert {
+  return {
+    sprint_id: 303,
+    claude_verdict: "PASS",
+    codex_verdict: "PASS",
+    codex_json: SAMPLE_CODEX_JSON,
+    divergence_score: 0.0,
+    decision: "PASS",
+    degraded: false,
+    degraded_reason: null,
+    model: "codex-cli",
+    ...overrides,
+  };
+}
+
+describe("F552 DualReviewService", () => {
+  let db: D1Database;
+  let svc: DualReviewService;
+
+  beforeEach(async () => {
+    const mockDb = createMockD1();
+    await mockDb.exec(DDL);
+    db = mockDb as unknown as D1Database;
+    svc = new DualReviewService(db);
+  });
+
+  describe("insert()", () => {
+    it("inserts a review and returns the id", async () => {
+      const result = await svc.insert(makeSample());
+      expect(result).toHaveProperty("id");
+      expect(result.id).toBeGreaterThan(0);
+    });
+
+    it("stores all fields correctly", async () => {
+      const data = makeSample({
+        sprint_id: 300,
+        claude_verdict: "WARN",
+        codex_verdict: "BLOCK",
+        divergence_score: 0.75,
+        decision: "BLOCK",
+        degraded: true,
+        degraded_reason: "codex_empty_response",
+        model: "mock",
+      });
+      const { id } = await svc.insert(data);
+      const rows = await svc.list(1);
+      const row = rows.find((r) => r.id === id);
+      expect(row).toBeDefined();
+      expect(row!.sprint_id).toBe(300);
+      expect(row!.claude_verdict).toBe("WARN");
+      expect(row!.codex_verdict).toBe("BLOCK");
+      expect(row!.divergence_score).toBe(0.75);
+      expect(row!.decision).toBe("BLOCK");
+      expect(row!.degraded).toBe(true);
+      expect(row!.degraded_reason).toBe("codex_empty_response");
+      expect(row!.model).toBe("mock");
+    });
+
+    it("allows multiple reviews per sprint (append model)", async () => {
+      await svc.insert(makeSample({ sprint_id: 303, codex_verdict: "PASS" }));
+      await svc.insert(makeSample({ sprint_id: 303, codex_verdict: "BLOCK" }));
+      const rows = await svc.list();
+      const sprint303 = rows.filter((r) => r.sprint_id === 303);
+      expect(sprint303.length).toBe(2);
+    });
+  });
+
+  describe("list()", () => {
+    it("returns empty array when no reviews exist", async () => {
+      const rows = await svc.list();
+      expect(rows).toEqual([]);
+    });
+
+    it("returns reviews ordered by created_at DESC", async () => {
+      await svc.insert(makeSample({ sprint_id: 300 }));
+      await svc.insert(makeSample({ sprint_id: 301 }));
+      await svc.insert(makeSample({ sprint_id: 302 }));
+      const rows = await svc.list();
+      expect(rows.length).toBe(3);
+      expect(rows[0].sprint_id).toBe(302);
+    });
+
+    it("respects limit parameter", async () => {
+      await svc.insert(makeSample({ sprint_id: 300 }));
+      await svc.insert(makeSample({ sprint_id: 301 }));
+      await svc.insert(makeSample({ sprint_id: 302 }));
+      const rows = await svc.list(2);
+      expect(rows.length).toBe(2);
+    });
+  });
+
+  describe("stats()", () => {
+    it("returns zero stats when no reviews exist", async () => {
+      const s = await svc.stats();
+      expect(s.total).toBe(0);
+      expect(s.concordance_rate).toBe(0);
+      expect(s.block_rate).toBe(0);
+      expect(s.degraded_rate).toBe(0);
+      expect(s.block_reasons).toEqual([]);
+      expect(s.recent_reviews).toEqual([]);
+    });
+
+    it("calculates concordance rate correctly", async () => {
+      await svc.insert(makeSample({ sprint_id: 300, claude_verdict: "PASS", codex_verdict: "PASS" }));
+      await svc.insert(makeSample({ sprint_id: 301, claude_verdict: "PASS", codex_verdict: "PASS" }));
+      await svc.insert(makeSample({ sprint_id: 302, claude_verdict: "PASS", codex_verdict: "PASS" }));
+      await svc.insert(makeSample({ sprint_id: 303, claude_verdict: "PASS", codex_verdict: "BLOCK", decision: "BLOCK" }));
+      const s = await svc.stats();
+      expect(s.total).toBe(4);
+      expect(s.concordance_rate).toBe(75);
+    });
+
+    it("calculates block rate correctly", async () => {
+      await svc.insert(makeSample({ sprint_id: 300, decision: "PASS" }));
+      await svc.insert(makeSample({ sprint_id: 301, decision: "BLOCK" }));
+      await svc.insert(makeSample({ sprint_id: 302, decision: "PASS" }));
+      await svc.insert(makeSample({ sprint_id: 303, decision: "BLOCK" }));
+      const s = await svc.stats();
+      expect(s.block_rate).toBe(50);
+    });
+
+    it("calculates degraded rate correctly", async () => {
+      await svc.insert(makeSample({ sprint_id: 300, degraded: false }));
+      await svc.insert(makeSample({ sprint_id: 301, degraded: true, degraded_reason: "codex_unavailable" }));
+      const s = await svc.stats();
+      expect(s.degraded_rate).toBe(50);
+    });
+
+    it("extracts block reasons from codex_json code_issues", async () => {
+      const jsonWithIssues = JSON.stringify({
+        verdict: "BLOCK",
+        code_issues: [
+          { file: "a.ts", line: 1, severity: "high", msg: "Missing null check" },
+          { file: "b.ts", line: 5, severity: "high", msg: "Missing null check" },
+          { file: "c.ts", line: 10, severity: "high", msg: "SQL injection risk" },
+        ],
+      });
+      await svc.insert(makeSample({
+        sprint_id: 300,
+        codex_verdict: "BLOCK",
+        decision: "BLOCK",
+        codex_json: jsonWithIssues,
+      }));
+      const s = await svc.stats();
+      expect(s.block_reasons.length).toBeGreaterThanOrEqual(1);
+      const nullCheck = s.block_reasons.find((r) => r.reason === "Missing null check");
+      expect(nullCheck).toBeDefined();
+      expect(nullCheck!.count).toBe(2);
+    });
+
+    it("includes recent reviews in stats", async () => {
+      await svc.insert(makeSample({ sprint_id: 300 }));
+      await svc.insert(makeSample({ sprint_id: 301 }));
+      const s = await svc.stats();
+      expect(s.recent_reviews.length).toBe(2);
+      expect(s.recent_reviews[0]).toHaveProperty("sprint_id");
+      expect(s.recent_reviews[0]).toHaveProperty("claude_verdict");
+      expect(s.recent_reviews[0]).toHaveProperty("codex_verdict");
+      expect(s.recent_reviews[0]).toHaveProperty("decision");
+      expect(s.recent_reviews[0]).toHaveProperty("divergence_score");
+      expect(s.recent_reviews[0]).toHaveProperty("degraded");
+      expect(s.recent_reviews[0]).toHaveProperty("created_at");
+    });
+  });
+});

--- a/packages/api/src/core/verification/services/__tests__/dual-review.service.test.ts
+++ b/packages/api/src/core/verification/services/__tests__/dual-review.service.test.ts
@@ -116,7 +116,7 @@ describe("F552 DualReviewService", () => {
       await svc.insert(makeSample({ sprint_id: 302 }));
       const rows = await svc.list();
       expect(rows.length).toBe(3);
-      expect(rows[0].sprint_id).toBe(302);
+      expect(rows[0]!.sprint_id).toBe(302);
     });
 
     it("respects limit parameter", async () => {

--- a/packages/api/src/core/verification/services/dual-review.service.ts
+++ b/packages/api/src/core/verification/services/dual-review.service.ts
@@ -1,18 +1,121 @@
-// F552: Dual AI Review service — stub (TDD Red phase)
+// F552: Dual AI Review service
 import type { DualReviewInsert, DualReview, DualReviewStats } from "../types.js";
 
 export class DualReviewService {
   constructor(private db: D1Database) {}
 
-  async insert(_data: DualReviewInsert): Promise<{ id: number }> {
-    throw new Error("Not implemented");
+  async insert(data: DualReviewInsert): Promise<{ id: number }> {
+    const result = await this.db
+      .prepare(
+        `INSERT INTO dual_ai_reviews
+         (sprint_id, claude_verdict, codex_verdict, codex_json, divergence_score, decision, degraded, degraded_reason, model)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        data.sprint_id,
+        data.claude_verdict,
+        data.codex_verdict,
+        data.codex_json,
+        data.divergence_score,
+        data.decision,
+        data.degraded ? 1 : 0,
+        data.degraded_reason,
+        data.model
+      )
+      .run();
+
+    return { id: Number(result.meta.last_row_id) };
   }
 
-  async list(_limit?: number): Promise<DualReview[]> {
-    throw new Error("Not implemented");
+  async list(limit: number = 20): Promise<DualReview[]> {
+    const { results } = await this.db
+      .prepare(
+        `SELECT id, sprint_id, claude_verdict, codex_verdict, codex_json,
+                divergence_score, decision, degraded, degraded_reason, model, created_at
+         FROM dual_ai_reviews
+         ORDER BY id DESC
+         LIMIT ?`
+      )
+      .bind(limit)
+      .all();
+
+    return (results as Array<Record<string, unknown>>).map((row) => ({
+      id: row.id as number,
+      sprint_id: row.sprint_id as number,
+      claude_verdict: row.claude_verdict as string | null,
+      codex_verdict: row.codex_verdict as string,
+      codex_json: row.codex_json as string,
+      divergence_score: row.divergence_score as number,
+      decision: row.decision as string,
+      degraded: row.degraded === 1,
+      degraded_reason: row.degraded_reason as string | null,
+      model: row.model as string,
+      created_at: row.created_at as string,
+    }));
   }
 
   async stats(): Promise<DualReviewStats> {
-    throw new Error("Not implemented");
+    const reviews = await this.list(100);
+    const total = reviews.length;
+
+    if (total === 0) {
+      return {
+        total: 0,
+        concordance_rate: 0,
+        block_rate: 0,
+        degraded_rate: 0,
+        block_reasons: [],
+        recent_reviews: [],
+      };
+    }
+
+    const concordant = reviews.filter(
+      (r) => r.claude_verdict === r.codex_verdict
+    ).length;
+    const blocked = reviews.filter((r) => r.decision === "BLOCK").length;
+    const degraded = reviews.filter((r) => r.degraded).length;
+
+    const blockReasonMap = new Map<string, number>();
+    for (const r of reviews) {
+      if (r.decision !== "BLOCK") continue;
+      try {
+        const parsed = JSON.parse(r.codex_json);
+        const issues = parsed.code_issues;
+        if (Array.isArray(issues)) {
+          for (const issue of issues) {
+            if (issue.severity === "high" && issue.msg) {
+              blockReasonMap.set(
+                issue.msg,
+                (blockReasonMap.get(issue.msg) ?? 0) + 1
+              );
+            }
+          }
+        }
+      } catch {
+        // ignore malformed JSON
+      }
+    }
+
+    const block_reasons = Array.from(blockReasonMap.entries())
+      .map(([reason, count]) => ({ reason, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 5);
+
+    return {
+      total,
+      concordance_rate: Math.round((concordant / total) * 100),
+      block_rate: Math.round((blocked / total) * 100),
+      degraded_rate: Math.round((degraded / total) * 100),
+      block_reasons,
+      recent_reviews: reviews.slice(0, 20).map((r) => ({
+        sprint_id: r.sprint_id,
+        claude_verdict: r.claude_verdict ?? null,
+        codex_verdict: r.codex_verdict,
+        decision: r.decision,
+        divergence_score: r.divergence_score,
+        degraded: r.degraded,
+        created_at: r.created_at,
+      })),
+    };
   }
 }

--- a/packages/api/src/core/verification/services/dual-review.service.ts
+++ b/packages/api/src/core/verification/services/dual-review.service.ts
@@ -1,0 +1,18 @@
+// F552: Dual AI Review service — stub (TDD Red phase)
+import type { DualReviewInsert, DualReview, DualReviewStats } from "../types.js";
+
+export class DualReviewService {
+  constructor(private db: D1Database) {}
+
+  async insert(_data: DualReviewInsert): Promise<{ id: number }> {
+    throw new Error("Not implemented");
+  }
+
+  async list(_limit?: number): Promise<DualReview[]> {
+    throw new Error("Not implemented");
+  }
+
+  async stats(): Promise<DualReviewStats> {
+    throw new Error("Not implemented");
+  }
+}

--- a/packages/api/src/core/verification/types.ts
+++ b/packages/api/src/core/verification/types.ts
@@ -1,0 +1,35 @@
+// F552: Dual AI Review types
+
+export interface DualReviewInsert {
+  sprint_id: number;
+  claude_verdict: string | null;
+  codex_verdict: string;
+  codex_json: string;
+  divergence_score: number;
+  decision: string;
+  degraded: boolean;
+  degraded_reason: string | null;
+  model: string;
+}
+
+export interface DualReview extends DualReviewInsert {
+  id: number;
+  created_at: string;
+}
+
+export interface DualReviewStats {
+  total: number;
+  concordance_rate: number;
+  block_rate: number;
+  degraded_rate: number;
+  block_reasons: Array<{ reason: string; count: number }>;
+  recent_reviews: Array<{
+    sprint_id: number;
+    claude_verdict: string | null;
+    codex_verdict: string;
+    decision: string;
+    divergence_score: number;
+    degraded: boolean;
+    created_at: string;
+  }>;
+}

--- a/packages/api/src/core/verification/types.ts
+++ b/packages/api/src/core/verification/types.ts
@@ -2,13 +2,13 @@
 
 export interface DualReviewInsert {
   sprint_id: number;
-  claude_verdict: string | null;
+  claude_verdict?: string | null;
   codex_verdict: string;
   codex_json: string;
   divergence_score: number;
   decision: string;
   degraded: boolean;
-  degraded_reason: string | null;
+  degraded_reason?: string | null;
   model: string;
 }
 

--- a/packages/api/src/db/migrations/0138_dual_ai_reviews.sql
+++ b/packages/api/src/db/migrations/0138_dual_ai_reviews.sql
@@ -1,0 +1,18 @@
+-- F552: Dual AI Review storage (Sprint 303)
+-- Stores codex-review.json results from autopilot Phase 5c
+
+CREATE TABLE IF NOT EXISTS dual_ai_reviews (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  sprint_id INTEGER NOT NULL,
+  claude_verdict TEXT,
+  codex_verdict TEXT,
+  codex_json TEXT NOT NULL,
+  divergence_score REAL DEFAULT 0.0,
+  decision TEXT,
+  degraded INTEGER DEFAULT 0,
+  degraded_reason TEXT,
+  model TEXT,
+  created_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_dual_ai_reviews_sprint ON dual_ai_reviews(sprint_id);

--- a/packages/web/src/routes/work-management.tsx
+++ b/packages/web/src/routes/work-management.tsx
@@ -747,7 +747,7 @@ function ChangelogTab() {
   );
 }
 
-type Tab = "kanban" | "context" | "classify" | "sessions" | "pipeline" | "velocity" | "backlog" | "roadmap" | "changelog" | "submit" | "trace";
+type Tab = "kanban" | "context" | "classify" | "sessions" | "pipeline" | "velocity" | "backlog" | "roadmap" | "changelog" | "submit" | "trace" | "ai-review";
 
 export function Component() {
   const [tab, setTab] = useState<Tab>("kanban");
@@ -827,6 +827,7 @@ export function Component() {
     { key: "classify",  label: "작업 분류" },
     { key: "submit",    label: "아이디어 제출" },
     { key: "trace",     label: "추적" },
+    { key: "ai-review", label: "AI 검증" },
   ];
 
   return (
@@ -917,6 +918,185 @@ export function Component() {
       {tab === "classify"  && <ClassifyTab />}
       {tab === "submit"    && <SubmitTab />}
       {tab === "trace"     && <TraceTab />}
+      {tab === "ai-review" && <DualAiReviewTab />}
+    </div>
+  );
+}
+
+// ─── F552: DualAiReviewTab ───────────────────────────────────────────────────
+
+interface DualReviewStatsData {
+  total: number;
+  concordance_rate: number;
+  block_rate: number;
+  degraded_rate: number;
+  block_reasons: Array<{ reason: string; count: number }>;
+  recent_reviews: Array<{
+    sprint_id: number;
+    claude_verdict: string | null;
+    codex_verdict: string;
+    decision: string;
+    divergence_score: number;
+    degraded: boolean;
+    created_at: string;
+  }>;
+}
+
+function DualAiReviewTab() {
+  const [stats, setStats] = useState<DualReviewStatsData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const data = await fetchApi<DualReviewStatsData>("/verification/dual-reviews/stats");
+        if (mounted) setStats(data);
+      } catch {
+        // ignore
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => { mounted = false; };
+  }, []);
+
+  if (loading) {
+    return <div style={{ padding: 24, color: T.text.muted }}>로딩 중...</div>;
+  }
+
+  if (!stats || stats.total === 0) {
+    return (
+      <div style={{
+        padding: 32, textAlign: "center", color: T.text.secondary,
+        background: T.bg.card, borderRadius: 12, border: `1px solid ${T.border.subtle}`,
+      }}>
+        <div style={{ fontSize: 32, marginBottom: 12 }}>🤖</div>
+        <div style={{ fontSize: 15, fontWeight: 600, marginBottom: 8 }}>
+          아직 Dual AI Review 데이터가 없어요
+        </div>
+        <div style={{ fontSize: 13, color: T.text.muted }}>
+          Sprint autopilot Phase 5c에서 Codex 리뷰가 실행되면 여기에 표시돼요.
+        </div>
+      </div>
+    );
+  }
+
+  const verdictColor = (v: string | null) => {
+    if (!v) return T.text.muted;
+    if (v === "PASS" || v === "PASS-degraded") return T.status.done;
+    if (v === "BLOCK") return "#ef4444";
+    if (v === "WARN") return T.status.warning;
+    return T.text.secondary;
+  };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+      {/* Summary Cards */}
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 14 }}>
+        {[
+          { label: "총 리뷰", value: stats.total, color: T.text.accent },
+          { label: "일치율", value: `${stats.concordance_rate}%`, color: T.status.done },
+          { label: "BLOCK율", value: `${stats.block_rate}%`, color: "#ef4444" },
+          { label: "Degraded율", value: `${stats.degraded_rate}%`, color: T.status.warning },
+        ].map((card) => (
+          <div key={card.label} style={{
+            background: T.bg.card, borderRadius: 10,
+            border: `1px solid ${T.border.subtle}`, padding: "16px 18px",
+          }}>
+            <div style={{ fontSize: 11, color: T.text.muted, marginBottom: 6, textTransform: "uppercase", letterSpacing: "0.05em" }}>
+              {card.label}
+            </div>
+            <div style={{ fontSize: 24, fontWeight: 700, color: card.color, fontFamily: T.mono }}>
+              {card.value}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Review Table */}
+      <div style={{
+        background: T.bg.card, borderRadius: 12, border: `1px solid ${T.border.subtle}`,
+        overflow: "hidden",
+      }}>
+        <div style={{ padding: "14px 18px", borderBottom: `1px solid ${T.border.subtle}` }}>
+          <span style={{ fontSize: 14, fontWeight: 700 }}>최근 Sprint 리뷰</span>
+        </div>
+        <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
+          <thead>
+            <tr style={{ background: T.bg.inset }}>
+              {["Sprint", "Claude", "Codex", "Decision", "Divergence", "Date"].map((h) => (
+                <th key={h} style={{
+                  padding: "10px 14px", textAlign: "left", fontWeight: 600,
+                  color: T.text.secondary, fontSize: 11, textTransform: "uppercase",
+                  letterSpacing: "0.05em",
+                }}>
+                  {h}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {stats.recent_reviews.map((r) => (
+              <tr key={`${r.sprint_id}-${r.created_at}`} style={{ borderBottom: `1px solid ${T.border.subtle}` }}>
+                <td style={{ padding: "10px 14px", fontFamily: T.mono, fontWeight: 600 }}>
+                  #{r.sprint_id}
+                </td>
+                <td style={{ padding: "10px 14px", color: verdictColor(r.claude_verdict), fontWeight: 600 }}>
+                  {r.claude_verdict ?? "—"}
+                </td>
+                <td style={{ padding: "10px 14px", color: verdictColor(r.codex_verdict), fontWeight: 600 }}>
+                  {r.codex_verdict}{r.degraded ? " ⚡" : ""}
+                </td>
+                <td style={{ padding: "10px 14px", color: verdictColor(r.decision), fontWeight: 700 }}>
+                  {r.decision}
+                </td>
+                <td style={{ padding: "10px 14px", fontFamily: T.mono }}>
+                  {r.divergence_score.toFixed(2)}
+                </td>
+                <td style={{ padding: "10px 14px", color: T.text.muted, fontSize: 12 }}>
+                  {r.created_at.slice(0, 10)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Block Reasons */}
+      {stats.block_reasons.length > 0 && (
+        <div style={{
+          background: T.bg.card, borderRadius: 12, border: `1px solid ${T.border.subtle}`,
+          padding: 18,
+        }}>
+          <div style={{ fontSize: 14, fontWeight: 700, marginBottom: 14 }}>BLOCK 사유 Top 5</div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {stats.block_reasons.map((br) => (
+              <div key={br.reason} style={{ display: "flex", alignItems: "center", gap: 12 }}>
+                <div style={{
+                  flex: 1, background: T.bg.inset, borderRadius: 6, height: 24,
+                  position: "relative", overflow: "hidden",
+                }}>
+                  <div style={{
+                    position: "absolute", left: 0, top: 0, bottom: 0,
+                    width: `${Math.min(100, (br.count / (stats.block_reasons[0]?.count || 1)) * 100)}%`,
+                    background: "rgba(239, 68, 68, 0.3)", borderRadius: 6,
+                  }} />
+                  <span style={{
+                    position: "relative", padding: "0 10px", fontSize: 12,
+                    lineHeight: "24px", color: T.text.secondary,
+                  }}>
+                    {br.reason}
+                  </span>
+                </div>
+                <span style={{ fontFamily: T.mono, fontSize: 13, fontWeight: 600, color: "#ef4444", minWidth: 30 }}>
+                  {br.count}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/scripts/autopilot/save-dual-review.sh
+++ b/scripts/autopilot/save-dual-review.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# F552: Save codex-review.json to D1 via API
+# Called by autopilot Phase 5c after codex-review.sh + composite-verify.sh
+set -euo pipefail
+
+SPRINT_NUM="${SPRINT_NUM:-}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+API_URL="${VITE_API_URL:-https://fx-gateway.ktds-axbd.workers.dev/api}"
+
+for arg in "$@"; do
+  case "$arg" in
+    --sprint) shift; SPRINT_NUM="${1:-}" ;;
+    --sprint=*) SPRINT_NUM="${arg#--sprint=}" ;;
+  esac
+done
+
+if [ -z "$SPRINT_NUM" ]; then
+  if [ -f "$REPO_ROOT/.sprint-context" ]; then
+    SPRINT_NUM=$(grep "^SPRINT_NUM=" "$REPO_ROOT/.sprint-context" | cut -d= -f2)
+  fi
+fi
+
+if [ -z "$SPRINT_NUM" ]; then
+  echo "[save-dual-review] ❌ SPRINT_NUM 필요" >&2
+  exit 1
+fi
+
+CODEX_JSON="$REPO_ROOT/.claude/reviews/sprint-${SPRINT_NUM}/codex-review.json"
+COMPOSITE_JSON="$REPO_ROOT/.claude/reviews/sprint-${SPRINT_NUM}/composite-verify.json"
+
+if [ ! -f "$CODEX_JSON" ]; then
+  echo "[save-dual-review] ⚠️  codex-review.json 없음 — 건너뜀"
+  exit 0
+fi
+
+# Extract fields from codex-review.json
+codex_verdict=$(python3 -c "import json; print(json.load(open('$CODEX_JSON')).get('verdict','PASS-degraded'))" 2>/dev/null || echo "PASS-degraded")
+divergence_score=$(python3 -c "import json; print(json.load(open('$CODEX_JSON')).get('divergence_score', 0.0))" 2>/dev/null || echo "0.0")
+model=$(python3 -c "import json; print(json.load(open('$CODEX_JSON')).get('model','none'))" 2>/dev/null || echo "none")
+degraded=$(python3 -c "import json; print('true' if json.load(open('$CODEX_JSON')).get('degraded', False) else 'false')" 2>/dev/null || echo "false")
+degraded_reason=$(python3 -c "import json; print(json.load(open('$CODEX_JSON')).get('degraded_reason') or '')" 2>/dev/null || echo "")
+
+# Extract composite decision (from composite-verify.json if available)
+decision="$codex_verdict"
+if [ -f "$COMPOSITE_JSON" ]; then
+  decision=$(python3 -c "import json; print(json.load(open('$COMPOSITE_JSON')).get('decision', '$codex_verdict'))" 2>/dev/null || echo "$codex_verdict")
+fi
+
+# Read full codex JSON
+codex_json_content=$(cat "$CODEX_JSON")
+
+# Build POST body
+body=$(python3 -c "
+import json, sys
+print(json.dumps({
+    'sprint_id': int('$SPRINT_NUM'),
+    'claude_verdict': None,
+    'codex_verdict': '$codex_verdict',
+    'codex_json': json.dumps(json.load(open('$CODEX_JSON'))),
+    'divergence_score': float('$divergence_score'),
+    'decision': '$decision',
+    'degraded': $degraded,
+    'degraded_reason': '$degraded_reason' if '$degraded_reason' else None,
+    'model': '$model',
+}))
+" 2>/dev/null)
+
+if [ -z "$body" ]; then
+  echo "[save-dual-review] ⚠️  JSON 구성 실패 — 건너뜀"
+  exit 0
+fi
+
+# POST to API
+response=$(curl -s -w "\n%{http_code}" -X POST \
+  "${API_URL}/verification/dual-review" \
+  -H "Content-Type: application/json" \
+  -d "$body" 2>/dev/null || echo "")
+
+http_code=$(echo "$response" | tail -1)
+body_response=$(echo "$response" | head -1)
+
+if [ "$http_code" = "201" ]; then
+  echo "[save-dual-review] ✅ Sprint $SPRINT_NUM 리뷰 저장 완료 (verdict=$codex_verdict)"
+else
+  echo "[save-dual-review] ⚠️  API 응답: $http_code — $body_response"
+fi


### PR DESCRIPTION
## Summary
- **F552** (FX-REQ-589, P1) — Phase 46 Dual-AI Verification 계속
- D1 migration `0138_dual_ai_reviews`: Sprint별 Codex 리뷰 결과 영속화
- `core/verification/` 도메인 신규: DualReviewService + Hono routes (POST/GET/stats)
- `/work-management` "AI 검증" 탭: 요약 카드 4개 + Sprint 리뷰 테이블 + BLOCK 사유 Top 5
- `scripts/autopilot/save-dual-review.sh`: Phase 5c → D1 POST 배선

## Metrics
- TDD: 20 tests RED → 20 GREEN
- Typecheck: PASS (13 packages)
- Files: 10 changed (+1145)
- Match Rate: TBD (Gap Analysis 실행 후)

## Test plan
- [ ] `vitest run src/core/verification` — 20/20 PASS
- [ ] `turbo typecheck` — PASS
- [ ] D1 migration dry-run
- [ ] `/work-management` AI 검증 탭 렌더링 확인 (빈 상태)
- [ ] POST /api/verification/dual-review → 201 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)