### PR TITLE
feat(api/eslint-rules): C75 no-cross-domain-d1 — D1 격리 ESLint 룰 신규

### DIFF
--- a/packages/api/eslint.config.js
+++ b/packages/api/eslint.config.js
@@ -21,6 +21,8 @@ export default tseslint.config(
       'foundry-x-api/no-direct-route-register': 'error',
       // C71: 하드코딩 모델 ID 차단 — @foundry-x/shared/model-defaults SSOT 강제
       'foundry-x-api/use-model-ssot': 'error',
+      // C75: D1 크로스도메인 테이블 접근 차단 (forward-only, 기존 23건 위반은 별도 fix PR)
+      'foundry-x-api/no-cross-domain-d1': 'warn',
     },
   },
   {

--- a/packages/api/src/eslint-rules/index.mjs
+++ b/packages/api/src/eslint-rules/index.mjs
@@ -1,3 +1,4 @@
+import { noCrossDomainD1 } from './no-cross-domain-d1.mjs';
 import { noCrossDomainImport } from './no-cross-domain-import.mjs';
 import { noDirectRouteRegister } from './no-direct-route-register.mjs';
 import { useModelSsot } from './use-model-ssot.mjs';
@@ -5,6 +6,7 @@ import { useModelSsot } from './use-model-ssot.mjs';
 export const foundryXApiPlugin = {
   meta: { name: 'eslint-plugin-foundry-x-api', version: '1.0.0' },
   rules: {
+    'no-cross-domain-d1': noCrossDomainD1,
     'no-cross-domain-import': noCrossDomainImport,
     'no-direct-route-register': noDirectRouteRegister,
     'use-model-ssot': useModelSsot,

--- a/packages/api/src/eslint-rules/index.ts
+++ b/packages/api/src/eslint-rules/index.ts
@@ -1,3 +1,4 @@
+import { noCrossDomainD1 } from './no-cross-domain-d1.js';
 import { noCrossDomainImport } from './no-cross-domain-import.js';
 import { noDirectRouteRegister } from './no-direct-route-register.js';
 import { useModelSsot } from './use-model-ssot.js';
@@ -5,6 +6,7 @@ import { useModelSsot } from './use-model-ssot.js';
 export const foundryXApiPlugin = {
   meta: { name: 'eslint-plugin-foundry-x-api', version: '1.0.0' },
   rules: {
+    'no-cross-domain-d1': noCrossDomainD1,
     'no-cross-domain-import': noCrossDomainImport,
     'no-direct-route-register': noDirectRouteRegister,
     'use-model-ssot': useModelSsot,

--- a/packages/api/src/eslint-rules/no-cross-domain-d1.mjs
+++ b/packages/api/src/eslint-rules/no-cross-domain-d1.mjs
@@ -1,0 +1,85 @@
+// MSA 원칙: core/{domain}/ 파일에서 다른 도메인 소속 D1 테이블 직접 접근 차단
+const DOMAIN_TABLE_PREFIXES = {
+  discovery_: 'discovery',
+  shaping_: 'shaping',
+  offering_: 'offering',
+  agent_: 'agent',
+};
+
+const AGENT_EXACT_TABLES = new Set(['agents']);
+
+const EXEMPT_PATH_SEGMENTS = ['/db/migrations/', '/__tests__/', '/archive/'];
+
+function isExemptPath(filename) {
+  return EXEMPT_PATH_SEGMENTS.some((seg) => filename.includes(seg));
+}
+
+function getDomainFromFilePath(filepath) {
+  const match = filepath.match(/\/core\/([^/]+)\//);
+  return match ? match[1] : null;
+}
+
+function getTableDomain(tableName) {
+  for (const [prefix, domain] of Object.entries(DOMAIN_TABLE_PREFIXES)) {
+    if (tableName.startsWith(prefix)) return domain;
+  }
+  if (AGENT_EXACT_TABLES.has(tableName)) return 'agent';
+  return null;
+}
+
+const SQL_DML_RE = /\b(?:SELECT|INSERT|DELETE|CREATE|DROP|ALTER)\b/i;
+const SQL_TABLE_RE = /\b(?:FROM|INTO|UPDATE|JOIN)\s+(\w+)/gi;
+
+function looksLikeSql(str) {
+  return SQL_DML_RE.test(str) || /\bUPDATE\s+\w+\s+SET\b/i.test(str);
+}
+
+function extractTableNames(sql) {
+  if (!looksLikeSql(sql)) return [];
+  return [...sql.matchAll(SQL_TABLE_RE)].map((m) => m[1]);
+}
+
+export const noCrossDomainD1 = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow cross-domain D1 table access in MSA core domains. Each domain may only access tables with its own prefix (discovery_*, shaping_*, offering_*, agent_*).',
+    },
+    messages: {
+      noCrossDomainD1:
+        'Domain "{{currentDomain}}" cannot access table "{{table}}" which belongs to domain "{{tableDomain}}". Access only {{currentDomain}}_* tables or shared (unprefixed) tables.',
+    },
+    schema: [],
+  },
+  create(context) {
+    if (isExemptPath(context.filename)) return {};
+
+    const currentDomain = getDomainFromFilePath(context.filename);
+    if (!currentDomain) return {};
+
+    function checkSql(node, sql) {
+      for (const table of extractTableNames(sql)) {
+        const tableDomain = getTableDomain(table);
+        if (tableDomain && tableDomain !== currentDomain) {
+          context.report({
+            node,
+            messageId: 'noCrossDomainD1',
+            data: { currentDomain, table, tableDomain },
+          });
+        }
+      }
+    }
+
+    return {
+      Literal(node) {
+        if (typeof node.value !== 'string') return;
+        checkSql(node, node.value);
+      },
+      TemplateLiteral(node) {
+        const sql = node.quasis.map((q) => q.value.raw).join(' ');
+        checkSql(node, sql);
+      },
+    };
+  },
+};

--- a/packages/api/src/eslint-rules/no-cross-domain-d1.test.ts
+++ b/packages/api/src/eslint-rules/no-cross-domain-d1.test.ts
@@ -1,0 +1,148 @@
+// C75 no-cross-domain-d1 ESLint 룰 단위 테스트 (TDD Red phase)
+// ESLint v9+ RuleTester는 전역 describe/it을 감지하여 개별 테스트를 등록함 — run()을 describe() 안에서 직접 호출
+import { RuleTester } from 'eslint';
+import { describe } from 'vitest';
+import { noCrossDomainD1 } from './no-cross-domain-d1.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+});
+
+const DISCOVERY_FILE = '/project/packages/api/src/core/discovery/services/foo.ts';
+const SHAPING_FILE = '/project/packages/api/src/core/shaping/services/bar.ts';
+const OFFERING_FILE = '/project/packages/api/src/core/offering/services/baz.ts';
+const AGENT_FILE = '/project/packages/api/src/core/agent/services/qux.ts';
+
+describe('C75 foundry-x-api/no-cross-domain-d1', () => {
+  ruleTester.run('no-cross-domain-d1', noCrossDomainD1, {
+    valid: [
+      // 같은 도메인 테이블 접근 — 허용
+      {
+        code: 'db.prepare(`SELECT * FROM shaping_runs WHERE id = ?`);',
+        filename: SHAPING_FILE,
+      },
+      {
+        code: 'db.prepare(`SELECT * FROM discovery_pipeline_runs WHERE id = ?`);',
+        filename: DISCOVERY_FILE,
+      },
+      {
+        code: 'db.prepare(`INSERT INTO offering_versions (id) VALUES (?)`);',
+        filename: OFFERING_FILE,
+      },
+      {
+        code: 'db.prepare(`UPDATE agent_sessions SET status = ? WHERE id = ?`);',
+        filename: AGENT_FILE,
+      },
+      // 레거시 공유 테이블(도메인 prefix 없음) — 모든 도메인 허용
+      {
+        code: 'db.prepare(`SELECT * FROM biz_items WHERE id = ?`);',
+        filename: SHAPING_FILE,
+      },
+      {
+        code: 'db.prepare(`SELECT * FROM ax_bmc_blocks WHERE id = ?`);',
+        filename: DISCOVERY_FILE,
+      },
+      {
+        code: 'db.prepare(`SELECT * FROM projects WHERE id = ?`);',
+        filename: AGENT_FILE,
+      },
+      // core/ 경로 밖 파일 — 룰 미적용
+      {
+        code: 'db.prepare(`SELECT * FROM offering_versions WHERE id = ?`);',
+        filename: '/project/packages/api/src/services/some-service.ts',
+      },
+      // 면제: migrations/ 경로 (db/migrations/ 하위의 .ts seed/helper 파일)
+      {
+        code: 'const sql = "SELECT * FROM shaping_runs WHERE id = ?";',
+        filename: '/project/packages/api/src/db/migrations/seed.ts',
+      },
+      // 면제: __tests__/ 경로
+      {
+        code: 'db.prepare(`SELECT * FROM offering_versions WHERE id = ?`);',
+        filename: '/project/packages/api/src/core/shaping/__tests__/service.test.ts',
+      },
+      // 면제: archive/ 경로
+      {
+        code: 'db.prepare(`SELECT * FROM discovery_pipeline_runs WHERE id = ?`);',
+        filename: '/project/packages/api/src/core/offering/archive/old.ts',
+      },
+      // 일반 문자열 리터럴 — SQL DML 키워드 없으면 통과 (오탐 방지)
+      {
+        code: 'const msg = "hello from offering_versions table";',
+        filename: SHAPING_FILE,
+      },
+      // SQL DML 키워드 없으면 FROM 절도 통과
+      {
+        code: 'const info = "data from offering_versions source";',
+        filename: SHAPING_FILE,
+      },
+      // agents (agent 도메인 소속) — agent 파일에서 허용
+      {
+        code: 'db.prepare(`SELECT * FROM agents WHERE id = ?`);',
+        filename: AGENT_FILE,
+      },
+    ],
+    invalid: [
+      // shaping → offering 테이블 접근 금지
+      {
+        code: 'db.prepare(`SELECT * FROM offering_prototypes WHERE id = ?`);',
+        filename: SHAPING_FILE,
+        errors: [{ messageId: 'noCrossDomainD1' }],
+      },
+      // shaping → discovery 테이블 접근 금지
+      {
+        code: 'db.prepare(`SELECT * FROM discovery_pipeline_runs WHERE id = ?`);',
+        filename: SHAPING_FILE,
+        errors: [{ messageId: 'noCrossDomainD1' }],
+      },
+      // offering → discovery 테이블 접근 금지
+      {
+        code: 'db.prepare(`SELECT * FROM discovery_pipeline_runs WHERE id = ?`);',
+        filename: OFFERING_FILE,
+        errors: [{ messageId: 'noCrossDomainD1' }],
+      },
+      // discovery → shaping 테이블 접근 금지
+      {
+        code: 'db.prepare(`SELECT * FROM shaping_runs WHERE id = ?`);',
+        filename: DISCOVERY_FILE,
+        errors: [{ messageId: 'noCrossDomainD1' }],
+      },
+      // agent → shaping 테이블 접근 금지
+      {
+        code: 'db.prepare(`SELECT * FROM shaping_six_hats WHERE id = ?`);',
+        filename: AGENT_FILE,
+        errors: [{ messageId: 'noCrossDomainD1' }],
+      },
+      // offering → agent 테이블 접근 금지
+      {
+        code: 'db.prepare(`SELECT * FROM agent_sessions WHERE id = ?`);',
+        filename: OFFERING_FILE,
+        errors: [{ messageId: 'noCrossDomainD1' }],
+      },
+      // 일반 string literal에서도 감지
+      {
+        code: 'const sql = "SELECT * FROM offering_versions WHERE id = ?";',
+        filename: SHAPING_FILE,
+        errors: [{ messageId: 'noCrossDomainD1' }],
+      },
+      // JOIN 절에서도 감지
+      {
+        code: 'db.prepare(`SELECT a.* FROM shaping_runs a JOIN offering_prototypes b ON a.id = b.shaping_id`);',
+        filename: DISCOVERY_FILE,
+        errors: [
+          { messageId: 'noCrossDomainD1' }, // shaping_runs
+          { messageId: 'noCrossDomainD1' }, // offering_prototypes
+        ],
+      },
+      // agents — agent 도메인 소속, shaping 파일에서 금지
+      {
+        code: 'db.prepare(`SELECT * FROM agents WHERE domain = ?`);',
+        filename: SHAPING_FILE,
+        errors: [{ messageId: 'noCrossDomainD1' }],
+      },
+    ],
+  });
+});

--- a/packages/api/src/eslint-rules/no-cross-domain-d1.ts
+++ b/packages/api/src/eslint-rules/no-cross-domain-d1.ts
@@ -1,0 +1,94 @@
+// MSA 원칙: core/{domain}/ 파일에서 다른 도메인 소속 D1 테이블 직접 접근 차단
+// 도메인 소속 판정: 테이블명 prefix 기준 (discovery_* / shaping_* / offering_* / agent_*)
+// 면제: db/migrations/, __tests__/, archive/
+import type { Rule } from 'eslint';
+
+// 도메인별 테이블명 prefix (이 prefix로 시작하는 테이블은 해당 도메인 소속)
+const DOMAIN_TABLE_PREFIXES: Record<string, string> = {
+  discovery_: 'discovery',
+  shaping_: 'shaping',
+  offering_: 'offering',
+  agent_: 'agent',
+};
+
+// 정확한 이름으로 도메인 소속이 확정되는 테이블 (prefix 규칙으로 미포함)
+const AGENT_EXACT_TABLES = new Set(['agents']);
+
+const EXEMPT_PATH_SEGMENTS = ['/db/migrations/', '/__tests__/', '/archive/'];
+
+function isExemptPath(filename: string): boolean {
+  return EXEMPT_PATH_SEGMENTS.some((seg) => filename.includes(seg));
+}
+
+function getDomainFromFilePath(filepath: string): string | null {
+  const match = filepath.match(/\/core\/([^/]+)\//);
+  return match?.[1] ?? null;
+}
+
+function getTableDomain(tableName: string): string | null {
+  for (const [prefix, domain] of Object.entries(DOMAIN_TABLE_PREFIXES)) {
+    if (tableName.startsWith(prefix)) return domain;
+  }
+  if (AGENT_EXACT_TABLES.has(tableName)) return 'agent';
+  return null; // 도메인 prefix 없는 레거시/공유 테이블
+}
+
+// 문자열이 SQL 쿼리인지 판단하는 최소 휴리스틱 (오탐 방지)
+const SQL_DML_RE = /\b(?:SELECT|INSERT|DELETE|CREATE|DROP|ALTER)\b/i;
+const SQL_TABLE_RE = /\b(?:FROM|INTO|UPDATE|JOIN)\s+(\w+)/gi;
+
+function looksLikeSql(str: string): boolean {
+  return SQL_DML_RE.test(str) || /\bUPDATE\s+\w+\s+SET\b/i.test(str);
+}
+
+function extractTableNames(sql: string): string[] {
+  if (!looksLikeSql(sql)) return [];
+  return [...sql.matchAll(SQL_TABLE_RE)].map((m) => m[1]).filter((t): t is string => t !== undefined);
+}
+
+export const noCrossDomainD1: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow cross-domain D1 table access in MSA core domains. Each domain may only access tables with its own prefix (discovery_*, shaping_*, offering_*, agent_*).',
+    },
+    messages: {
+      noCrossDomainD1:
+        'Domain "{{currentDomain}}" cannot access table "{{table}}" which belongs to domain "{{tableDomain}}". Access only {{currentDomain}}_* tables or shared (unprefixed) tables.',
+    },
+    schema: [],
+  },
+  create(context) {
+    if (isExemptPath(context.filename)) return {};
+
+    const currentDomain = getDomainFromFilePath(context.filename);
+    if (!currentDomain) return {};
+
+    function checkSql(node: Rule.Node, sql: string): void {
+      for (const table of extractTableNames(sql)) {
+        const tableDomain = getTableDomain(table);
+        if (tableDomain && tableDomain !== currentDomain) {
+          context.report({
+            node,
+            messageId: 'noCrossDomainD1',
+            data: { currentDomain, table, tableDomain },
+          });
+        }
+      }
+    }
+
+    return {
+      Literal(node) {
+        if (typeof node.value !== 'string') return;
+        checkSql(node as unknown as Rule.Node, node.value);
+      },
+      TemplateLiteral(node) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ESLint AST TemplateLiteral quasis
+        const quasis = (node as any).quasis as Array<{ value: { raw: string } }>;
+        const sql = quasis.map((q) => q.value.raw).join(' ');
+        checkSql(node as unknown as Rule.Node, sql);
+      },
+    };
+  },
+};


