### PR TITLE
chore(content-sync): Sprint 313 → 314 + Phase 45 (S308)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Foundry-X가 이를 읽고 분석하고 동기화를 강제해요.
 <!-- README_SYNC_START: daily-check가 SPEC.md 실측값 기준으로 자동 동기화 -->
 | 항목 | 수치 |
 |------|------|
-| Phase | 45 (Sprint 313) |
-| Sprints | 313 완료 |
+| Phase | 45 (Sprint 314) |
+| Sprints | 314 완료 |
 | API Routes | ~11 |
 | API Services | ~31 |
 | API Schemas | ~14 |

--- a/packages/web/content/landing/hero.md
+++ b/packages/web/content/landing/hero.md
@@ -12,7 +12,7 @@ stats:
     label: "AI 에이전트"
   - value: "63"
     label: "자동화 스킬"
-  - value: "313"
+  - value: "314"
     label: "Sprints"
 ---
 

--- a/packages/web/src/components/landing/footer.tsx
+++ b/packages/web/src/components/landing/footer.tsx
@@ -69,7 +69,7 @@ export function Footer() {
             &copy; {new Date().getFullYear()} KTDS AX BD. All rights reserved.
           </p>
           <p className="font-mono text-xs text-muted-foreground/60">
-            Sprint 313 &middot; Phase 45
+            Sprint 314 &middot; Phase 45
           </p>
         </div>
       </div>

--- a/packages/web/src/routes/landing.tsx
+++ b/packages/web/src/routes/landing.tsx
@@ -69,7 +69,7 @@ function getSectionOrder(section: string): number {
    ═══════════════════════════════════════════════ */
 
 const SITE_META_FALLBACK = {
-  sprint: "Sprint 313",
+  sprint: "Sprint 314",
   phase: "Phase 45",
   phaseTitle: "MSA 3rd Separation",
   tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼",
@@ -79,7 +79,7 @@ const STATS_FALLBACK = [
   { value: "2", label: "BD 파이프라인" },
   { value: "10+", label: "AI 에이전트" },
   { value: "63", label: "자동화 스킬" },
-  { value: "313", label: "Sprints" },
+  { value: "314", label: "Sprints" },
 ];
 
 // Build-time content from TinaCMS-managed Markdown


### PR DESCRIPTION
## Summary
S308 session-end에서 `content-sync-check.sh` (C89 fix 이후 첫 dogfood) **drift 5건 정확 감지 → 수동 보정**.

- Phase 0c-3: 9건 false positive (이전) → **5건 실드리프트 정확 감지** (C89 `✅` row 필터 덕분)
- Sprint 313 → 314, Phase 45 값 일관성 회복
- 4 파일: README.md + hero.md + landing.tsx(2곳) + footer.tsx

## Test plan
- [x] 로컬 `bash scripts/content-sync-check.sh` → `content sync: OK (Sprint 314, Phase 45)`
- [ ] PR CI 녹색
- [ ] prod /fx.minu.best landing 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)