### PR TITLE
fix(ci): shared-contracts 선행 빌드 — F562 Sprint 313 hotfix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,6 +84,7 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @foundry-x/shared-contracts build
       - run: pnpm --filter @foundry-x/shared build
       - run: pnpm --filter @foundry-x/harness-kit build
       - name: Apply D1 migrations (remote)
@@ -117,6 +118,7 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @foundry-x/shared-contracts build
       - run: pnpm --filter @foundry-x/shared build
       - run: pnpm --filter @foundry-x/web build
         env:
@@ -161,6 +163,7 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @foundry-x/shared-contracts build
       - run: pnpm --filter @foundry-x/shared build
       - name: Secret Preflight Check (C83)
         env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,6 +24,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Build shared-contracts (dependency of shared)
+        run: pnpm -F @foundry-x/shared-contracts build
+
       - name: Build shared package
         run: pnpm -F @foundry-x/shared build
 

--- a/.github/workflows/msa-lint.yml
+++ b/.github/workflows/msa-lint.yml
@@ -26,6 +26,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Build shared-contracts (dependency of shared)
+        run: pnpm --filter @foundry-x/shared-contracts build
+
       - name: Build shared (dependency of api)
         run: pnpm --filter @foundry-x/shared build
 


### PR DESCRIPTION
## 배경

Sprint 313 F562에서 `packages/shared-contracts/` workspace 신규 추가. `packages/shared/src/discovery-contract.ts`가 `@foundry-x/shared-contracts`를 import.

## 문제

4개 workflow가 `pnpm --filter @foundry-x/shared build`를 직접 호출 — pnpm filter는 workspace 의존성을 자동 빌드하지 않아 tsc FAIL.

**관측**:
- E2E Run #24725637175: 4 shards 전부 FAIL at "Build shared package"
- Deploy Run #24725638147: test job 완료 후 api/web/preflight 전부 FAIL 예상 확증
- `error TS2307: Cannot find module '@foundry-x/shared-contracts'`

## 수정

`pnpm --filter @foundry-x/shared build` 바로 앞에 `pnpm --filter @foundry-x/shared-contracts build` 선행 스텝 추가:

- `deploy.yml`: 3곳 (api build, web build, preflight 각 job)
- `e2e.yml`: 1곳
- `msa-lint.yml`: 1곳

## 대안 검토

| 대안 | 장단점 |
|------|--------|
| **선행 step 추가 (채택)** | 명시적, 최소 변경, 예측 가능 |
| `pnpm -F @foundry-x/shared... build` (재귀 필터) | filter syntax 가독성 낮음 |
| `pnpm turbo build --filter=...` | 오버헤드, 기존 스타일과 불일치 |

## Test plan

- [x] Local diff 확인 (9 lines, 5 files)
- [ ] PR CI (deploy test + e2e) 통과
- [ ] Master merge 후 재배포 success