### PR TITLE
chore: 모델 버전 alias 전환 + SSOT 보강 (B1/B2/B7)

### DIFF
--- a/packages/shared/src/model-defaults.ts
+++ b/packages/shared/src/model-defaults.ts
@@ -1,7 +1,26 @@
 /**
- * Central Claude model ID constants.
- * Undated aliases auto-route to the latest version within the family.
- * Update HERE when upgrading model generations.
+ * Central Claude model ID constants — **Single Source of Truth (SSOT)**.
+ *
+ * Anthropic Direct API는 undated alias(`claude-sonnet`, `claude-haiku`)를
+ * 지원하지 않고 구체 family 버전(`claude-sonnet-4-6`)이 필요하다.
+ * 따라서 이 파일이 프로젝트 전체 SDK 호출의 SSOT 역할을 한다.
+ *
+ * ## 업그레이드 절차 (Anthropic이 새 minor release 공표 시)
+ * 1. 이 파일의 버전 번호 1곳만 수정 (예: `claude-sonnet-4-6` → `claude-sonnet-4-7`)
+ * 2. `pnpm typecheck` — import consumer 전파 확인
+ * 3. `/ax:daily-check` "모델 버전 drift" 항목 통과 확인
+ * 4. `.claude/MEMORY.md`의 "모델 업그레이드 절차" feedback 참조
+ *
+ * ## CLI 경로 (별도 관리)
+ * Claude Code CLI는 `--model sonnet` alias 지원 → CLI 스크립트는
+ * `sonnet`/`opus`/`haiku` alias 사용으로 자동 현행화.
+ *
+ * ## 소비자 목록 (grep으로 감지; 추가 시 이 주석 갱신)
+ * - `packages/api/src/services/llm.ts`
+ * - `packages/api/src/core/agent/specs/*.agent.yaml`
+ * - `packages/gate-x/src/services/llm/providers/anthropic.ts`
+ * - `packages/fx-shaping/src/agent/services/{model-router,openrouter-runner}.ts`
+ *   (OpenRouter 경로 — `OR_MODEL_*` 사용)
  *
  * @example
  *   // Direct Anthropic API

--- a/scripts/skill-demo-seed.sh
+++ b/scripts/skill-demo-seed.sh
@@ -42,7 +42,7 @@ for skill in cost-model feasibility-study market-sizing competitor-analysis valu
         \"skillId\": \"${skill}\",
         \"status\": \"completed\",
         \"durationMs\": ${DURATION},
-        \"model\": \"claude-sonnet-4-20250514\",
+        \"model\": \"claude-sonnet-4-6\",
         \"inputTokens\": $((RANDOM % 2000 + 500)),
         \"outputTokens\": $((RANDOM % 3000 + 1000)),
         \"costUsd\": 0.$(printf '%02d' $((RANDOM % 10 + 1)))

--- a/scripts/task/task-start.sh
+++ b/scripts/task/task-start.sh
@@ -375,7 +375,11 @@ if [ -n "$PANE_ID" ]; then
   # S260 C28: WT worker는 토큰 비용 절감 위해 Sonnet 강제.
   # feedback_sprint_model.md "Master=Opus, WT=Sonnet" 원칙의 구현.
   # 사용자는 worker 세션에서 /model 명령으로 수동 변경 가능.
-  CCS_WT_CMD="${CCS_BIN} --model claude-sonnet-4-6"
+  # S300 (2026-04-18): minor 버전 하드코딩 → `sonnet` alias로 교체.
+  # Claude Code CLI가 Sonnet 현행 최신 버전을 자동 선택하므로
+  # Anthropic release 시 별도 수정 없이 자동 추종. 특정 minor 버전
+  # 고정이 필요한 경우에만 --model claude-sonnet-4-N 복원.
+  CCS_WT_CMD="${CCS_BIN} --model sonnet"
 
   cat > "$INJECT_SCRIPT" << INJECT_EOF
 #!/usr/bin/env bash

--- a/scripts/usage-tracker-hook.sh
+++ b/scripts/usage-tracker-hook.sh
@@ -46,7 +46,7 @@ curl -s -X POST "${API_URL}/skills/metrics/record" \
     \"skillId\": \"ax-${SKILL_NAME}\",
     \"status\": \"${STATUS}\",
     \"durationMs\": ${DURATION_MS},
-    \"model\": \"claude-sonnet-4-20250514\",
+    \"model\": \"claude-sonnet-4-6\",
     \"inputTokens\": 0,
     \"outputTokens\": 0,
     \"costUsd\": 0


### PR DESCRIPTION
## 배경
- CLI 경로는 `--model sonnet/opus` alias로 자동 현행화 ✅
- SDK 경로는 Anthropic Direct API가 구체 버전(`claude-sonnet-4-6`) 요구 → `packages/shared/src/model-defaults.ts` **SSOT**로 일원화
- 실행 경로에 `claude-sonnet-4-6` minor 버전 하드코딩 지점 + stale `20250514` 값 잔존 → 자동 추종 깨짐

## 변경 (B1/B2/B7)
| # | 파일 | 변경 | 영향 |
|---|------|------|------|
| B1 | `scripts/task/task-start.sh` | `--model claude-sonnet-4-6` → `--model sonnet` alias | CLI가 Sonnet 최신 자동 선택 |
| B2 | `packages/shared/src/model-defaults.ts` | 주석 보강(SSOT 역할, 업그레이드 절차, 소비자 목록) | comment-only, 상수 불변 |
| B7 | `scripts/usage-tracker-hook.sh`, `scripts/skill-demo-seed.sh` | stale `claude-sonnet-4-20250514` → `claude-sonnet-4-6` | 메트릭 기록 문자열 현행화 |

## CI 영향
- shared typecheck PASS 확인 (comment 변경만, import consumer 무영향)
- scripts/*.sh 리터럴 교체 — lint 대상 아님, 실행 시 동작 동일 (alias 해석은 Claude CLI 담당)

## 후속
- ax-plugin `daily-check` skill에 "모델 버전 Drift" 자동 감지 추가 (별도 skill update)
- MEMORY `feedback_model_version_ssot` 기록

## 범위 외 (Sprint 단위 처리 권장)
- B3 `packages/api/src/core/agent/specs/*.agent.yaml` (5개 — `claude-haiku-4-5-20251001` → SSOT 참조)
- B4 `packages/gate-x/src/services/llm/providers/anthropic.ts:11`
- B5 `packages/api/src/services/llm.ts:80`
- B6 `packages/fx-shaping/src/agent/services/{model-router,openrouter-runner}.ts`
→ Sprint 309 완료 직후 packages/ 내부 범위, 별도 Sprint로

🤖 Generated with [Claude Code](https://claude.com/claude-code)