### PR TITLE
fix(deploy): F562 test job — shared-contracts 선행 빌드 (Sprint 314 hotfix)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,6 +66,8 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - name: Build shared-contracts (dependency of shared)
+        run: pnpm --filter @foundry-x/shared-contracts build
       - run: pnpm turbo typecheck lint test
 
   # Production deploy — API (코드 변경 시에만)


### PR DESCRIPTION
## Summary
- PR #657 (F562 hotfix)의 커버리지 누락 해소: deploy.yml **test job**에 `shared-contracts` 선행 빌드 스텝 추가
- 증상: F563 merge 후 deploy run #24728582298 `test` job에서 `@foundry-x/web#typecheck` 가 `@foundry-x/shared-contracts` 모듈을 못 찾아 exit 2 → deploy 5 jobs skip → prod 미배포
- 수정: `pnpm install` 후 `pnpm turbo typecheck lint test` 앞에 `pnpm --filter @foundry-x/shared-contracts build` 1 스텝 추가 (PR #657 패턴 재사용)

## Test plan
- [ ] PR CI 녹색 (test job PASS)
- [ ] master merge 후 deploy run success
- [ ] prod smoke-test 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)