### PR TITLE
chore: sync landing Sprint/Phase to 303/46

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Foundry-X가 이를 읽고 분석하고 동기화를 강제해요.
 <!-- README_SYNC_START: daily-check가 SPEC.md 실측값 기준으로 자동 동기화 -->
 | 항목 | 수치 |
 |------|------|
-| Phase | 44 (Sprint 298) |
+| Phase | 46 (Sprint 303) |
 | Sprints | 297 완료 |
 | API Routes | ~11 |
 | API Services | ~31 |

--- a/packages/web/content/landing/hero.md
+++ b/packages/web/content/landing/hero.md
@@ -3,8 +3,8 @@ title: Foundry-X
 section: hero
 sort_order: 0
 tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼"
-phase: "Phase 44"
-phaseTitle: "MSA 2차 분리 + Agent 품질 튜닝"
+phase: "Phase 46"
+phaseTitle: "Dual-AI Verification"
 stats:
   - value: "2"
     label: "BD 파이프라인"
@@ -12,7 +12,7 @@ stats:
     label: "AI 에이전트"
   - value: "63"
     label: "자동화 스킬"
-  - value: "298"
+  - value: "303"
     label: "Sprints"
 ---
 

--- a/packages/web/src/components/landing/footer.tsx
+++ b/packages/web/src/components/landing/footer.tsx
@@ -69,7 +69,7 @@ export function Footer() {
             &copy; {new Date().getFullYear()} KTDS AX BD. All rights reserved.
           </p>
           <p className="font-mono text-xs text-muted-foreground/60">
-            Sprint 298 &middot; Phase 44
+            Sprint 303 &middot; Phase 46
           </p>
         </div>
       </div>

--- a/packages/web/src/routes/landing.tsx
+++ b/packages/web/src/routes/landing.tsx
@@ -69,9 +69,9 @@ function getSectionOrder(section: string): number {
    ═══════════════════════════════════════════════ */
 
 const SITE_META_FALLBACK = {
-  sprint: "Sprint 298",
-  phase: "Phase 44",
-  phaseTitle: "MSA 2차 분리 + Agent 품질 튜닝",
+  sprint: "Sprint 303",
+  phase: "Phase 46",
+  phaseTitle: "Dual-AI Verification",
   tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼",
 } as const;
 
@@ -79,7 +79,7 @@ const STATS_FALLBACK = [
   { value: "2", label: "BD 파이프라인" },
   { value: "10+", label: "AI 에이전트" },
   { value: "63", label: "자동화 스킬" },
-  { value: "298", label: "Sprints" },
+  { value: "303", label: "Sprints" },
 ];
 
 // Build-time content from TinaCMS-managed Markdown


### PR DESCRIPTION
## Summary
- 콘텐츠 drift 5건 해소: Sprint 298→303, Phase 44→46
- `hero.md`, `landing.tsx`, `footer.tsx`, `README.md` 동기화

## Test plan
- [ ] CI deploy.yml PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)