### PR TITLE
[C79] task-complete.sh auto-commit 조건부 skip (C67 관찰 해소)

### DIFF
--- a/scripts/task/task-complete.sh
+++ b/scripts/task/task-complete.sh
@@ -66,7 +66,6 @@ DIRTY=$(git status --porcelain 2>/dev/null | grep -v '^\?' | head -1 || true)
 UNTRACKED=$(git status --porcelain 2>/dev/null | grep '^?' | head -1 || true)
 
 if [ -n "$DIRTY" ] || [ -n "$UNTRACKED" ]; then
-  echo "[fx-task-complete] 미커밋 변경 감지 — 자동 커밋"
   # stage tracked changes
   git add -u 2>/dev/null || true
   # stage new files (exclude task-context/prompt)
@@ -74,7 +73,16 @@ if [ -n "$DIRTY" ] || [ -n "$UNTRACKED" ]; then
     | grep -v '\.task-context\|\.task-prompt' \
     | xargs -r git add 2>/dev/null || true
 
-  git commit -m "chore(${TASK_ID}): auto-commit on task complete" 2>/dev/null || true
+  # C79 (FX-REQ-601): filter 적용 후 stage가 비어있으면 auto-commit 생략. worker가
+  # 이미 fix commit을 만든 뒤 task-context/prompt만 남아있는 경우 두 번째 chore
+  # 커밋이 같은 브랜치에 push되어 중복 PR(e.g. #594, #645 빈 squash)이 생성되는
+  # 패턴을 차단해요. C67(S294) 최초 관찰 → C83(S303) 재발 → S305 근본 fix.
+  if git diff --cached --quiet 2>/dev/null; then
+    echo "[fx-task-complete] auto-commit skip — stage 결과 비어있음 (filter 제외 후 변경 없음)"
+  else
+    echo "[fx-task-complete] 미커밋 변경 감지 — 자동 커밋"
+    git commit -m "chore(${TASK_ID}): auto-commit on task complete" 2>/dev/null || true
+  fi
 fi
 
 # ─── Step 2b: web 변경 시 스크린샷 검증 ──────────────────────────────────────

--- a/scripts/task/test-task-complete-empty.sh
+++ b/scripts/task/test-task-complete-empty.sh
@@ -104,4 +104,40 @@ set -e
 [ "$RC" -eq 0 ] || { cat /tmp/fx-test-s3.log; fail "aggregate non-empty — expected exit 0, got $RC"; }
 pass "aggregate non-empty passes"
 
+# ─── Scenario 4: C79 — auto-commit skip when stage is empty after filter ────
+# Worker가 이미 fix commit을 만든 상태에서, 남은 untracked가 task-context/prompt만
+# 있어 filter 후 staging이 비어있는 경우, 두 번째 chore commit을 생성하지 않아야
+# 해요. 현재 구현은 "미커밋 변경 감지" 로그 후 `git commit ... || true`로 silently
+# fail하지만, 실행 의도(skip)가 로그에 드러나지 않음. 이 scenario는 after-fix의
+# explicit skip 로그를 회귀 보호해요.
+echo "[test] scenario 4 — C79 auto-commit skip when stage empty after filter"
+git reset --hard master -q
+echo "real worker fix" > payload.txt
+git add payload.txt
+git commit -qm "feat: worker fix commit"
+
+# .task-context from Scenario 1 setup remains as the only untracked file — it must
+# be stripped by the filter, leaving the stage empty after `git add`. Do NOT
+# overwrite it here; preserve the BRANCH/TASK_ID fields task-complete.sh sources.
+[ -f .task-context ] || fail "scenario 4 precondition: .task-context must exist from scenario 1 setup"
+
+PRE_COMMIT_COUNT=$(git rev-list master..HEAD --count)
+rm -f "$SIG_FILE"
+set +e
+bash "$TASK_COMPLETE" --dry-run >/tmp/fx-test-s4.log 2>&1
+RC=$?
+set -e
+POST_COMMIT_COUNT=$(git rev-list master..HEAD --count)
+
+[ "$RC" -eq 0 ] || { cat /tmp/fx-test-s4.log; fail "scenario 4 expected exit 0, got $RC"; }
+pass "exit code = 0"
+
+[ "$PRE_COMMIT_COUNT" -eq "$POST_COMMIT_COUNT" ] \
+  || { cat /tmp/fx-test-s4.log; fail "scenario 4 expected no new commits (pre=$PRE_COMMIT_COUNT post=$POST_COMMIT_COUNT)"; }
+pass "no auto-commit created (commit count preserved)"
+
+grep -q "auto-commit skip" /tmp/fx-test-s4.log \
+  || { cat /tmp/fx-test-s4.log; fail "scenario 4 expected 'auto-commit skip' marker in log"; }
+pass "auto-commit skip marker logged"
+
 echo "[test] ✅ ALL TESTS PASSED"


### PR DESCRIPTION
## Summary

C79 근본 fix — task-complete.sh의 `chore(TASKID): auto-commit on task complete` 두 번째 커밋 생성으로 인한 중복 PR 발행 패턴 차단.

- C67 최초 관찰 (S294, 2026-04-15) — PR #593/#594
- C83 dogfood 재발 (S303, 2026-04-20) — PR #644/#645 (#645는 "빈 squash")
- S305 근본 fix

## 변경

**`scripts/task/task-complete.sh`** — Step 2 분기 추가
- `git add -u` + untracked filter add 이후 `git diff --cached --quiet` 체크
- stage 비어있으면 `auto-commit skip` 로그만 출력 (commit 시도 생략)
- stage 있으면 기존대로 `chore(TASKID)` 커밋 생성

**`scripts/task/test-task-complete-empty.sh`** — Scenario 4 신규 (회귀 보호)
- worker fix commit 이후 `.task-context`만 untracked 상태에서 auto-commit이 생성되지 않고 `auto-commit skip` 로그가 남는지 검증
- Red→Green TDD

## Test plan

- [x] Local: `bash scripts/task/test-task-complete-empty.sh` — 4 scenarios / 12 assertions 전부 PASS
- [ ] CI PASS 후 auto-squash merge
- [ ] Post-merge: SPEC §5 C79 row `PLANNED → ✅` 갱신 (master direct)

## 영향 범위

- DIRTY/UNTRACKED 감지 로직 유지 (조건 진입 불변)
- `.task-context`/`.task-prompt` filter 규칙 불변
- Step 2b(screenshot) / Step 2c(empty check) / Step 3(push+PR) 이후 경로 영향 없음

FX-REQ-601