### PR TITLE
feat(api/eslint-rules): C71 use-model-ssot — 하드코딩 모델 ID 차단 룰

### DIFF
--- a/packages/api/eslint.config.js
+++ b/packages/api/eslint.config.js
@@ -19,6 +19,8 @@ export default tseslint.config(
       // MSA 원칙 룰 — core/{domain}/ 신규 파일에만 의도적으로 적용
       'foundry-x-api/no-cross-domain-import': 'error',
       'foundry-x-api/no-direct-route-register': 'error',
+      // C71: 하드코딩 모델 ID 차단 — @foundry-x/shared/model-defaults SSOT 강제
+      'foundry-x-api/use-model-ssot': 'error',
     },
   },
   {

--- a/packages/api/src/eslint-rules/index.mjs
+++ b/packages/api/src/eslint-rules/index.mjs
@@ -1,10 +1,12 @@
 import { noCrossDomainImport } from './no-cross-domain-import.mjs';
 import { noDirectRouteRegister } from './no-direct-route-register.mjs';
+import { useModelSsot } from './use-model-ssot.mjs';
 
 export const foundryXApiPlugin = {
   meta: { name: 'eslint-plugin-foundry-x-api', version: '1.0.0' },
   rules: {
     'no-cross-domain-import': noCrossDomainImport,
     'no-direct-route-register': noDirectRouteRegister,
+    'use-model-ssot': useModelSsot,
   },
 };

--- a/packages/api/src/eslint-rules/index.ts
+++ b/packages/api/src/eslint-rules/index.ts
@@ -1,10 +1,12 @@
 import { noCrossDomainImport } from './no-cross-domain-import.js';
 import { noDirectRouteRegister } from './no-direct-route-register.js';
+import { useModelSsot } from './use-model-ssot.js';
 
 export const foundryXApiPlugin = {
   meta: { name: 'eslint-plugin-foundry-x-api', version: '1.0.0' },
   rules: {
     'no-cross-domain-import': noCrossDomainImport,
     'no-direct-route-register': noDirectRouteRegister,
+    'use-model-ssot': useModelSsot,
   },
 };

--- a/packages/api/src/eslint-rules/use-model-ssot.mjs
+++ b/packages/api/src/eslint-rules/use-model-ssot.mjs
@@ -1,0 +1,38 @@
+const MODEL_LITERAL_RE = /claude-(sonnet|haiku|opus)-\d+-\d+/;
+
+const EXEMPT_PATH_SEGMENTS = ['/__tests__/', '/e2e/fixtures/', '/archive/'];
+
+function isExemptPath(filename) {
+  return EXEMPT_PATH_SEGMENTS.some((seg) => filename.includes(seg));
+}
+
+export const useModelSsot = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow hardcoded Claude model ID literals. Use MODEL_SONNET / MODEL_HAIKU / OR_MODEL_SONNET / OR_MODEL_HAIKU from @foundry-x/shared/model-defaults.',
+    },
+    messages: {
+      useModelSsot:
+        'Hardcoded model ID "{{value}}" is forbidden. Import MODEL_SONNET / MODEL_HAIKU / OR_MODEL_SONNET / OR_MODEL_HAIKU from @foundry-x/shared/model-defaults instead.',
+    },
+    schema: [],
+  },
+  create(context) {
+    if (isExemptPath(context.filename)) return {};
+
+    return {
+      Literal(node) {
+        if (typeof node.value !== 'string') return;
+        if (MODEL_LITERAL_RE.test(node.value)) {
+          context.report({
+            node,
+            messageId: 'useModelSsot',
+            data: { value: node.value },
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/api/src/eslint-rules/use-model-ssot.test.ts
+++ b/packages/api/src/eslint-rules/use-model-ssot.test.ts
@@ -1,0 +1,82 @@
+// C71 use-model-ssot ESLint 룰 단위 테스트 (TDD Red phase)
+// ESLint v9+ RuleTester는 전역 describe/it을 감지하여 개별 테스트를 등록함 — run()을 describe() 안에서 직접 호출
+import { RuleTester } from 'eslint';
+import { describe } from 'vitest';
+import { useModelSsot } from './use-model-ssot.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+});
+
+describe('C71 foundry-x-api/use-model-ssot', () => {
+  ruleTester.run('use-model-ssot', useModelSsot, {
+    valid: [
+      // SSOT 상수 참조 — 문자열 리터럴 아님
+      { code: 'const m = MODEL_SONNET;' },
+      { code: 'const m = MODEL_HAIKU;' },
+      { code: 'const m = OR_MODEL_SONNET;' },
+      // 관련 없는 문자열
+      { code: 'const s = "hello world";' },
+      { code: 'const s = "claude";' },
+      { code: 'const s = "claude-sonnet";' },
+      // __tests__/ 경로 면제
+      {
+        code: 'const m = "claude-sonnet-4-6";',
+        filename: '/project/src/__tests__/foo.test.ts',
+      },
+      {
+        code: 'const m = "claude-haiku-4-5";',
+        filename: '/project/packages/api/src/__tests__/service.test.ts',
+      },
+      // archive/ 경로 면제
+      {
+        code: 'const m = "claude-sonnet-4-6";',
+        filename: '/project/archive/old-service.ts',
+      },
+      // e2e/fixtures/ 경로 면제
+      {
+        code: 'const m = "claude-haiku-4-5";',
+        filename: '/project/packages/web/e2e/fixtures/mock.ts',
+      },
+    ],
+    invalid: [
+      // Direct Anthropic API 리터럴
+      {
+        code: 'const m = "claude-sonnet-4-6";',
+        errors: [{ messageId: 'useModelSsot' }],
+      },
+      {
+        code: 'const m = "claude-haiku-4-5";',
+        errors: [{ messageId: 'useModelSsot' }],
+      },
+      // 날짜 suffix 포함 (claude-haiku-4-5-20251001)
+      {
+        code: 'const m = "claude-haiku-4-5-20251001";',
+        errors: [{ messageId: 'useModelSsot' }],
+      },
+      // OpenRouter 경로 prefix 포함
+      {
+        code: 'const m = "anthropic/claude-sonnet-4-6";',
+        errors: [{ messageId: 'useModelSsot' }],
+      },
+      // opus 포함
+      {
+        code: 'const m = "claude-opus-4-7";',
+        errors: [{ messageId: 'useModelSsot' }],
+      },
+      // 객체 값에 포함된 경우
+      {
+        code: 'const config = { model: "claude-sonnet-4-6" };',
+        errors: [{ messageId: 'useModelSsot' }],
+      },
+      // 함수 인자로 전달
+      {
+        code: 'fetch(url, { body: JSON.stringify({ model: "claude-haiku-4-5" }) });',
+        errors: [{ messageId: 'useModelSsot' }],
+      },
+    ],
+  });
+});

--- a/packages/api/src/eslint-rules/use-model-ssot.ts
+++ b/packages/api/src/eslint-rules/use-model-ssot.ts
@@ -1,0 +1,41 @@
+import type { Rule } from 'eslint';
+
+// claude-(sonnet|haiku|opus)-N-N (날짜 suffix 포함) 또는 anthropic/ prefix 포함
+const MODEL_LITERAL_RE = /claude-(sonnet|haiku|opus)-\d+-\d+/;
+
+const EXEMPT_PATH_SEGMENTS = ['/__tests__/', '/e2e/fixtures/', '/archive/'];
+
+function isExemptPath(filename: string): boolean {
+  return EXEMPT_PATH_SEGMENTS.some((seg) => filename.includes(seg));
+}
+
+export const useModelSsot: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow hardcoded Claude model ID literals. Use MODEL_SONNET / MODEL_HAIKU / OR_MODEL_SONNET / OR_MODEL_HAIKU from @foundry-x/shared/model-defaults.',
+    },
+    messages: {
+      useModelSsot:
+        'Hardcoded model ID "{{value}}" is forbidden. Import MODEL_SONNET / MODEL_HAIKU / OR_MODEL_SONNET / OR_MODEL_HAIKU from @foundry-x/shared/model-defaults instead.',
+    },
+    schema: [],
+  },
+  create(context) {
+    if (isExemptPath(context.filename)) return {};
+
+    return {
+      Literal(node) {
+        if (typeof node.value !== 'string') return;
+        if (MODEL_LITERAL_RE.test(node.value)) {
+          context.report({
+            node,
+            messageId: 'useModelSsot',
+            data: { value: node.value },
+          });
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
## Summary

- `foundry-x-api/use-model-ssot` ESLint 룰 신규 추가 (C71, FX-REQ-594, P2)
- `claude-(sonnet|haiku|opus)-N-N` 패턴 리터럴을 `error`로 차단
- `@foundry-x/shared/model-defaults`의 `MODEL_SONNET`/`MODEL_HAIKU`/`OR_MODEL_*` 사용 강제
- `eslint.config.js`에 룰 활성화
- 면제 경로: `__tests__/`, `e2e/fixtures/`, `archive/`

## 구현 파일

- `packages/api/src/eslint-rules/use-model-ssot.ts` — TypeScript 소스
- `packages/api/src/eslint-rules/use-model-ssot.mjs` — flat config 런타임용 MJS
- `packages/api/src/eslint-rules/use-model-ssot.test.ts` — Vitest 단위 테스트 (17 cases)
- `packages/api/src/eslint-rules/index.{ts,mjs}` — 플러그인 등록
- `packages/api/eslint.config.js` — 룰 활성화

## Test plan

- [x] TDD Red (stub): 7 invalid cases FAIL 확인
- [x] TDD Green (impl): 17 cases (10 valid + 7 invalid) PASS
- [x] `turbo typecheck` PASS
- [x] 전체 테스트 370 files PASS (3737 tests)
- [ ] CI 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)