### PR TITLE
fix(content-sync): Sprint 318 drift 해소 (5 files)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Foundry-X가 이를 읽고 분석하고 동기화를 강제해요.
 <!-- README_SYNC_START: daily-check가 SPEC.md 실측값 기준으로 자동 동기화 -->
 | 항목 | 수치 |
 |------|------|
-| Phase | 46 (Sprint 309) |
-| Sprints | 309 완료 |
+| Phase | 46 (Sprint 318) |
+| Sprints | 318 완료 |
 | API Routes | ~11 |
 | API Services | ~31 |
 | API Schemas | ~14 |

--- a/SPEC.md
+++ b/SPEC.md
@@ -57,7 +57,7 @@ Foundry-X — AX 사업개발 라이프사이클을 AI 에이전트로 자동화
 > ```
 > wc -l SPEC.md && find packages/api/src/db/migrations/*.sql | sort | tail -1
 > ```
-> **마지막 실측** (Sprint 309, 2026-04-19): ~11 routes, ~30 services, ~14 schemas, D1 0138, 11 packages — Phase 44 F541 Offering ✅ MERGED (PR #624 Match 100%, Sprint 309 autopilot). fx-gateway + fx-discovery + fx-shaping + **fx-offering** 4 MSA Workers live. S301: 모델 SSOT 3단 체인(C73 PR#628 use-model-ssot / C74 PR#630 literal→SSOT / C75 PR#632 no-cross-domain-d1) + C76 PR#634 daemon orphan SPEC mark fix. C56→C75 / C72→C74 / C71→C73 ID forward
+> **마지막 실측** (Sprint 310, 2026-04-19): ~11 routes, ~31 services, ~14 schemas, D1 0138, 11 packages — Phase 45 MSA 3rd Separation 착수. Sprint 310 F556 MetaAgent Rubric 튜닝 ✅ MERGED (PR #638 Match 100%, S302 autopilot). Phase 45 F560~F572 13 F-items 등록(FX-REQ-603~615, Sprint 311~318). S302: C69 ID 중복 해소(→C77), C78 preflight 후속 PR #637 MERGED. S307: tmux 3.5a segfault 대응 L2/L3 구현(TASK_MAX_RETRY=5 + phase_tmux_health)
 
 ## §3 Phase 진행 현황
 

--- a/packages/web/content/landing/hero.md
+++ b/packages/web/content/landing/hero.md
@@ -12,7 +12,7 @@ stats:
     label: "AI 에이전트"
   - value: "63"
     label: "자동화 스킬"
-  - value: "309"
+  - value: "318"
     label: "Sprints"
 ---
 

--- a/packages/web/src/components/landing/footer.tsx
+++ b/packages/web/src/components/landing/footer.tsx
@@ -69,7 +69,7 @@ export function Footer() {
             &copy; {new Date().getFullYear()} KTDS AX BD. All rights reserved.
           </p>
           <p className="font-mono text-xs text-muted-foreground/60">
-            Sprint 309 &middot; Phase 46
+            Sprint 318 &middot; Phase 46
           </p>
         </div>
       </div>

--- a/packages/web/src/routes/landing.tsx
+++ b/packages/web/src/routes/landing.tsx
@@ -69,7 +69,7 @@ function getSectionOrder(section: string): number {
    ═══════════════════════════════════════════════ */
 
 const SITE_META_FALLBACK = {
-  sprint: "Sprint 309",
+  sprint: "Sprint 318",
   phase: "Phase 46",
   phaseTitle: "Dual-AI Verification",
   tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼",
@@ -79,7 +79,7 @@ const STATS_FALLBACK = [
   { value: "2", label: "BD 파이프라인" },
   { value: "10+", label: "AI 에이전트" },
   { value: "63", label: "자동화 스킬" },
-  { value: "309", label: "Sprints" },
+  { value: "318", label: "Sprints" },
 ];
 
 // Build-time content from TinaCMS-managed Markdown


### PR DESCRIPTION
## Summary
- Phase 0c-3 세션 종료 콘텐츠 동기화 drift 5건 해소 — Sprint 309 → 318
- SPEC §5 table max Sprint 번호(318, Phase 45 Pipeline)가 SSOT
- content-sync-check.sh PASS 확인 후 PR

## Changes
- SPEC.md §2 "마지막 실측" Sprint 310 + services 31 (drift 동시 갱신)
- README.md, landing hero.md / landing.tsx (SITE_META+STATS) / footer.tsx
- 총 5 files, +7/-7

## Test plan
- [x] scripts/content-sync-check.sh PASS
- [ ] CI typecheck + lint + test (auto)
- [ ] landing Pages 빌드 통과 (auto)