### PR TITLE
feat(web): ai-foundry-os theme-aware light/dark toggle

### DIFF
--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -43,6 +43,38 @@
     --discovery-amber-bg: #fef3c7;
     --discovery-red-bg: #fee2e2;
     --discovery-purple-bg: #f3e8ff;
+
+    /* ── AI Foundry OS (light) ── */
+    --fos-surface-abyss: #FFFFFF;
+    --fos-surface-hull: #F9FAFB;
+    --fos-surface-panel: #FFFFFF;
+    --fos-surface-panel-hi: #F3F4F6;
+    --fos-surface-inset: #F9FAFB;
+    --fos-border-default: rgba(17, 24, 39, 0.10);
+    --fos-border-strong: rgba(17, 24, 39, 0.18);
+    --fos-border-subtle: #E5E7EB;
+    --fos-text-primary: #111827;
+    --fos-text-secondary: #4B5563;
+    --fos-text-muted: #6B7280;
+    --fos-text-dim: #9CA3AF;
+    --fos-text-accent: #2563EB;
+    --fos-accent-input: #b8860b;
+    --fos-accent-input-soft: #fdf6e3;
+    --fos-accent-input-text: #92670a;
+    --fos-accent-control: #16A34A;
+    --fos-accent-control-soft: #F0FDF4;
+    --fos-accent-control-text: #15803D;
+    --fos-accent-takeaway: #DC2626;
+    --fos-accent-takeaway-soft: #FEF2F2;
+    --fos-accent-takeaway-text: #B91C1C;
+    --fos-status-ok: #16A34A;
+    --fos-status-warn: #CA8A04;
+    --fos-status-info: #2563EB;
+    --fos-status-error: #DC2626;
+    --fos-scanline-opacity: 0;
+    --fos-gradient-control: rgba(22, 163, 74, 0.04);
+    --fos-gradient-input: rgba(184, 134, 11, 0.03);
+    --fos-gradient-takeaway: rgba(220, 38, 38, 0.03);
 }
 
 /* Discovery 단계별 색상 매핑 (data-step 선택자) */
