### PR TITLE
fix(deploy): F561 discovery-db prod 프로비저닝 + migration 자동화

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,6 +93,12 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           workingDirectory: packages/api
           command: d1 migrations apply foundry-x-db --remote
+      - name: Apply fx-discovery D1 migrations (remote) — F561 discovery-db
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          workingDirectory: packages/fx-discovery
+          command: d1 migrations apply foundry-x-discovery-db --remote
       - uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/packages/fx-discovery/wrangler.toml
+++ b/packages/fx-discovery/wrangler.toml
@@ -4,15 +4,15 @@ main = "src/index.ts"
 compatibility_date = "2026-03-17"
 compatibility_flags = ["nodejs_compat"]
 
-# F561: D1 Option A — foundry-x-discovery-db (신규, Phase 45 MVP M2)
-# PoC 상태: sinclairseo@gmail.com 계정에 생성됨 (ID: 51288e69-a614-40ac-9d4d-453f5faf7a37)
-# 프로덕션 전환 시: ktds.axbd@gmail.com 계정에서 재생성 필요 (§4 FK 분석 문서 참조)
+# F561: D1 Option A — foundry-x-discovery-db (Phase 45 MVP M2)
+# Prod: ktds.axbd@gmail.com (S307 2026-04-21 생성, ID f129f04b-0149-4ff4-bc2f-382b025130b9)
+# Dev:  sinclairseo@gmail.com (F561 PoC, ID 51288e69...) — env.dev 블록 참조
 # DISCOVERY_DB_MODE=shadow: 양쪽 write (기존 DB primary), 검증 전용
 # DISCOVERY_DB_MODE=legacy: 기존 foundry-x-db만 (rollback 시)
 [[d1_databases]]
 binding = "DISCOVERY_DB"
 database_name = "foundry-x-discovery-db"
-database_id = "51288e69-a614-40ac-9d4d-453f5faf7a37"
+database_id = "f129f04b-0149-4ff4-bc2f-382b025130b9"
 migrations_dir = "migrations"
 
 # 기존 shared DB (롤백 시 primary, legacy 모드)


### PR DESCRIPTION
## 배경

Sprint 313 F561 (Phase 45 MVP M2, PR #656 merged)이 `packages/fx-discovery/wrangler.toml`에 **sinclairseo@gmail.com PoC 계정의 D1 ID**를 남겼음. 주석에도 *"프로덕션 전환 시 재생성 필요"* 명시.

## 증상

Deploy run #24726011482 deploy-msa 실패:

```
✘ [ERROR] A request to the Cloudflare API (/accounts/b6c06059.../workers/scripts/fx-discovery/versions) failed.
  D1 binding 'DISCOVERY_DB' references database '51288e69-a614-40ac-9d4d-453f5faf7a37'
  which was not found. [code: 10181]
```

## 조치

1. **Prod 계정 D1 생성** (이미 수행): Cloudflare API `POST /accounts/.../d1/database` `{"name":"foundry-x-discovery-db"}` → UUID `f129f04b-0149-4ff4-bc2f-382b025130b9`
2. **Migration 13개 적용** (이미 수행): `npx wrangler d1 migrations apply foundry-x-discovery-db --remote` — 0001~0013 전부 ✅
3. **wrangler.toml 업데이트**: top-level DISCOVERY_DB binding의 database_id 교체. env.dev 블록은 dev 계정 ID 유지
4. **deploy.yml 확장**: `d1 migrations apply foundry-x-discovery-db` 스텝 추가 — 차기 migration 자동 적용

## 배포 영향

- 기존 서비스: 무영향 (fx-discovery `DISCOVERY_DB_MODE=shadow` — 기존 foundry-x-db가 primary, 신규 DB는 shadow-write 전용)
- 재배포: 이 PR merge 즉시 fx-discovery 재배포 복구

## 재발 방지 후보 (후속 C-track)

- **C90 (proposed)**: deploy-verifier agent에 새 worker의 D1 binding 존재 preflight 추가 (C83/C85 secret matrix 확장 패턴과 동일)
- Sprint autopilot: 신규 D1 binding 추가 시 prod 계정에 DB 생성 단계가 범위에 포함되도록 check

## Test plan

- [x] Local: D1 생성 + migration 13개 ✅
- [ ] PR CI: shared-contracts 선행 빌드(PR #657) 포함 → test/deploy 전부 PASS
- [ ] master merge 후 deploy-msa job Deploy fx-discovery Worker 성공
- [ ] 프로덕션 fx-discovery 응답 확인