### PR TITLE
C88 (e): task-daemon terminal state guard — phase_recover/watch/signals

### DIFF
--- a/scripts/task/task-daemon.sh
+++ b/scripts/task/task-daemon.sh
@@ -52,6 +52,31 @@ mkdir -p "$FX_HOME" "$SNAPSHOT_DIR" /tmp/task-signals
 log() { echo "[$(date +%H:%M:%S)] $*" >> "$DAEMON_LOG"; }
 
 # ═══════════════════════════════════════════════════════════════════════════
+# (e) Terminal state guard — C88/S306 / FX-REQ-625
+# tasks-cache.json `.tasks[tid].status` 가 terminal(merged/failed/cancelled)
+# 이면 0(=terminal) 반환. 복구 진입점(phase_recover/phase_watch/phase_signals)
+# 모두가 이 판정을 공유하여 early return 한다.
+#
+# 근거: S305 Live dogfood (C79 MERGED 후 pane %12 stale 복구 루프 attempts=36).
+# pane 필드만 보고 복구를 시도하면 terminal state task 도 영구 loop 가 된다.
+# ═══════════════════════════════════════════════════════════════════════════
+is_terminal_state() {
+  local tid="$1"
+  local s
+  s=$(jq -r --arg tid "$tid" '.tasks[$tid].status // ""' "$FX_CACHE" 2>/dev/null || echo "")
+  case "$s" in
+    merged|failed|cancelled) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# cache 에서 status 문자열을 읽어 반환 (빈 문자열이면 "") — guard 이벤트 extra 용
+_cache_status() {
+  local tid="$1"
+  jq -r --arg tid "$tid" '.tasks[$tid].status // ""' "$FX_CACHE" 2>/dev/null || echo ""
+}
+
+# ═══════════════════════════════════════════════════════════════════════════
 # Phase 1: Signal 처리 (기존 task-monitor.sh 역할)
 # ═══════════════════════════════════════════════════════════════════════════
 phase_signals() {
@@ -63,6 +88,16 @@ phase_signals() {
 
     [ "$STATUS" = "DONE" ] || continue
     [ -n "$TASK_ID" ] || continue
+
+    # (e) Terminal state guard — C88 — cache 이미 terminal 이면 중복 signal skip + 파일 보존.
+    # 재처리로 인한 WT 재-제거 / merge 재시도 / master pull 중복 방지.
+    if is_terminal_state "$TASK_ID"; then
+      local _termstate; _termstate=$(_cache_status "$TASK_ID")
+      log "🛡️  ${TASK_ID}: terminal state (${_termstate}) — phase_signals skip (signal 파일 보존)"
+      log_event "$TASK_ID" "phase_signals_terminal_skip" \
+        "$(jq -nc --arg s "$_termstate" '{status:$s, guard:"phase_signals"}')"
+      continue
+    fi
 
     log "📡 signal: ${TASK_ID}"
 
@@ -287,6 +322,17 @@ phase_watch() {
   while IFS='|' read -r task_id pane_id wt_path; do
     [ -z "$task_id" ] || [ -z "$pane_id" ] && continue
 
+    # (e) Terminal state guard — C88 — jq filter 이후 cache 가 변경된 race 방어.
+    # phase_watch 시작 시 in_progress 였지만 중간에 merged/failed/cancelled 로 바뀐
+    # task 는 phase_recover 를 호출하지 않는다.
+    if is_terminal_state "$task_id"; then
+      local _ws; _ws=$(_cache_status "$task_id")
+      log "🛡️  ${task_id}: terminal state (${_ws}) — phase_watch skip"
+      log_event "$task_id" "phase_watch_terminal_guard" \
+        "$(jq -nc --arg s "$_ws" '{status:$s, guard:"phase_watch"}')"
+      continue
+    fi
+
     # pane 존재 확인
     if ! tmux list-panes -a -F '#{pane_id}' 2>/dev/null | grep -q "^${pane_id}$"; then
       # pane 죽었지만 signal 없음 → 실패 기록 + 자동 복구 시도
@@ -444,6 +490,17 @@ phase_queue() {
 # ═══════════════════════════════════════════════════════════════════════════
 phase_recover() {
   local tid="$1" wt="$2"
+
+  # (e) Terminal state guard — C88 — 진입 차단 1차 방어선.
+  # phase_watch 의 2차 guard 가 race 로 뚫린 경우, 그리고 __debug-recover 같은
+  # 단독 CLI 진입점에서도 terminal state task 는 복구 로직을 건너뛴다.
+  if is_terminal_state "$tid"; then
+    local _rs; _rs=$(_cache_status "$tid")
+    log "🛡️  ${tid}: terminal state (${_rs}) — phase_recover skip (복구 진입 차단)"
+    log_event "$tid" "phase_recover_terminal_guard" \
+      "$(jq -nc --arg s "$_rs" '{status:$s, guard:"phase_recover"}')"
+    return 0
+  fi
 
   [ -d "$wt" ] || { log "복구: ${tid} WT 없음 — 포기"; return 1; }
 

--- a/scripts/task/test-daemon-terminal-guard.sh
+++ b/scripts/task/test-daemon-terminal-guard.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# scripts/task/test-daemon-terminal-guard.sh — C88 (e) / FX-REQ-625
+#
+# task-daemon.sh terminal state guard 단위 테스트.
+# tasks-cache.json `.tasks[tid].status` 가 terminal(merged/failed/cancelled)인
+# task가 복구 진입점에 도달했을 때 early return 되는지 검증한다.
+#
+#   scenario A: phase_recover + cache status=merged    → early return + guard 이벤트
+#   scenario B: phase_recover + cache status=failed    → early return
+#   scenario C: phase_recover + cache status=cancelled → early return
+#   scenario D: phase_signals + cache status=failed    → signal 파일 보존 + skip 로그
+#
+# Red Phase 기준(현재 구현): guard 없어서 daemon 로그에
+#   "복구: <tid> — work_commits=..."  이 찍힘 + guard 이벤트 미기록 → FAIL.
+# Green Phase 기준: daemon 로그에 복구 진입 흔적 없음 + guard 이벤트 기록 → PASS.
+#
+# 격리: tmp git repo + 격리 PROJECT 이름으로 실제 retry/signal 디렉토리 오염 최소화.
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DAEMON="$SCRIPT_DIR/task-daemon.sh"
+[ -x "$DAEMON" ] || chmod +x "$DAEMON" 2>/dev/null || true
+
+TMP=$(mktemp -d)
+PROJECT="Foundry-X-termguard-$$"
+export FX_HOME="$TMP/fx-home"
+mkdir -p "$FX_HOME" /tmp/task-retry /tmp/task-signals
+
+REPO="$TMP/$PROJECT"
+CACHE="$FX_HOME/tasks-cache.json"
+EVENT_LOG="$FX_HOME/task-log.ndjson"          # lib.sh: FX_LOG = task-log.ndjson
+DAEMON_LOG="/tmp/task-signals/daemon-${PROJECT}.log"
+
+cleanup() {
+  rm -rf "$TMP"
+  rm -f "$DAEMON_LOG"
+  rm -f /tmp/task-retry/${PROJECT}-*.json 2>/dev/null || true
+  rm -f /tmp/task-signals/${PROJECT}-*.signal 2>/dev/null || true
+}
+trap cleanup EXIT
+
+mkdir -p "$REPO"
+cd "$REPO"
+git init -q -b master
+git config user.email "test@foundry-x.local"
+git config user.name  "fx-test"
+echo "init" > README.md
+git add README.md
+git commit -qm "init"
+
+pass() { echo "  ✅ $*"; }
+fail() { echo "  ❌ $*" >&2; exit 1; }
+
+# terminal cache fixture — 실제 작업 흔적도 있는 WT 제공.
+# guard 가 없으면 phase_recover 가 work_commits 분석 → task-complete 실행까지 진입.
+make_worker_wt() {
+  local tid="$1" wt="$2"
+  git worktree add -q -b "task/${tid}-tg" "$wt" master
+  local base_sha; base_sha=$(git rev-parse HEAD)
+  cat > "$wt/.task-context" <<EOF
+TASK_ID=${tid}
+TASK_TYPE=C
+TITLE=terminal guard test
+REQ_ID=FX-REQ-625
+BRANCH=task/${tid}-tg
+BASE_SHA=${base_sha}
+EOF
+  echo "prompt" > "$wt/.task-prompt"
+  (cd "$wt" && git add .task-context .task-prompt && git commit -qm "chore(meta): ${tid} task context init")
+  echo "real payload" > "$wt/out.txt"
+  (cd "$wt" && git add out.txt && git commit -qm "feat: dummy worker output")
+}
+
+# cache 주입 — .tasks[tid].status 를 terminal 값으로 seed
+seed_cache_terminal() {
+  local tid="$1" status="$2" pane="${3:-%9999}" wt="${4:-/nonexistent}"
+  if [ ! -f "$CACHE" ]; then
+    echo '{"version":1,"tasks":{}}' > "$CACHE"
+  fi
+  local tmp; tmp=$(mktemp)
+  jq --arg tid "$tid" --arg st "$status" --arg pn "$pane" --arg wt "$wt" \
+    '.tasks[$tid] = {status:$st, track:"C", pane:$pn, wt:$wt}' \
+    "$CACHE" > "$tmp" && mv "$tmp" "$CACHE"
+}
+
+# guard 이벤트 매칭 — FX_LOG 구조: {ts, id, event, extra}
+grep_event() {
+  local tid="$1" reason="$2"
+  [ -f "$EVENT_LOG" ] || { echo 0; return; }
+  jq -r --arg tid "$tid" --arg r "$reason" \
+    'select(.id==$tid and .event==$r) | .event' "$EVENT_LOG" 2>/dev/null | wc -l
+}
+
+run_recover_scenario() {
+  local label="$1" tid="$2" status="$3"
+  local WT="$TMP/wt-${tid}"
+
+  echo "[test] ${label} — phase_recover + cache status=${status} should early-return"
+  make_worker_wt "$tid" "$WT"
+  seed_cache_terminal "$tid" "$status" "%8888" "$WT"
+
+  : > "$DAEMON_LOG"
+  rm -f "$EVENT_LOG"
+
+  # phase_recover 단독 호출 — exit code 는 무시 (Red 단계에서 task-complete 부재로 fail 할 수 있음).
+  # 실제 guard 동작은 로그/이벤트로 판정한다.
+  bash "$DAEMON" __debug-recover "$tid" "$WT" > "/tmp/fx-tg-${tid}.log" 2>&1 || true
+  pass "${label}: phase_recover 호출 반환"
+
+  # 핵심 1: daemon log에 "복구: <tid> — work_commits=..." 흔적 없어야 함 (guard로 진입 차단)
+  if grep -q "복구: ${tid} — work_commits=" "$DAEMON_LOG" 2>/dev/null; then
+    echo "---DAEMON_LOG---"; cat "$DAEMON_LOG"
+    fail "${label}: phase_recover 가 복구 블록 진입 (guard 미동작)"
+  fi
+  pass "${label}: 복구 블록 미진입"
+
+  # 핵심 2: guard 이벤트 기록
+  local n; n=$(grep_event "$tid" "phase_recover_terminal_guard")
+  [ "$n" -ge 1 ] || {
+    [ -f "$EVENT_LOG" ] && { echo "---EVENT_LOG---"; cat "$EVENT_LOG"; }
+    fail "${label}: phase_recover_terminal_guard 이벤트 누락 (expected ≥1, got ${n})"
+  }
+  pass "${label}: phase_recover_terminal_guard 이벤트 기록 (n=${n})"
+
+  # 핵심 3: retry 파일 미생성 (guard 전 진입 시 empty-diff 분기로 retry 생길 가능성 차단)
+  [ ! -f "/tmp/task-retry/${PROJECT}-${tid}.json" ] \
+    || fail "${label}: retry 파일이 생성됨 (guard 이전 진입 의심)"
+  pass "${label}: retry 파일 미생성"
+}
+
+# ─── Scenario A/B/C: phase_recover terminal states ──────────────────────────
+run_recover_scenario "scenario A" "T997" "merged"
+run_recover_scenario "scenario B" "T996" "failed"
+run_recover_scenario "scenario C" "T995" "cancelled"
+
+# ─── Scenario D: phase_signals + terminal cache → signal 파일 보존 ──────────
+echo "[test] scenario D — phase_signals should skip when cache status=failed"
+TID_D="T994"
+SIGFILE="/tmp/task-signals/${PROJECT}-${TID_D}.signal"
+cat > "$SIGFILE" <<EOF
+TASK_ID=${TID_D}
+STATUS=DONE
+BRANCH=task/${TID_D}-tg
+PR_URL=none
+COMMIT_COUNT=0
+WT_PATH=/nonexistent
+PANE_ID=%9999
+TIMESTAMP=$(date -Iseconds)
+EOF
+
+seed_cache_terminal "$TID_D" "failed" "%9999" "/nonexistent"
+
+: > "$DAEMON_LOG"
+rm -f "$EVENT_LOG"
+
+# phase_signals 단독 호출 — 기존 __debug-phase-signals 진입점 (line 1121)
+bash "$DAEMON" __debug-phase-signals > "/tmp/fx-tg-${TID_D}.log" 2>&1 || true
+pass "scenario D: phase_signals 호출 반환"
+
+# 핵심 1: guard 이벤트 기록
+n=$(grep_event "$TID_D" "phase_signals_terminal_skip")
+[ "$n" -ge 1 ] || {
+  [ -f "$EVENT_LOG" ] && { echo "---EVENT_LOG---"; cat "$EVENT_LOG"; }
+  fail "scenario D: phase_signals_terminal_skip 이벤트 누락 (got ${n})"
+}
+pass "scenario D: phase_signals_terminal_skip 이벤트 기록 (n=${n})"
+
+# 핵심 2: signal 파일 보존 (guard 없으면 처리 시도 중 삭제)
+[ -f "$SIGFILE" ] || fail "scenario D: signal 파일이 삭제됨 (guard 보존 실패)"
+pass "scenario D: signal 파일 보존"
+
+# 핵심 3: daemon log에 "📡 signal: <tid>" 진입 흔적 없어야 함 (guard로 진입 차단)
+if grep -q "📡 signal: ${TID_D}" "$DAEMON_LOG" 2>/dev/null; then
+  echo "---DAEMON_LOG---"; cat "$DAEMON_LOG"
+  fail "scenario D: phase_signals 가 처리 블록 진입 (guard 미동작)"
+fi
+pass "scenario D: phase_signals 처리 블록 미진입"
+
+echo "[test] ✅ ALL TESTS PASSED"


### PR DESCRIPTION
## Summary

C88 (e) Terminal state guard — task-daemon 복구 진입점에 `tasks-cache.json` status terminal(merged/failed/cancelled) early return 추가.

- **is_terminal_state()** 공통 헬퍼 + `_cache_status()` 보조
- **phase_recover**: 진입 차단 1차 방어선 (단독 CLI + phase_watch 경유 모두)
- **phase_watch**: jq filter 이후 race 방어 (per-task 2차)
- **phase_signals**: cache 이미 terminal 이면 signal 파일 **보존** + skip

## Background

S305 Live dogfood (2026-04-21) — C79 MERGED 후 pane `%12` stale 복구 루프 attempts=22→36 포착. 기존 구조는 pane 필드만 보고 복구를 시도하여 terminal state task 도 영구 loop 에 빠뜨렸음.

(a) attempts cap 과 **독립 축** — (e) 는 진입 차단, (a) 는 진입 후 cap. 본 PR 은 (e) 만 scope. (a)/(b)/(c)/(d) 는 후속 세션 작업.

## Tests

Red → Green 4 scenario 전부 PASS (`scripts/task/test-daemon-terminal-guard.sh`):

| # | scenario | 기대 이벤트 |
|---|----------|-----------|
| A | `phase_recover` + status=merged | `phase_recover_terminal_guard` |
| B | `phase_recover` + status=failed | 동일 |
| C | `phase_recover` + status=cancelled | 동일 |
| D | `phase_signals` + status=failed | `phase_signals_terminal_skip` (+ signal 파일 보존) |

회귀 확인: `test-daemon-retry` / `c64-merged-first` / `merge-reconfirm` / `restart-hook` 4 테스트 전부 PASS.

## Test plan

- [x] Red test FAIL 확인 (guard 부재 상태 commit `fe13f358`)
- [x] Green test 4/4 PASS
- [x] 기존 daemon 테스트 4/4 회귀 PASS
- [ ] master merge 후 live dogfood — daemon `--stop && --bg` 재기동 후 인위적 terminal cache 주입 → guard 이벤트 확인

## Refs

- FX-REQ-625, SPEC §5 C88 row (PLANNED → 🔧(impl))
- MEMORY: `feedback_task_daemon_post_merge.md`, S305/S306 세션

🤖 Generated with [Claude Code](https://claude.com/claude-code)