### PR TITLE
refactor(packages): C74 — model ID literals → SSOT 참조 (B3~B6)

### DIFF
--- a/packages/api/src/core/agent/runtime/agent-spec-loader.ts
+++ b/packages/api/src/core/agent/runtime/agent-spec-loader.ts
@@ -1,6 +1,7 @@
 // ─── F527: F-L2-2 AgentSpec YAML 파서 (Sprint 280) ───
 
 import { z } from "zod";
+import { MODEL_HAIKU, MODEL_SONNET } from "@foundry-x/shared";
 import type { AgentSpec } from "@foundry-x/shared";
 
 // Zod 스키마로 AgentSpec 검증
@@ -42,8 +43,18 @@ const agentSpecSchema = z.object({
  *
  * Workers 호환: 외부 YAML 라이브러리 없이 직접 파싱
  */
+/** agent.yaml 내 모델 sentinel(@@MODEL_HAIKU@@, @@MODEL_SONNET@@)을 SSOT 상수로 치환 */
+const MODEL_SENTINELS: Record<string, string> = {
+  "@@MODEL_HAIKU@@": MODEL_HAIKU,
+  "@@MODEL_SONNET@@": MODEL_SONNET,
+};
+
+function resolveModelSentinel(yaml: string): string {
+  return yaml.replace(/@@MODEL_\w+@@/g, (token) => MODEL_SENTINELS[token] ?? token);
+}
+
 export function parseAgentSpec(yaml: string): AgentSpec {
-  const raw = parseSimpleYaml(yaml);
+  const raw = parseSimpleYaml(resolveModelSentinel(yaml));
   const result = agentSpecSchema.safeParse(raw);
   if (!result.success) {
     const issues = result.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join(", ");

--- a/packages/api/src/core/agent/specs/architect.agent.yaml
+++ b/packages/api/src/core/agent/specs/architect.agent.yaml
@@ -1,6 +1,6 @@
 name: architect
 version: "1.0"
-model: claude-haiku-4-5-20251001
+model: "@@MODEL_HAIKU@@"
 systemPrompt: |
   You are an ArchitectAgent for the Foundry-X platform.
   Analyze code changes and evaluate architecture quality.

--- a/packages/api/src/core/agent/specs/infra.agent.yaml
+++ b/packages/api/src/core/agent/specs/infra.agent.yaml
@@ -1,6 +1,6 @@
 name: infra
 version: "1.0"
-model: claude-haiku-4-5-20251001
+model: "@@MODEL_HAIKU@@"
 systemPrompt: |
   You are an InfraAgent for the Foundry-X platform on Cloudflare.
   Analyze infrastructure configuration for health, resource usage, and optimization.

--- a/packages/api/src/core/agent/specs/meta-agent.agent.yaml
+++ b/packages/api/src/core/agent/specs/meta-agent.agent.yaml
@@ -1,6 +1,6 @@
 name: meta-agent
 version: "2.0"
-model: claude-sonnet-4-6
+model: "@@MODEL_SONNET@@"
 systemPrompt: |
   You are a MetaAgent for the Foundry-X HyperFX Agent Stack.
   Your role is to analyze agent performance diagnostics (6-axis scores) and generate

--- a/packages/api/src/core/agent/specs/planner.agent.yaml
+++ b/packages/api/src/core/agent/specs/planner.agent.yaml
@@ -1,6 +1,6 @@
 name: planner
 version: "1.0"
-model: claude-haiku-4-5-20251001
+model: "@@MODEL_HAIKU@@"
 systemPrompt: |
   You are a PlannerAgent for the Foundry-X project.
   Analyze the provided code context and create a detailed execution plan.

--- a/packages/api/src/core/agent/specs/qa.agent.yaml
+++ b/packages/api/src/core/agent/specs/qa.agent.yaml
@@ -1,6 +1,6 @@
 name: qa
 version: "1.0"
-model: claude-haiku-4-5-20251001
+model: "@@MODEL_HAIKU@@"
 systemPrompt: |
   You are a QAAgent for the Foundry-X platform.
   Generate Playwright browser test scenarios and validate acceptance criteria.

--- a/packages/api/src/core/agent/specs/reviewer.agent.yaml
+++ b/packages/api/src/core/agent/specs/reviewer.agent.yaml
@@ -1,6 +1,6 @@
 name: reviewer
 version: "1.0"
-model: claude-haiku-4-5-20251001
+model: "@@MODEL_HAIKU@@"
 systemPrompt: |
   You are a ReviewerAgent for the Foundry-X platform.
   Perform thorough code review focusing on correctness, maintainability, and security.

--- a/packages/api/src/core/agent/specs/security.agent.yaml
+++ b/packages/api/src/core/agent/specs/security.agent.yaml
@@ -1,6 +1,6 @@
 name: security
 version: "1.0"
-model: claude-haiku-4-5-20251001
+model: "@@MODEL_HAIKU@@"
 systemPrompt: |
   You are a SecurityAgent for the Foundry-X platform.
   Scan source code for OWASP Top 10 vulnerabilities and security anti-patterns.

--- a/packages/api/src/core/agent/specs/test.agent.yaml
+++ b/packages/api/src/core/agent/specs/test.agent.yaml
@@ -1,6 +1,6 @@
 name: test
 version: "1.0"
-model: claude-haiku-4-5-20251001
+model: "@@MODEL_HAIKU@@"
 systemPrompt: |
   You are a TestAgent for the Foundry-X platform.
   Generate comprehensive vitest test code for given source files.

--- a/packages/api/src/services/llm.ts
+++ b/packages/api/src/services/llm.ts
@@ -77,7 +77,7 @@ export class LLMService {
 
     return {
       content: data.content[0]?.text ?? "",
-      model: "claude-haiku-4-5",
+      model: MODEL_HAIKU,
       tokensUsed: data.usage.input_tokens + data.usage.output_tokens,
     };
   }

--- a/packages/fx-shaping/src/agent/services/model-router.ts
+++ b/packages/fx-shaping/src/agent/services/model-router.ts
@@ -2,7 +2,7 @@
  * F136: 태스크별 모델 라우팅 — D1 규칙 기반 자동 모델 선택
  */
 import type { AgentTaskType, AgentRunnerType } from "./execution-types.js";
-import { OR_MODEL_SONNET, OR_MODEL_HAIKU } from "@foundry-x/shared";
+import { OR_MODEL_OPUS, OR_MODEL_SONNET, OR_MODEL_HAIKU } from "@foundry-x/shared";
 
 export interface RoutingRule {
   id: string;
@@ -18,16 +18,16 @@ export interface RoutingRule {
 
 /** D1 규칙 없을 때 하드코딩 폴백 */
 export const DEFAULT_MODEL_MAP: Record<AgentTaskType, string> = {
-  "code-review": "anthropic/claude-sonnet-4",
-  "code-generation": "anthropic/claude-sonnet-4",
-  "spec-analysis": "anthropic/claude-opus-4",
+  "code-review": OR_MODEL_SONNET,
+  "code-generation": OR_MODEL_SONNET,
+  "spec-analysis": OR_MODEL_OPUS,
   "test-generation": OR_MODEL_HAIKU,
   "policy-evaluation": OR_MODEL_HAIKU,
   "skill-query": OR_MODEL_HAIKU,
   "ontology-lookup": OR_MODEL_HAIKU,
   "security-review": OR_MODEL_SONNET,
   "qa-testing": OR_MODEL_HAIKU,
-  "infra-analysis": "anthropic/claude-sonnet-4",
+  "infra-analysis": OR_MODEL_SONNET,
   "bmc-generation": OR_MODEL_SONNET,
   "bmc-insight": OR_MODEL_SONNET,
   "market-summary": OR_MODEL_SONNET,
@@ -76,7 +76,7 @@ export class ModelRouter {
     }
 
     // D1 규칙 없으면 DEFAULT_MODEL_MAP 폴백
-    const modelId = DEFAULT_MODEL_MAP[taskType] ?? "anthropic/claude-sonnet-4";
+    const modelId = DEFAULT_MODEL_MAP[taskType] ?? OR_MODEL_SONNET;
     return {
       id: `default_${taskType}`,
       taskType,

--- a/packages/fx-shaping/src/agent/services/openrouter-runner.ts
+++ b/packages/fx-shaping/src/agent/services/openrouter-runner.ts
@@ -1,3 +1,4 @@
+import { OR_MODEL_SONNET } from "@foundry-x/shared";
 import type {
   AgentExecutionRequest,
   AgentExecutionResult,
@@ -6,7 +7,7 @@ import type { AgentRunner } from "./agent-runner.js";
 import { TASK_SYSTEM_PROMPTS, buildUserPrompt, getSystemPrompt } from "./prompt-utils.js";
 
 export const DEFAULT_BASE_URL = "https://openrouter.ai/api/v1";
-export const DEFAULT_MODEL = "anthropic/claude-sonnet-4";
+export const DEFAULT_MODEL = OR_MODEL_SONNET;
 export const DEFAULT_MAX_TOKENS = 4096;
 export const REQUEST_TIMEOUT_MS = 60_000;
 

--- a/packages/gate-x/package.json
+++ b/packages/gate-x/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@foundry-x/harness-kit": "workspace:*",
+    "@foundry-x/shared": "workspace:*",
     "@hono/zod-openapi": "^0.18.4",
     "hono": "^4.0.0",
     "zod": "^3.22.0"

--- a/packages/gate-x/src/services/llm/providers/anthropic.ts
+++ b/packages/gate-x/src/services/llm/providers/anthropic.ts
@@ -1,3 +1,4 @@
+import { MODEL_SONNET } from '@foundry-x/shared';
 import type { LLMProvider, LLMRequest, LLMResponse } from '../types.js';
 
 export class AnthropicProvider implements LLMProvider {
@@ -8,7 +9,7 @@ export class AnthropicProvider implements LLMProvider {
       throw new Error('ANTHROPIC_API_KEY not set');
     }
 
-    const model = 'claude-sonnet-4-6';
+    const model = MODEL_SONNET;
     const body: Record<string, unknown> = {
       model,
       max_tokens: req.maxTokens ?? 1024,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -511,8 +511,10 @@ export type {
 
 // F555: Central model ID constants
 export {
+  MODEL_OPUS,
   MODEL_SONNET,
   MODEL_HAIKU,
+  OR_MODEL_OPUS,
   OR_MODEL_SONNET,
   OR_MODEL_HAIKU,
 } from './model-defaults.js';

--- a/packages/shared/src/model-defaults.ts
+++ b/packages/shared/src/model-defaults.ts
@@ -30,9 +30,11 @@
  */
 
 // ── Direct Anthropic API ──────────────────────────────────────
+export const MODEL_OPUS = "claude-opus-4-7" as const;
 export const MODEL_SONNET = "claude-sonnet-4-6" as const;
 export const MODEL_HAIKU = "claude-haiku-4-5" as const;
 
 // ── OpenRouter-prefixed ───────────────────────────────────────
+export const OR_MODEL_OPUS = `anthropic/${MODEL_OPUS}` as const;
 export const OR_MODEL_SONNET = `anthropic/${MODEL_SONNET}` as const;
 export const OR_MODEL_HAIKU = `anthropic/${MODEL_HAIKU}` as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,6 +263,9 @@ importers:
       '@foundry-x/harness-kit':
         specifier: workspace:*
         version: link:../harness-kit
+      '@foundry-x/shared':
+        specifier: workspace:*
+        version: link:../shared
       '@hono/zod-openapi':
         specifier: ^0.18.4
         version: 0.18.4(hono@4.12.8)(zod@3.25.76)


### PR DESCRIPTION
## Summary

- **B3** `packages/api` agent yaml 8개 — `claude-haiku-4-5-20251001`/`claude-sonnet-4-6` literal → `@@MODEL_HAIKU@@`/`@@MODEL_SONNET@@` sentinel; `agent-spec-loader.ts`에 `resolveModelSentinel()` 추가
- **B4** `packages/gate-x` `anthropic.ts` — `'claude-sonnet-4-6'` literal → `MODEL_SONNET` import (`@foundry-x/shared` dep 추가)
- **B5** `packages/api` `services/llm.ts` — response 객체 `"claude-haiku-4-5"` literal → `MODEL_HAIKU`
- **B6** `packages/fx-shaping` `model-router.ts` / `openrouter-runner.ts` — `"anthropic/claude-sonnet-4"` / `"anthropic/claude-opus-4"` literal → `OR_MODEL_SONNET` / `OR_MODEL_OPUS`; `shared`에 `MODEL_OPUS` + `OR_MODEL_OPUS` 신규 export

## Test plan

- [x] `turbo typecheck` — 15 packages 전체 PASS
- [x] `turbo test` — 3737 tests PASS (370 files)
- [ ] CI 통과 후 auto-squash merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)