### PR TITLE
feat(api): svc-skill bridge — org-spec + skill-spec

### DIFF
--- a/packages/api/src/core/decode-bridge/routes/index.ts
+++ b/packages/api/src/core/decode-bridge/routes/index.ts
@@ -15,6 +15,8 @@ import {
   getAnalysisFindings,
   getAnalysisComparison,
   triggerAnalysis,
+  getOrgSpec,
+  getSkillSpec,
 } from "../services/decode-client.js";
 import { LPON_HARNESS_METRICS } from "../data/lpon-mock.js";
 
@@ -76,6 +78,20 @@ decodeBridgeRoute.get("/decode/harness/metrics", async (c) => {
     // Table may not exist — use mock
   }
   return c.json({ ...LPON_HARNESS_METRICS, concreteness });
+});
+
+// ── Skill Spec (svc-skill) ────────────────────────────────────────────
+
+decodeBridgeRoute.get("/decode/org-spec/:orgId/:type", async (c) => {
+  const { orgId, type } = c.req.param();
+  const data = await getOrgSpec(c.env, orgId, type);
+  return c.json(data);
+});
+
+decodeBridgeRoute.get("/decode/skills/:skillId/spec/:type", async (c) => {
+  const { skillId, type } = c.req.param();
+  const data = await getSkillSpec(c.env, skillId, type);
+  return c.json(data);
 });
 
 // ── LPON Export / Download (F547) ─────────────────────────────────────

--- a/packages/api/src/core/decode-bridge/services/decode-client.ts
+++ b/packages/api/src/core/decode-bridge/services/decode-client.ts
@@ -93,6 +93,32 @@ export async function getAnalysisComparison(env: Env, documentId: string): Promi
   return LPON_MOCK_COMPARISON;
 }
 
+export async function getOrgSpec(env: Env, orgId: string, type: string): Promise<unknown> {
+  const secret = (env as unknown as Record<string, string>).DECODE_X_INTERNAL_SECRET ?? "";
+  const res = await callService(
+    (env as unknown as Record<string, Fetcher>).SVC_SKILL,
+    (env as unknown as Record<string, string>).DECODE_X_SKILL_URL,
+    `/admin/org-spec/${orgId}/${type}`,
+    "GET",
+    makeInternalHeaders(secret),
+  );
+  if (res?.ok) return res.json();
+  return { success: false, error: { code: "NOT_FOUND", message: `org-spec not available for ${orgId}/${type}` } };
+}
+
+export async function getSkillSpec(env: Env, skillId: string, type: string): Promise<unknown> {
+  const secret = (env as unknown as Record<string, string>).DECODE_X_INTERNAL_SECRET ?? "";
+  const res = await callService(
+    (env as unknown as Record<string, Fetcher>).SVC_SKILL,
+    (env as unknown as Record<string, string>).DECODE_X_SKILL_URL,
+    `/skills/${skillId}/spec/${type}`,
+    "GET",
+    makeInternalHeaders(secret),
+  );
+  if (res?.ok) return res.json();
+  return { success: false, error: { code: "NOT_FOUND", message: `skill-spec not available for ${skillId}/${type}` } };
+}
+
 export async function triggerAnalysis(
   env: Env,
   payload: { documentId: string; orgId: string },

--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -74,6 +74,10 @@ service = "svc-extraction"
 binding = "SVC_ONTOLOGY"
 service = "svc-ontology"
 
+[[services]]
+binding = "SVC_SKILL"
+service = "svc-skill"
+
 # F441: R2 File Storage (Sprint 213)
 [[r2_buckets]]
 binding = "FILES_BUCKET"


### PR DESCRIPTION
## Summary
- `SVC_SKILL` 서비스 바인딩 추가 (wrangler.toml)
- `/api/decode/org-spec/:orgId/:type` — Org 단위 B/T/Q Spec 프록시
- `/api/decode/skills/:id/spec/:type` — Skill 단위 B/T/Q Spec 프록시
- C69 본부장 시연 Decode-X 실데이터 연동

## Test plan
- [x] svc-skill 직접 호출 검증 (`org_ktds_axbd/business` → 8 sections)
- [x] Foundry-X bridge 경유 검증 (동일 결과)
- [x] typecheck PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)