@@ -53,6 +85,38 @@
 [data-step="2-9"] { --step-color: var(--discovery-purple); --step-bg: var(--discovery-purple-bg); }
 
 .dark {
+    /* ── AI Foundry OS (dark) ── */
+    --fos-surface-abyss: #05080d;
+    --fos-surface-hull: #0a1018;
+    --fos-surface-panel: #0e1620;
+    --fos-surface-panel-hi: #131d2a;
+    --fos-surface-inset: #0a131f;
+    --fos-border-default: rgba(230, 234, 246, 0.08);
+    --fos-border-strong: rgba(230, 234, 246, 0.14);
+    --fos-border-subtle: #1a2d47;
+    --fos-text-primary: #e7ecf5;
+    --fos-text-secondary: #a1adc4;
+    --fos-text-muted: #6b7a95;
+    --fos-text-dim: #495569;
+    --fos-text-accent: #60a5fa;
+    --fos-accent-input: #d4a54c;
+    --fos-accent-input-soft: #2a200e;
+    --fos-accent-input-text: #e8c679;
+    --fos-accent-control: #3fb08a;
+    --fos-accent-control-soft: #0f2720;
+    --fos-accent-control-text: #6fd7b1;
+    --fos-accent-takeaway: #e25c5c;
+    --fos-accent-takeaway-soft: #2a1012;
+    --fos-accent-takeaway-text: #ff8585;
+    --fos-status-ok: #34d399;
+    --fos-status-warn: #f59e0b;
+    --fos-status-info: #60a5fa;
+    --fos-status-error: #f87171;
+    --fos-scanline-opacity: 1;
+    --fos-gradient-control: rgba(63, 176, 138, 0.04);
+    --fos-gradient-input: rgba(212, 165, 76, 0.03);
+    --fos-gradient-takeaway: rgba(226, 92, 92, 0.03);
+
     --sidebar: oklch(0.205 0 0);
     --sidebar-foreground: oklch(0.985 0 0);
     --sidebar-primary: oklch(0.488 0.243 264.376);

--- a/packages/web/src/routes/ai-foundry-os/index.tsx
+++ b/packages/web/src/routes/ai-foundry-os/index.tsx
@@ -39,7 +39,6 @@ function GlobalStyle() {
       @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.css');
 
       *, *::before, *::after { box-sizing: border-box; }
-      html, body, #root { margin: 0; padding: 0; background: ${ink.abyss}; }
       body {
         font-family: ${body};
         font-feature-settings: "ss01", "ss02", "cv01", "cv02";
@@ -48,17 +47,18 @@ function GlobalStyle() {
 
       .fos-root {
         background:
-          radial-gradient(ellipse 1200px 600px at 50% -10%, rgba(63, 176, 138, 0.04), transparent 60%),
-          radial-gradient(ellipse 900px 500px at 90% 30%, rgba(212, 165, 76, 0.03), transparent 60%),
-          radial-gradient(ellipse 800px 400px at 10% 70%, rgba(226, 92, 92, 0.03), transparent 60%),
-          ${ink.abyss};
-        color: ${ink.text};
+          radial-gradient(ellipse 1200px 600px at 50% -10%, var(--fos-gradient-control), transparent 60%),
+          radial-gradient(ellipse 900px 500px at 90% 30%, var(--fos-gradient-input), transparent 60%),
+          radial-gradient(ellipse 800px 400px at 10% 70%, var(--fos-gradient-takeaway), transparent 60%),
+          var(--fos-surface-abyss);
+        color: var(--fos-text-primary);
         min-height: 100vh;
         overflow-x: hidden;
       }
       .fos-root::before {
         content: "";
         position: fixed; inset: 0; pointer-events: none; z-index: 0;
+        opacity: var(--fos-scanline-opacity);
         background-image:
           repeating-linear-gradient(
             0deg,
@@ -81,7 +81,7 @@ function GlobalStyle() {
       }
 
       .fos-nav-item { cursor: pointer; transition: color 140ms, border-color 140ms; }
-      .fos-nav-item:hover { color: ${ink.text}; }
+      .fos-nav-item:hover { color: var(--fos-text-primary); }
 
       .fos-section-card {
         cursor: pointer;

--- a/packages/web/src/routes/ai-foundry-os/tokens.ts
+++ b/packages/web/src/routes/ai-foundry-os/tokens.ts
@@ -1,6 +1,6 @@
-// AI Foundry OS — Unified Design Tokens
-// AXIS Design System dark mode aligned (@axis-ds/tokens v1.1.1)
-// Source: ink/glint (index.tsx) + T (harness/ontology/lpon) 통합
+// AI Foundry OS — Theme-aware Design Tokens
+// CSS custom properties defined in globals.css (:root + .dark)
+// AXIS Design System aligned (@axis-ds/tokens v1.1.1)
 
 // ─── Font Stacks ───────────────────────────────────────────────────
 export const fonts = {
@@ -9,59 +9,64 @@ export const fonts = {
   mono: "'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace",
 } as const;
 
-// ─── Surface / Background ──────────────────────────────────────────
-// Custom deep-dark palette (AXIS gray-950 #030712 기반 확장)
+// ─── CSS Variable References ───────────────────────────────────────
+// These resolve at runtime based on the active theme (.dark / :root)
 const surface = {
-  abyss: "#05080d",      // 최심부 배경
-  hull: "#0a1018",       // 외곽 배경
-  panel: "#0e1620",      // 카드/패널
-  panelHi: "#131d2a",    // 카드 hover/강조
-  inset: "#0a131f",      // 인셋 영역 (harness/ontology)
+  abyss: "var(--fos-surface-abyss)",
+  hull: "var(--fos-surface-hull)",
+  panel: "var(--fos-surface-panel)",
+  panelHi: "var(--fos-surface-panel-hi)",
+  inset: "var(--fos-surface-inset)",
 } as const;
 
-// ─── Border ────────────────────────────────────────────────────────
 const border = {
-  default: "rgba(230, 234, 246, 0.08)",
-  strong: "rgba(230, 234, 246, 0.14)",
-  subtle: "#1a2d47",     // harness/ontology 패널 경계
+  default: "var(--fos-border-default)",
+  strong: "var(--fos-border-strong)",
+  subtle: "var(--fos-border-subtle)",
 } as const;
 
-// ─── Text ──────────────────────────────────────────────────────────
-// AXIS dark mode 매핑: primary=#F3F4F6, secondary=#9CA3AF, tertiary=#6B7280
 const text = {
-  primary: "#e7ecf5",    // ≈ axis-gray-100 (dark mode text-primary)
-  secondary: "#a1adc4",  // ≈ axis-gray-400 (dark mode text-secondary)
-  muted: "#6b7a95",      // ≈ axis-gray-500 (dark mode text-tertiary)
-  dim: "#495569",        // axis-gray-600
-  accent: "#60a5fa",     // axis-blue-400
+  primary: "var(--fos-text-primary)",
+  secondary: "var(--fos-text-secondary)",
+  muted: "var(--fos-text-muted)",
+  dim: "var(--fos-text-dim)",
+  accent: "var(--fos-text-accent)",
 } as const;
 
-// ─── Accent (3-Plane) ──────────────────────────────────────────────
-// Input(gold) / Control(green) / Takeaway(red) — Foundry OS 전용
 const accent = {
-  input: { accent: "#d4a54c", soft: "#2a200e", text: "#e8c679" },
-  control: { accent: "#3fb08a", soft: "#0f2720", text: "#6fd7b1" },
-  takeaway: { accent: "#e25c5c", soft: "#2a1012", text: "#ff8585" },
+  input: {
+    accent: "var(--fos-accent-input)",
+    soft: "var(--fos-accent-input-soft)",
+    text: "var(--fos-accent-input-text)",
+  },
+  control: {
+    accent: "var(--fos-accent-control)",
+    soft: "var(--fos-accent-control-soft)",
+    text: "var(--fos-accent-control-text)",
+  },
+  takeaway: {
+    accent: "var(--fos-accent-takeaway)",
+    soft: "var(--fos-accent-takeaway-soft)",
+    text: "var(--fos-accent-takeaway-text)",
+  },
 } as const;
 
-// ─── Status ────────────────────────────────────────────────────────
-// AXIS semantic colors 직접 사용
 const status = {
-  ok: "#34d399",         // axis-green-400
-  warn: "#f59e0b",       // axis-yellow-500
-  info: "#60a5fa",       // axis-blue-400
-  error: "#f87171",      // axis-red-400
+  ok: "var(--fos-status-ok)",
+  warn: "var(--fos-status-warn)",
+  info: "var(--fos-status-info)",
+  error: "var(--fos-status-error)",
 } as const;
 
-// ─── Node Colors (Ontology KG) ─────────────────────────────────────
+// ─── Node Colors (Ontology KG) — semantic, theme-independent ──────
 export const NODE_COLORS: Record<string, string> = {
-  SubProcess: "#3b82f6",     // axis-blue-500
-  Method: "#8b5cf6",         // axis-purple-500
-  Condition: "#f59e0b",      // axis-yellow-500
-  Actor: "#34d399",          // axis-green-400
-  Requirement: "#f87171",    // axis-red-400
+  SubProcess: "#3b82f6",       // axis-blue-500
+  Method: "#8b5cf6",           // axis-purple-500
+  Condition: "#f59e0b",        // axis-yellow-500
+  Actor: "#34d399",            // axis-green-400
+  Requirement: "#f87171",      // axis-red-400
   DiagnosisFinding: "#ec4899", // axis-pink-500
-  default: "#6b7280",       // axis-gray-500
+  default: "#6b7280",         // axis-gray-500
 };
 
 // ─── Composed Export ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `tokens.ts` 하드코딩 hex → CSS custom properties (`--fos-*`) 참조로 전환
- `globals.css`에 `--fos-*` 33종 라이트/다크 양쪽 정의
- AXIS `ThemeProvider`의 `.dark`/`.light` 클래스 전환에 실시간 반응
- 다크 모드: 기존 Deep Space 디자인 **그대로 유지** (시각적 회귀 0)
- 라이트 모드: 흰 배경 + 짙은 텍스트 + 톤다운 3-Plane 액센트
- `--fos-scanline-opacity`: 다크에서만 scanline 오버레이 표시

## Changed files (3)
- `globals.css` — `--fos-*` 33종 `:root`(light) + `.dark` 양쪽 추가
- `tokens.ts` — hex → `var(--fos-*)` 참조 문자열
- `index.tsx` — `GlobalStyle` 내 `ink.*` → CSS 변수 참조

## Test plan
- [x] `tsc --noEmit` PASS
- [x] 다크 모드 히어로 스크린샷 — 기존과 동일
- [x] 라이트 모드 히어로 전환 — 흰 배경 + 검정 텍스트 정상
- [x] 라이트 모드 카드/파이프라인 영역 — 배경/보더/텍스트 정상
- [x] 다크↔라이트 실시간 토글 — CSS 변수 즉시 반영
- [ ] 프로덕션 배포 후 fx.minu.best 테마 토글 최종 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)