### PR TITLE
fix(ci): C94 — pnpm filter '...' 로 harness-kit 선행 빌드 (msa-lint 8회 fail 근본 fix)

### DIFF
--- a/.github/workflows/deploy-gate-x.yml
+++ b/.github/workflows/deploy-gate-x.yml
@@ -21,6 +21,7 @@ jobs:
           node-version: '20'
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter '@foundry-x/gate-x...' build
       - run: pnpm --filter @foundry-x/gate-x typecheck
       - run: pnpm --filter @foundry-x/gate-x test
 

--- a/.github/workflows/msa-lint.yml
+++ b/.github/workflows/msa-lint.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Build shared (dependency of api)
         run: pnpm --filter @foundry-x/shared build
 
-      - name: Build ESLint rules plugin
-        run: pnpm --filter @foundry-x/api build
+      - name: Build ESLint rules plugin (+ workspace deps — harness-kit)
+        run: pnpm --filter '@foundry-x/api...' build
 
       - name: MSA lint — 신규/수정 파일만
         run: bash scripts/lint-new-files.sh origin/master


### PR DESCRIPTION
## Summary

- **msa-lint 8회 연속 fail 근본 원인** (4/16~4/21): \`pnpm --filter @foundry-x/api build\` 호출 시 api가 의존하는 \`@foundry-x/harness-kit\` dist 미생성 → tsc TS2307 → Step 9 MSA lint skip → PR blocking
- **해결**: \`pnpm --filter '@foundry-x/api...' build\` — \`...\` 가 workspace dep 전체(harness-kit, shared, shared-contracts) 자동 선행 빌드
- **범위**: msa-lint.yml + deploy-gate-x.yml (gate-x도 harness-kit 직접 import)

## Root Cause 확증

\`\`\`
# 로컬 재현
$ rm -rf packages/harness-kit/dist
$ pnpm --filter @foundry-x/api build
src/routes/proxy.ts(7,43): error TS2307: Cannot find module '@foundry-x/harness-kit'
src/routes/proxy.ts(8,37): error TS2307: Cannot find module '@foundry-x/harness-kit'

# CI 증거: gh run view 24728578200 jobs JSON
Step 6 Build shared-contracts: success
Step 7 Build shared: success  
Step 8 Build ESLint rules plugin (= api build): failure
Step 9 MSA lint: skipped
\`\`\`

## Why `turbo.json dependsOn: ["^build"]` 안 막아줬나

\`turbo.json\`에 \`typecheck.dependsOn: ["^build"]\` 이미 있으나 workflow가 \`pnpm --filter\` 직접 호출 → **turbo 우회**. \`turbo run build\` 경유만 \`^build\` 자동 해소.

## 해결 방식 선택

| 옵션 | 평가 |
|------|------|
| **A. pnpm \`...\` (채택)** | 1줄 변경, workspace dep 자동 포함, 앞으로 dep 추가 시 자동 대응 |
| B. 명시적 harness-kit build 스텝 | F562 hotfix PR #657 패턴과 동일, 가독성 높지만 dep 추가마다 스텝 추가 필요 |
| C. turbo 경유 전환 | 근본 해결이나 turbo cache scope·다른 workflow 리팩터링 동반 — scope 초과 |

## Local 검증

\`\`\`
$ rm -rf packages/harness-kit/dist
$ pnpm --filter '@foundry-x/api...' build
Scope: 4 of 15 workspace projects
packages/shared-contracts build: Done
packages/harness-kit build: Done
packages/shared build: Done
packages/api build: Done
\`\`\`

## Test plan

- [ ] PR CI: MSA Lint (PR only) job PASS (Step 8 api build success + Step 9 MSA lint 실행)
- [ ] 병합 후 후속 PR(master 베이스)에서 msa-lint 재검증
- [ ] deploy-gate-x.yml은 paths 조건 매칭 시(gate-x/harness-kit 변경) 자동 트리거 — 본 PR paths 미매칭이라 해당 workflow는 이 PR에서 실행 안 됨. 후속 PR에서 실증 확보

## 관련

- SPEC §5 C94 (FX-REQ-631, P1, S309)
- MEMORY feedback: \`feedback_pnpm_filter_workspace_dep.md\` — S307 shared-contracts 선행 빌드 gap과 동일 구조 패턴
- Out-of-scope: deploy-gate-x 5회 fail(4/7~)의 dormant 해소(별건), F569 harness-kit 표준화, turbo 경유 전환