### PR TITLE
chore(preflight): add DECODE_X_HANDOFF_SECRET to foundry-x-api matrix

### DIFF
--- a/scripts/preflight/required-secrets.json
+++ b/scripts/preflight/required-secrets.json
@@ -6,7 +6,8 @@
     "ANTHROPIC_API_KEY",
     "WEBHOOK_SECRET",
     "GITHUB_TOKEN",
-    "OPENROUTER_API_KEY"
+    "OPENROUTER_API_KEY",
+    "DECODE_X_HANDOFF_SECRET"
   ],
   "fx-discovery": ["JWT_SECRET"],
   "fx-shaping": ["JWT_SECRET"],


### PR DESCRIPTION
## Summary
- F355b Sprint 219 handoff endpoint는 PR #651로 랜딩됐지만 `DECODE_X_HANDOFF_SECRET`이 prod 미등록 상태 + preflight 매트릭스에서도 누락 → 사각지대
- C83 preflight JSON에 1행 추가하여 다음 배포부터 fail-fast 활성화
- C85 deploy-verifier는 본 JSON을 SSOT로 참조하므로 동시 커버

## 변경 내역
- `scripts/preflight/required-secrets.json` foundry-x-api 배열에 `DECODE_X_HANDOFF_SECRET` 추가

## ⚠️ Merge 후 선행 조건
이 PR merge 후 **다음 배포부터 `foundry-x-api` 배포는 secret 등록까지 block**됨. 사용자 prod secret 등록 필요:
```bash
VAL=$(openssl rand -hex 32)
echo "$VAL" | wrangler secret put DECODE_X_HANDOFF_SECRET --name foundry-x-api
echo "$VAL" | wrangler secret put FOUNDRY_X_SECRET --name svc-skill  # Decode-X 측
```
(Decode-X `services/svc-skill/src/routes/handoff.ts:244`에서 `env.FOUNDRY_X_SECRET` 참조)

## Test plan
- [x] `bash scripts/preflight/__tests__/check-worker-secrets.test.sh` 7/7 PASS (local)
- [ ] CI preflight job PASS
- [ ] 사용자 secret 등록 후 다음 배포 PASS 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)