### PR TITLE
chore(web): sync landing Sprint/Phase to 309/46 (F541 MERGED)

### DIFF
--- a/packages/web/content/landing/hero.md
+++ b/packages/web/content/landing/hero.md
@@ -12,7 +12,7 @@ stats:
     label: "AI 에이전트"
   - value: "63"
     label: "자동화 스킬"
-  - value: "308"
+  - value: "309"
     label: "Sprints"
 ---
 

--- a/packages/web/src/components/landing/footer.tsx
+++ b/packages/web/src/components/landing/footer.tsx
@@ -69,7 +69,7 @@ export function Footer() {
             &copy; {new Date().getFullYear()} KTDS AX BD. All rights reserved.
           </p>
           <p className="font-mono text-xs text-muted-foreground/60">
-            Sprint 308 &middot; Phase 46
+            Sprint 309 &middot; Phase 46
           </p>
         </div>
       </div>

--- a/packages/web/src/routes/landing.tsx
+++ b/packages/web/src/routes/landing.tsx
@@ -69,7 +69,7 @@ function getSectionOrder(section: string): number {
    ═══════════════════════════════════════════════ */
 
 const SITE_META_FALLBACK = {
-  sprint: "Sprint 308",
+  sprint: "Sprint 309",
   phase: "Phase 46",
   phaseTitle: "Dual-AI Verification",
   tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼",
@@ -79,7 +79,7 @@ const STATS_FALLBACK = [
   { value: "2", label: "BD 파이프라인" },
   { value: "10+", label: "AI 에이전트" },
   { value: "63", label: "자동화 스킬" },
-  { value: "308", label: "Sprints" },
+  { value: "309", label: "Sprints" },
 ];
 
 // Build-time content from TinaCMS-managed Markdown


### PR DESCRIPTION
## 배경
Sprint 309 F541 Offering 분리 MERGED(PR #624) 후 session-end 실행 시 content-sync-check.sh로 landing 5파일 drift 5건 감지. SSOT(SPEC.md §5 max Sprint=309) 기준 sync.

## 변경
| 파일 | 변경 |
|------|------|
| `packages/web/content/landing/hero.md` | stats Sprints `308` → `309` |
| `packages/web/src/routes/landing.tsx` | SITE_META_FALLBACK + STATS_FALLBACK `308` → `309` |
| `packages/web/src/components/landing/footer.tsx` | `Sprint 308` → `Sprint 309` |

README/SPEC은 master direct push(`39d48283`).

## 검증
- `bash scripts/content-sync-check.sh` → `content sync: OK (Sprint 309, Phase 46)` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)