### PR TITLE
feat(C88): task-daemon hardening (a)(b)(c)(d) — crash loop cap + restart counter + heartbeat warn + doctor --crash-loop

### DIFF
--- a/scripts/task/lib.sh
+++ b/scripts/task/lib.sh
@@ -345,3 +345,53 @@ mark_spec_done_row() {
     fi
   ) 8>"$FX_LOCK_DIR/master-push.lock"
 }
+
+# ─── Daemon crash loop guard (C88 b/c) ───────────────────────────────────────
+# (b) 1시간 윈도우 내 재시작 횟수를 epoch JSON array로 추적.
+#     3회 초과 시 stderr 경고 + 비정상 종료(return 1).
+# (c) heartbeat 파일이 120초 이내에 갱신됐으면 crash loop 의심 WARN 출력.
+#
+# 반환값: 0 = 정상 기동 허용 / 1 = crash loop 감지, 재기동 거부
+#
+# 용도: task-daemon.sh --bg 핸들러 + task-start.sh 자동 기동 경로에서 호출.
+daemon_restart_guard() {
+  local counter_file="${FX_HOME}/daemon-restart-counter"
+  local heartbeat_file="${FX_HOME}/daemon-heartbeat"
+  local warn_log="${FX_HOME}/daemon-warn.log"
+  local now; now=$(date +%s)
+  local window_start=$(( now - 3600 ))
+  local max_restarts=3
+
+  # (c) heartbeat stale 경고: PID가 없는데 heartbeat가 120초 이내면 crash loop 의심
+  if [ -f "$heartbeat_file" ]; then
+    local hb_ts; hb_ts=$(cat "$heartbeat_file" 2>/dev/null || echo "")
+    if [ -n "$hb_ts" ]; then
+      local hb_epoch; hb_epoch=$(date -d "$hb_ts" +%s 2>/dev/null || echo 0)
+      local hb_age=$(( now - hb_epoch ))
+      if [ "$hb_age" -lt 120 ]; then
+        local msg="[task-daemon] ⚠️  WARN: heartbeat ${hb_age}초 전에 갱신됨 — crash loop 의심 (daemon 비정상 종료?)"
+        echo "$msg" >&2
+        echo "$(date -Iseconds) $msg" >> "$warn_log" 2>/dev/null || true
+      fi
+    fi
+  fi
+
+  # (b) restart counter: 현재 epoch 추가 후 1h 윈도우 필터링
+  local entries
+  if [ -f "$counter_file" ]; then
+    entries=$(jq --argjson now "$now" --argjson ws "$window_start" \
+      'map(select(. > $ws)) + [$now]' "$counter_file" 2>/dev/null || echo "[$now]")
+  else
+    entries="[$now]"
+  fi
+  printf '%s\n' "$entries" > "$counter_file"
+
+  local count; count=$(jq 'length' <<< "$entries" 2>/dev/null || echo 0)
+  if [ "$count" -gt "$max_restarts" ]; then
+    local cmsg="[task-daemon] ❌ crash loop 감지: 1시간 내 ${count}회 재시작 (상한=${max_restarts}) — 수동 intervention 필요. daemon-warn.log 확인."
+    echo "$cmsg" >&2
+    echo "$(date -Iseconds) $cmsg" >> "$warn_log" 2>/dev/null || true
+    return 1
+  fi
+  return 0
+}

