### PR TITLE
chore: AX 컨설팅팀 라벨 + 신규 4명 + 콘텐츠 동기화 SSOT 복원

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Foundry-X가 이를 읽고 분석하고 동기화를 강제해요.
 <!-- README_SYNC_START: daily-check가 SPEC.md 실측값 기준으로 자동 동기화 -->
 | 항목 | 수치 |
 |------|------|
-| Phase | 46 (Sprint 318) |
-| Sprints | 318 완료 |
+| Phase | 45 (Sprint 311) |
+| Sprints | 311 완료 |
 | API Routes | ~11 |
 | API Services | ~31 |
 | API Schemas | ~14 |

--- a/packages/api/src/db/seed/team-accounts.ts
+++ b/packages/api/src/db/seed/team-accounts.ts
@@ -1,5 +1,5 @@
 /**
- * AX BD 팀 계정 시드 데이터
+ * AX 컨설팅팀 (구 AX BD팀) 계정 시드 데이터
  * 실제 이메일은 bulk signup API 호출 시 지정 — 여기는 구조 예시
  */
 export const TEAM_ACCOUNTS = [
@@ -11,6 +11,11 @@ export const TEAM_ACCOUNTS = [
   { email: "jimin.choi@kt.com", name: "최지민", role: "member" as const },
   { email: "sungho.jung@kt.com", name: "정성호", role: "member" as const },
   { email: "axbd.shared@kt.com", name: "AX BD 공용", role: "member" as const },
+  // 2026-04-20 신규 합류 (직급은 표시상 정보)
+  { email: "eungjulee@gmail.com", name: "이응주 책임", role: "member" as const },
+  { email: "namtank3@gmail.com", name: "남윤서 전임", role: "member" as const },
+  { email: "hahaha8176@gmail.com", name: "정한수 책임", role: "member" as const },
+  { email: "jerrygogo2002@gmail.com", name: "이원근 책임", role: "member" as const },
 ] as const;
 
 export const DEFAULT_ORG_ID = "org_axbd";

--- a/packages/web/content/landing/hero.md
+++ b/packages/web/content/landing/hero.md
@@ -3,8 +3,8 @@ title: Foundry-X
 section: hero
 sort_order: 0
 tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼"
-phase: "Phase 46"
-phaseTitle: "Dual-AI Verification"
+phase: "Phase 45"
+phaseTitle: "MSA 3rd Separation"
 stats:
   - value: "2"
     label: "BD 파이프라인"
@@ -12,7 +12,7 @@ stats:
     label: "AI 에이전트"
   - value: "63"
     label: "자동화 스킬"
-  - value: "318"
+  - value: "311"
     label: "Sprints"
 ---
 

--- a/packages/web/src/components/landing/footer.tsx
+++ b/packages/web/src/components/landing/footer.tsx
@@ -69,7 +69,7 @@ export function Footer() {
             &copy; {new Date().getFullYear()} KTDS AX BD. All rights reserved.
           </p>
           <p className="font-mono text-xs text-muted-foreground/60">
-            Sprint 318 &middot; Phase 46
+            Sprint 311 &middot; Phase 45
           </p>
         </div>
       </div>

--- a/packages/web/src/routes/landing.tsx
+++ b/packages/web/src/routes/landing.tsx
@@ -69,9 +69,9 @@ function getSectionOrder(section: string): number {
    ═══════════════════════════════════════════════ */
 
 const SITE_META_FALLBACK = {
-  sprint: "Sprint 318",
-  phase: "Phase 46",
-  phaseTitle: "Dual-AI Verification",
+  sprint: "Sprint 311",
+  phase: "Phase 45",
+  phaseTitle: "MSA 3rd Separation",
   tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼",
 } as const;
 
@@ -79,7 +79,7 @@ const STATS_FALLBACK = [
   { value: "2", label: "BD 파이프라인" },
   { value: "10+", label: "AI 에이전트" },
   { value: "63", label: "자동화 스킬" },
-  { value: "318", label: "Sprints" },
+  { value: "311", label: "Sprints" },
 ];
 
 // Build-time content from TinaCMS-managed Markdown


### PR DESCRIPTION
## Summary

- **content-sync (commit 3d7c81bb)**: PR #639가 README/hero/footer/landing.tsx에 미래값(Sprint 318/Phase 46)을 주입했으나 SPEC §2 마지막 실측은 Sprint 311/Phase 45 → 4파일 SSOT 복원
- **team rename + 신규 4명 (commit 3e2f1c43)**: AX BD팀 → AX 컨설팅팀 라벨 (자산 식별자 보존), team-accounts.ts 8 → 12명

## 변경 파일

### Content sync (4 파일)
- `README.md` — Phase 46 (Sprint 318) → Phase 45 (Sprint 311)
- `packages/web/content/landing/hero.md` — phase/phaseTitle/Sprints stat
- `packages/web/src/routes/landing.tsx` — SITE_META_FALLBACK + STATS_FALLBACK
- `packages/web/src/components/landing/footer.tsx` — Sprint N · Phase N

### Team data (1 파일)
- `packages/api/src/db/seed/team-accounts.ts` — 헤더 코멘트 + 신규 4명 (모두 `member`)
  - 이응주 책임 / 정한수 책임 / 이원근 책임 / 남윤서 전임
  - 직급은 `name` 필드에 보존 (예: `"이응주 책임"`)

## 보존 항목 (자산)
- `DEFAULT_ORG_ID = "org_axbd"` (D1 row 식별자)
- `"AX BD 공용"` 계정 (axbd.shared@kt.com)
- GitHub org `KTDS-AXBD`, 이메일 `ktds.axbd@gmail.com`, Workers URL `ktds-axbd.workers.dev`
- 코드 식별자 `ax-bd`, `axbd`, `KTDS-AXBD`

## 별도 처리
- `/home/sinclair/work/axbd/CLAUDE.md` (저장소 외부, git 추적 X) — 라벨 변경 완료 (이 PR 범위 외)

## Test plan

- [x] `npx eslint packages/api/src/db/seed/team-accounts.ts` PASS
- [x] `npx turbo typecheck --filter=@foundry-x/web --filter=@foundry-x/api` PASS
- [ ] CI: test + deploy-api + deploy-web + smoke-test
- [ ] 프로덕션 헬스체크 (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)