### PR TITLE
fix(test): bd-roi-calculator 시간 의존성 hotfix (master deploy 정상화)

### DIFF
--- a/packages/api/src/__tests__/bd-roi-calculator-service.test.ts
+++ b/packages/api/src/__tests__/bd-roi-calculator-service.test.ts
@@ -97,10 +97,15 @@ describe("BdRoiCalculatorService", () => {
   }
 
   function seedExecutions(costTotal: number) {
-    (db as any).exec(`
+    // Use a date 7 days ago so it always falls within the default 30-day window
+    const recentDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .slice(0, 10);
+    const sql = `
       INSERT INTO skill_executions (id, tenant_id, skill_id, model, status, input_tokens, output_tokens, cost_usd, duration_ms, executed_by, executed_at)
-      VALUES ('e1', 'org_test', 'skill-a', 'claude-haiku', 'completed', 200, 200, ${costTotal}, 500, 'user1', '2026-03-20')
-    `);
+      VALUES ('e1', 'org_test', 'skill-a', 'claude-haiku', 'completed', 200, 200, ${costTotal}, 500, 'user1', '${recentDate}')
+    `;
+    (db as any).exec(sql);
   }
 
   it("should calculate BD_ROI with savings + signal", async () => {


### PR DESCRIPTION
## Summary

- master deploy를 5건 누적 막고 있던 시간 의존성 테스트 버그 hotfix
- `seedExecutions`의 hardcoded `'2026-03-20'` → today-7days 동적 계산

## 증상

- 테스트가 `days: 30` 옵션으로 호출되어 fromStr = today-30
- seed의 `'2026-03-20'`이 fromStr보다 이전이면 SUM(cost_usd)=0 → totalInvestment=0
- **어제(2026-04-19)까지 PASS, 오늘(2026-04-20)부터 FAIL** (fromStr=2026-03-21로 seed 제외)

## 영향

마지막 성공 deploy(`24616519003`) 이후 master push 5건이 모두 deploy SKIP 누적:
- bef719fd FX-SPEC-003 mirror
- 67c82e44 C82 insight
- 35381d7a gov-doc
- db25f436 selfcheck C8
- 36488368 session-end Sprint 311
- 9aa042ce chore: AX 컨설팅팀 (PR #641)

이 PR merge 시 누적 변경 일괄 재배포.

## Test plan

- [x] Local: `npx vitest run bd-roi-calculator-service.test.ts` → 7 passed (이전: 1 failed)
- [ ] CI: test job PASS → deploy 5건 누적 정상 배포
- [ ] 프로덕션 헬스체크

🤖 Generated with [Claude Code](https://claude.com/claude-code)