--- a/scripts/task/task-daemon.sh
+++ b/scripts/task/task-daemon.sh
@@ -492,14 +492,27 @@ phase_recover() {
   local tid="$1" wt="$2"
 
   # (e) Terminal state guard — C88 — 진입 차단 1차 방어선.
-  # phase_watch 의 2차 guard 가 race 로 뚫린 경우, 그리고 __debug-recover 같은
-  # 단독 CLI 진입점에서도 terminal state task 는 복구 로직을 건너뛴다.
   if is_terminal_state "$tid"; then
     local _rs; _rs=$(_cache_status "$tid")
     log "🛡️  ${tid}: terminal state (${_rs}) — phase_recover skip (복구 진입 차단)"
     log_event "$tid" "phase_recover_terminal_guard" \
       "$(jq -nc --arg s "$_rs" '{status:$s, guard:"phase_recover"}')"
     return 0
+  fi
+
+  # (a) Attempts cap 선제 체크 — C88 — enqueue_retry 진입 전 조기 차단.
+  # retry 파일에 기록된 attempts 가 TASK_MAX_RETRY 에 도달했으면 더 이상 복구를
+  # 시도하지 않는다. enqueue_retry 내부의 동일 guard 와 이중 방어를 구성한다.
+  local _retry_file="/tmp/task-retry/${PROJECT}-${tid}.json"
+  if [ -f "$_retry_file" ]; then
+    local _prev_attempts; _prev_attempts=$(jq -r '.attempts // 0' "$_retry_file" 2>/dev/null || echo 0)
+    if [ "$_prev_attempts" -ge "$TASK_MAX_RETRY" ]; then
+      log "🛡️  ${tid}: attempts=${_prev_attempts} >= TASK_MAX_RETRY=${TASK_MAX_RETRY} — phase_recover 선제 차단"
+      log_event "$tid" "retry_attempts_total" \
+        "$(jq -nc --argjson a "$_prev_attempts" --argjson m "$TASK_MAX_RETRY" \
+           '{attempts:$a, max_retry:$m, guard:"phase_recover_precheck"}')"
+      return 0
+    fi
   fi
 
   [ -d "$wt" ] || { log "복구: ${tid} WT 없음 — 포기"; return 1; }
@@ -1139,6 +1152,9 @@ show_status() {
 # ═══════════════════════════════════════════════════════════════════════════
 case "${1:-}" in
   --bg)
+    # (b)(c) crash loop guard — 재시작 전 안전 확인
+    daemon_restart_guard || exit 1
+
     # PID 살아있으면 heartbeat 확인 후 재시작 여부 결정
     if [ -f "$DAEMON_PID_FILE" ] && kill -0 "$(cat "$DAEMON_PID_FILE")" 2>/dev/null; then
       if [ -f "$DAEMON_HEARTBEAT" ]; then
@@ -1174,6 +1190,15 @@ case "${1:-}" in
   __debug-recover)
     # 단위 테스트 진입점 — phase_recover 직접 호출 (FX-REQ-517 / C23)
     phase_recover "${2:?task_id required}" "${3:?wt_path required}"
+    ;;
+  __debug-restart-guard)
+    # 단위 테스트 진입점 — daemon_restart_guard 직접 호출 (C88 b/c 검증)
+    daemon_restart_guard
+    ;;
+  __debug-heartbeat-stale)
+    # 단위 테스트 진입점 — heartbeat stale 경고 경로만 실행 (C88 c 검증)
+    # daemon_restart_guard 내부의 (c) 로직을 트리거함
+    daemon_restart_guard
     ;;
   __debug-phase-signals)
     # 단위 테스트 진입점 — phase_signals 직접 호출 (C61 B-fix 검증)

--- a/scripts/task/task-doctor.sh
+++ b/scripts/task/task-doctor.sh
@@ -18,15 +18,78 @@ source "$SCRIPT_DIR/lib.sh"
 
 FIX_MODE=0
 FILTER_TASK=""
+CRASH_LOOP_MODE=0
 while [ $# -gt 0 ]; do
   case "$1" in
-    --fix)    FIX_MODE=1; shift ;;
-    --task)   FILTER_TASK="$2"; shift 2 ;;
+    --fix)         FIX_MODE=1; shift ;;
+    --task)        FILTER_TASK="$2"; shift 2 ;;
+    --crash-loop)  CRASH_LOOP_MODE=1; shift ;;
     --help|-h)
       sed -n '2,12p' "$0"; exit 0 ;;
     *) echo "[doctor] unknown arg: $1" >&2; exit 2 ;;
   esac
 done