### PR DESCRIPTION
## Summary

- `foundry-x-api/no-cross-domain-d1` ESLint 룰 신규 추가 (C75 / C56 no-cross-domain-d1)
- MSA 도메인 경계를 D1 테이블 접근 단위로 강제: `discovery_*` / `shaping_*` / `offering_*` / `agent_*` prefix 기반
- TDD Red+Green 23 tests PASS

## 룰 동작 방식

- 파일 경로에서 현재 도메인 감지 (`/core/{domain}/`)
- SQL 문자열 (Literal + TemplateLiteral quasis)에서 `FROM/INTO/UPDATE/JOIN` 뒤 테이블명 추출
- 다른 도메인 prefix 테이블 접근 시 `warn` 보고
- 면제: `db/migrations/`, `__tests__/`, `archive/`
- SQL 컨텍스트 휴리스틱 (`SELECT/INSERT/DELETE` 키워드 체크)으로 일반 문자열 오탐 방지

## 기존 코드 위반 현황 (23건, 별도 fix PR 예정)

| 도메인 | 테이블 | 건수 |
|--------|--------|------|
| harness | `discovery_pipeline_runs`, `agent_*` | 14건 |
| discovery | `offering_sections`, `offering_versions`, `offering_prototypes` | 4건 |
| shaping | `offering_prototypes`, `discovery_pipeline_runs` | 2건 |
| agent | `discovery_pipeline_runs` | 1건 |
| 기타 | 2건 | |

→ 기존 위반은 `warn`으로 등록하여 CI 차단 없이 forward-only 도입. 신규/수정 파일만 msa-lint CI가 검사.

## 변경 파일

- `src/eslint-rules/no-cross-domain-d1.ts` — 룰 구현 (TypeScript)
- `src/eslint-rules/no-cross-domain-d1.mjs` — 룰 구현 (ESM, ESLint config 로드용)
- `src/eslint-rules/no-cross-domain-d1.test.ts` — TDD 23 테스트
- `src/eslint-rules/index.{ts,mjs}` — 룰 등록
- `eslint.config.js` — `foundry-x-api/no-cross-domain-d1: warn` 추가

## Test plan

- [x] `pnpm test` — 23/23 PASS
- [x] `pnpm typecheck` — PASS
- [x] 기존 코드 위반 23건 측정 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)