### PR TITLE
F355b: Decode-X 219 handoff endpoint — Foundry-X side landing

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -52,6 +52,7 @@ import {
   userEvaluationsRoute, builderRoute, mcpRoute, expansionPackRoute,
   axBdKgRoute,
 } from "./core/index.js";
+import { internalPrototypeJobsRoute } from "./core/harness/routes/internal-prototype-jobs.js";
 // Flat routes (shared infrastructure — 8 routes)
 import { requirementsRoute } from "./routes/requirements.js";
 import { specRoute } from "./routes/spec.js";
@@ -217,6 +218,10 @@ app.route("/api", feedbackQueueRoute);
 // `/api/decode/*`는 authMiddleware 이전에 mount하여 공개 read-only 접근 허용.
 // 읽기 전용 + Decode-X로 단방향 프록시라 CSRF/변조 리스크 낮음.
 app.route("/api", decodeBridgeRoute);
+
+// F355b Sprint 219: Decode-X handoff internal endpoint — X-Internal-Secret 전용, JWT 우회
+// authMiddleware 이전에 배치하여 JWT 없이 접근 가능
+app.route("/api", internalPrototypeJobsRoute);
 
 // Protected API routes — JWT required + tenant isolation
 app.use("/api/*", authMiddleware);

--- a/packages/api/src/core/harness/routes/internal-prototype-jobs.ts
+++ b/packages/api/src/core/harness/routes/internal-prototype-jobs.ts
@@ -1,0 +1,38 @@
+// ─── F355b (Sprint 219): Internal Prototype Jobs — Decode-X handoff endpoint ───
+// X-Internal-Secret 전용 미들웨어 적용, JWT authMiddleware 우회
+// orgId는 body에서 명시적으로 받음 (JWT 컨텍스트 없음)
+
+import { Hono } from "hono";
+import { z } from "zod";
+import { CreatePrototypeJobSchema } from "../schemas/prototype-job.js";
+import { PrototypeJobService } from "../services/prototype-job-service.js";
+import type { Env } from "../../../env.js";
+
+export const internalPrototypeJobsRoute = new Hono<{ Bindings: Env }>();
+
+const InternalCreateSchema = CreatePrototypeJobSchema.extend({
+  orgId: z.string().min(1),
+  callerService: z.string().optional(),
+});
+
+// POST /internal/prototype-jobs — Decode-X handoff 전용
+internalPrototypeJobsRoute.post("/internal/prototype-jobs", async (c) => {
+  const secret = c.req.header("X-Internal-Secret");
+  const expected = c.env.DECODE_X_HANDOFF_SECRET;
+  if (!secret || !expected || secret !== expected) {
+    return c.json({ error: "Unauthorized", code: "INVALID_INTERNAL_SECRET" }, 401);
+  }
+
+  const raw = await c.req.json().catch(() => null);
+  if (!raw) return c.json({ error: "Invalid JSON body" }, 400);
+
+  const parsed = InternalCreateSchema.safeParse(raw);
+  if (!parsed.success) {
+    return c.json({ error: parsed.error.flatten() }, 400);
+  }
+
+  const { orgId, prdContent, prdTitle } = parsed.data;
+  const svc = new PrototypeJobService(c.env.DB);
+  const job = await svc.create(orgId, prdContent, prdTitle);
+  return c.json(job, 201);
+});

--- a/packages/api/src/env.ts
+++ b/packages/api/src/env.ts
@@ -40,4 +40,6 @@ export type Env = {
   DECODE_X_INTERNAL_SECRET?: string;
   DECODE_X_EXTRACTION_URL?: string;
   DECODE_X_ONTOLOGY_URL?: string;
+  // F355b Sprint 219: shared secret for Decode-X → Foundry-X internal handoff calls
+  DECODE_X_HANDOFF_SECRET?: string;
 };


### PR DESCRIPTION
## Summary
- Decode-X Sprint 219 (PR #22, `81c9805`, merged 2026-04-21 01:18Z)에서 "Foundry-X 통합 완결"로 선언된 Foundry-X 리포 측 변경이 **uncommitted로 방치**되어 있던 3파일을 긴급 랜딩
- Decode-X 쪽은 이미 prod 배포되어 `DECODE_X_HANDOFF_SECRET`로 Foundry-X `/api/internal/prototype-jobs` POST 호출 중 → **현재 404 응답** 상태 (endpoint 부재)

## 변경 내역
- `packages/api/src/core/harness/routes/internal-prototype-jobs.ts` (신규, 38L)
  - `POST /api/internal/prototype-jobs` — `X-Internal-Secret` 전용 미들웨어 + `orgId` body 필수
  - `CreatePrototypeJobSchema.extend({ orgId: string, callerService?: string })` 스키마
- `packages/api/src/app.ts` (+5) — `authMiddleware` 이전 마운트 (기존 `decodeBridgeRoute`와 동일 패턴)
- `packages/api/src/env.ts` (+2) — `DECODE_X_HANDOFF_SECRET?: string` 타입 추가

## 배경
Decode-X 81c9805 commit 메시지가 "Foundry-X 통합 완결"을 선언했으나, 실제 diff는 Decode-X 리포 파일만 포함. Foundry-X 리포 측 커밋이 별도 세션에서 작성됐으나 commit/push 누락된 채 idle 워크트리에 10+시간 방치. Session-start 점검으로 감지하여 긴급 랜딩.

## Test plan
- [ ] CI typecheck + tests 통과 (neither were added in this PR — Decode-X 219 쪽에서 통합 테스트 완료됐을 것으로 추정)
- [ ] auto-merge 후 deploy.yml smoke test PASS 확인
- [ ] Cloudflare Workers `DECODE_X_HANDOFF_SECRET` secret 이미 등록되어 있는지 `wrangler secret list`로 확인 (없으면 C83 preflight 매트릭스에 편승 필요)
- [ ] Decode-X prod handoff 재호출 → 201 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)