+
+# ─── --crash-loop diagnostics (C88 d) ─────────────────────────────────────────
+# 독립 실행 경로 — 정규 scan 루프 실행 없이 crash loop 진단만 출력하고 종료.
+if [ "$CRASH_LOOP_MODE" -eq 1 ]; then
+  echo ""
+  echo "🔍 Crash Loop Diagnostics"
+  echo "─────────────────────────────────────────────────"
+
+  HEARTBEAT_FILE="${FX_HOME}/daemon-heartbeat"
+  COUNTER_FILE="${FX_HOME}/daemon-restart-counter"
+  LOG_FILE="${FX_HOME}/task-log.ndjson"
+
+  # (1) 마지막 heartbeat 시각 + age
+  if [ -f "$HEARTBEAT_FILE" ]; then
+    hb_ts=$(cat "$HEARTBEAT_FILE" 2>/dev/null || echo "")
+    if [ -n "$hb_ts" ]; then
+      hb_epoch=$(date -d "$hb_ts" +%s 2>/dev/null || echo 0)
+      now=$(date +%s)
+      hb_age=$(( now - hb_epoch ))
+      echo "  [1] Daemon heartbeat: ${hb_ts} (${hb_age}초 전)"
+    else
+      echo "  [1] Daemon heartbeat: 파일 있으나 내용 없음"
+    fi
+  else
+    echo "  [1] Daemon heartbeat: 파일 없음 (daemon 미실행 또는 정상 종료)"
+  fi
+
+  # (2) DAEMON_RESTART_COUNTER 1h 내 재시작 횟수
+  if [ -f "$COUNTER_FILE" ]; then
+    now=$(date +%s)
+    window_start=$(( now - 3600 ))
+    count=$(jq --argjson ws "$window_start" '[.[] | select(. > $ws)] | length' "$COUNTER_FILE" 2>/dev/null || echo 0)
+    total=$(jq 'length' "$COUNTER_FILE" 2>/dev/null || echo 0)
+    echo "  [2] Restart counter: 1h 내 ${count}회 / 전체 ${total}회 기록"
+    if [ "$count" -gt 3 ]; then
+      echo "      ⚠️  임계치(3회) 초과 — crash loop 의심"
+    fi
+  else
+    echo "  [2] Restart counter: 파일 없음 (재시작 이력 0회)"
+  fi
+
+  # (3) task-log.ndjson에서 retry_attempts_total > 3 task 요약 (top 5)
+  if [ -f "$LOG_FILE" ]; then
+    echo "  [3] retry_attempts_total > 3 tasks (top 5):"
+    high_retry=$(jq -r 'select(.event == "retry_attempts_total" and (.extra.attempts // 0) > 3)
+      | "\(.id)\t attempts=\(.extra.attempts // 0)"' "$LOG_FILE" 2>/dev/null \
+      | sort -t$'\t' -k2 -rn | head -5)
+    if [ -n "$high_retry" ]; then
+      while IFS= read -r line; do
+        echo "      $line"
+      done <<< "$high_retry"
+    else
+      echo "      (없음)"
+    fi
+  else
+    echo "  [3] task-log.ndjson: 파일 없음"
+  fi
+
+  echo "─────────────────────────────────────────────────"
+  exit 0
+fi
 
 REPO_ROOT=$(_repo_root 2>/dev/null || echo "")
 SPEC_FILE="${REPO_ROOT}/SPEC.md"

--- a/scripts/task/task-start.sh
+++ b/scripts/task/task-start.sh
@@ -497,8 +497,13 @@ if [ -f "$DAEMON_PID_FILE" ] && kill -0 "$(cat "$DAEMON_PID_FILE")" 2>/dev/null;
 fi
 
 if [ "$DAEMON_RUNNING" = false ] && [ -f "$REPO_ROOT/scripts/task/task-daemon.sh" ]; then
-  bash "$REPO_ROOT/scripts/task/task-daemon.sh" --bg 2>/dev/null
-  DAEMON_STATUS="✅ daemon 시작 (PID $(cat "$DAEMON_PID_FILE" 2>/dev/null))"
+  # (b) crash loop guard 확인 — lib.sh daemon_restart_guard 재사용
+  if daemon_restart_guard 2>/dev/null; then
+    bash "$REPO_ROOT/scripts/task/task-daemon.sh" --bg 2>/dev/null
+    DAEMON_STATUS="✅ daemon 시작 (PID $(cat "$DAEMON_PID_FILE" 2>/dev/null))"
+  else
+    DAEMON_STATUS="⚠️  daemon crash loop 감지 — 자동 재기동 건너뜀 (수동 확인 필요)"
+  fi
 else
   DAEMON_STATUS="✅ daemon 실행 중 (PID $(cat "$DAEMON_PID_FILE" 2>/dev/null))"
 fi

--- a/scripts/task/test-daemon-crash-loop-cap.sh
+++ b/scripts/task/test-daemon-crash-loop-cap.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# scripts/task/test-daemon-crash-loop-cap.sh — C88 (a)(b)(c)(d) / FX-REQ-625
+#
+# task-daemon crash loop 방어 단위 테스트.
+#
+#   Scenario A: 정상 시작 (counter 빈 상태) → exit 0
+#   Scenario B: 1h 윈도우 내 2회 재시작 → exit 0 (cap 미만)
+#   Scenario C: 1h 윈도우 내 3회 초과(4회) → exit 1 + stderr에 "수동 intervention"
+#   Scenario D: heartbeat 60초 전 + 시작 시도 → stderr에 WARN
+#   Scenario E: phase_recover에서 attempts=5 task → ndjson에 retry_attempts_total emit + 진입 차단
+#
+# Red Phase: lib.sh daemon_restart_guard() 미구현 + phase_recover pre-check 미구현 → 전부 FAIL.
+# Green Phase: 5 scenarios 전부 PASS.
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DAEMON="$SCRIPT_DIR/task-daemon.sh"
+LIB="$SCRIPT_DIR/lib.sh"
+[ -x "$DAEMON" ] || chmod +x "$DAEMON" 2>/dev/null || true
+
+TMP=$(mktemp -d)
+PROJECT="Foundry-X-clcap-$$"
+export FX_HOME="$TMP/fx-home"
+mkdir -p "$FX_HOME" /tmp/task-retry /tmp/task-signals
+
+COUNTER_FILE="$FX_HOME/daemon-restart-counter"
+HEARTBEAT_FILE="$FX_HOME/daemon-heartbeat"
+WARN_LOG="$FX_HOME/daemon-warn.log"
+EVENT_LOG="$FX_HOME/task-log.ndjson"
+CACHE="$FX_HOME/tasks-cache.json"
+DAEMON_LOG="/tmp/task-signals/daemon-${PROJECT}.log"
+
+cleanup() {
+  rm -rf "$TMP"
+  rm -f "$DAEMON_LOG"
+  rm -f "/tmp/task-retry/${PROJECT}-"*.json 2>/dev/null || true
+  rm -f "/tmp/task-signals/${PROJECT}-"*.signal 2>/dev/null || true
+}
+trap cleanup EXIT
+
+REPO="$TMP/$PROJECT"
+mkdir -p "$REPO"
+cd "$REPO"
+git init -q -b master
+git config user.email "test@foundry-x.local"
+git config user.name  "fx-test"
+echo "init" > README.md
+git add README.md
+git commit -qm "init"
+
+pass() { echo "  ✅ $*"; }
+fail() { echo "  ❌ $*" >&2; exit 1; }
+
+echo "🧪 test-daemon-crash-loop-cap.sh"
+
+# ─── Scenario A: 정상 시작 (counter 빈 상태) → exit 0 ───────────────────────
+echo ""
+echo "── Scenario A: 정상 시작 (빈 counter) ──"
+
+rm -f "$COUNTER_FILE"
+
+# daemon_restart_guard() 는 lib.sh에서 sourced 후 직접 호출
+# __debug-restart-guard entry point로 테스트
+guard_exit=0
+bash "$DAEMON" __debug-restart-guard 2>/dev/null || guard_exit=$?
+
+[ "$guard_exit" -eq 0 ] || fail "A: 빈 counter여야 exit 0, 실제=${guard_exit}"
+[ -f "$COUNTER_FILE" ] || fail "A: counter 파일이 생성되어야 함"
+count_a=$(jq 'length' "$COUNTER_FILE" 2>/dev/null || echo 0)
+[ "$count_a" -ge 1 ] || fail "A: counter 파일에 epoch 1개 이상 기록되어야 함"
+pass "Scenario A PASS (exit 0, counter=${count_a})"
+
+# ─── Scenario B: 1h 윈도우 내 2회 재시작 → exit 0 ──────────────────────────
+echo ""
+echo "── Scenario B: 1h 윈도우 내 2회 기존 → exit 0 ──"
+
+now=$(date +%s)
+# 1h 내 2개 기존 epoch 주입
+jq -n --argjson t1 $((now - 1800)) --argjson t2 $((now - 900)) '[$t1, $t2]' > "$COUNTER_FILE"
+
+guard_exit=0
+bash "$DAEMON" __debug-restart-guard 2>/dev/null || guard_exit=$?
+
+[ "$guard_exit" -eq 0 ] || fail "B: 2회(+1=3)여야 exit 0, 실제=${guard_exit}"
+count_b=$(jq 'length' "$COUNTER_FILE" 2>/dev/null || echo 0)
+[ "$count_b" -eq 3 ] || fail "B: counter는 3이어야 함(기존2+신규1), 실제=${count_b}"
+pass "Scenario B PASS (exit 0, counter=${count_b})"
+
+# ─── Scenario C: 1h 윈도우 내 3회 초과(4회) → exit 1 ───────────────────────
+echo ""
+echo "── Scenario C: 1h 윈도우 내 4회 → exit 1 + warn ──"
+
+now=$(date +%s)
+# 1h 내 4개 기존 epoch (이미 cap 초과)
+jq -n \
+  --argjson t1 $((now - 3000)) \
+  --argjson t2 $((now - 2000)) \
+  --argjson t3 $((now - 1000)) \
+  --argjson t4 $((now - 500)) \
+  '[$t1, $t2, $t3, $t4]' > "$COUNTER_FILE"
+
+guard_exit=0
+stderr_c=$(bash "$DAEMON" __debug-restart-guard 2>&1 1>/dev/null) || guard_exit=$?
+
+[ "$guard_exit" -ne 0 ] || fail "C: 4회 재시작이면 exit 1 이어야 함"
+echo "$stderr_c" | grep -qi "수동\|intervention\|crash" || \
+  fail "C: stderr에 수동 intervention 안내 없음 (got: ${stderr_c})"
+pass "Scenario C PASS (exit 1, warn 출력)"
+
+# ─── Scenario D: heartbeat 60초 전 + 시작 → WARN on stderr ─────────────────
+echo ""
+echo "── Scenario D: heartbeat 60초 전 → WARN 출력 ──"
+
+rm -f "$COUNTER_FILE"
+
+# heartbeat 파일을 60초 전 mtime으로 생성
+hb_ts=$(date -d "60 seconds ago" -Iseconds 2>/dev/null || date -v -60S -Iseconds 2>/dev/null || date -Iseconds)
+echo "$hb_ts" > "$HEARTBEAT_FILE"
+touch -d "60 seconds ago" "$HEARTBEAT_FILE" 2>/dev/null || true
+
+# __debug-heartbeat-stale 로 heartbeat stale 경고만 테스트
+stderr_d=$(bash "$DAEMON" __debug-heartbeat-stale 2>&1) || true
+
+echo "$stderr_d" | grep -qiE "crash|stale|WARN|warn|경고" || \
+  fail "D: stderr에 heartbeat stale 경고 없음 (got: ${stderr_d:-<empty>})"
+pass "Scenario D PASS (WARN 포함 출력)"
+
+# ─── Scenario E: phase_recover + attempts=5 → ndjson emit + block ───────────
+echo ""
+echo "── Scenario E: phase_recover attempts=5 → retry_attempts_total + block ──"
+
+rm -f "$EVENT_LOG"
+: > "$EVENT_LOG"
+
+# tasks-cache.json 에 task C99 in_progress 상태로 등록
+echo '{"version":1,"tasks":{"C99":{"status":"in_progress","pane":"%99","branch":"task/C99-test","wt":"'"$TMP"'/wt99"}}}' > "$CACHE"
+
+# retry 파일에 attempts=5 기록 (TASK_MAX_RETRY=5 도달)
+mkdir -p /tmp/task-retry
+retry_file="/tmp/task-retry/${PROJECT}-C99.json"
+jq -n \
+  --arg id "C99" --argjson at 5 \
+  --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  '{task_id:$id, attempts:$at, timestamp:$ts, last_error:"worker_inactive_empty_diff"}' \
+  > "$retry_file"
+
+# worktree 없으므로 __debug-recover 는 WT 없음으로 실패할 수 있음 — ndjson emit만 확인
+wt_e="$TMP/wt99"
+mkdir -p "$wt_e"
+# wt에 작업 흔적 0 (빈 worktree) — phase_recover가 enqueue_retry로 향해야 함
+# 단, attempts pre-check가 먼저 진입 차단해야 함
+(cd "$wt_e" && git init -q -b master && git config user.email "t@t" && git config user.name t && git commit -q --allow-empty -m "task context init")
+
+TASK_MAX_RETRY=5 bash "$DAEMON" __debug-recover C99 "$wt_e" 2>/dev/null || true
+
+# ndjson에 retry_attempts_total 이벤트 기록 확인
+event_found=0
+if grep -q '"retry_attempts_total"' "$EVENT_LOG" 2>/dev/null; then
+  event_found=1
+fi
+[ "$event_found" -eq 1 ] || fail "E: task-log.ndjson에 retry_attempts_total 이벤트 없음"
+
+# 진입 차단 확인 — DAEMON_LOG에 "복구:" (work_commits 분석) 없어야 함
+if grep -q "^.*복구:.*work_commits" "$DAEMON_LOG" 2>/dev/null; then
+  fail "E: phase_recover가 work_commits 분석까지 진입함 (pre-check 차단 실패)"
+fi
+pass "Scenario E PASS (retry_attempts_total emit + 진입 차단)"
+
+# ─── cleanup retry file ───────────────────────────────────────────────────────
+rm -f "$retry_file" 2>/dev/null || true
+
+echo ""
+echo "✅ All scenarios PASS"


### PR DESCRIPTION
## Summary

C88 잔여 (a)(b)(c)(d) 4개 하드닝 항목 통합 구현. C88 (e) Terminal state guard (PR #655) 후속.

- **(a) attempts cap 선제 체크**: `phase_recover` 진입 전 retry file 기존 attempts ≥ `TASK_MAX_RETRY`이면 조기 차단 + `retry_attempts_total` ndjson emit
- **(b) DAEMON_RESTART_COUNTER 1h 윈도우 추적**: `~/.foundry-x/daemon-restart-counter` JSON array, 3회 초과 시 재기동 거부 + STDERR 안내
- **(c) heartbeat stale 경고**: daemon 시작 시 heartbeat < 120초이면 crash loop 의심 WARN 출력 (lib.sh `daemon_restart_guard()` 공유 함수)
- **(d) task-doctor --crash-loop**: heartbeat age + restart counter 1h 집계 + retry_attempts_total > 3 task top-5 출력

## Test

- `test-daemon-crash-loop-cap.sh` 5 scenarios: **A/B/C/D/E 모두 PASS**
- `test-daemon-terminal-guard.sh` 회귀 4 scenarios: **모두 PASS**
- `bash scripts/task/task-doctor.sh --crash-loop`: exit 0 + 진단 출력 정상

## Files

- `scripts/task/lib.sh` — `daemon_restart_guard()` 공유 함수 (b+c)
- `scripts/task/task-daemon.sh` — `phase_recover` pre-check (a), `--bg` guard 호출, debug entry points
- `scripts/task/task-doctor.sh` — `--crash-loop` 독립 실행 경로 (d)
- `scripts/task/task-start.sh` — daemon 재기동 전 guard 체크 (b)
- `scripts/task/test-daemon-crash-loop-cap.sh` — TDD Red/Green

🤖 Generated with [Claude Code](https://claude.com/claude-code)