### PR TITLE
feat: Sprint 315 — F564(Strangler 완결 MVP M3) + F569(harness-kit 표준화)

### DIFF
--- a/docs/01-plan/features/sprint-315.plan.md
+++ b/docs/01-plan/features/sprint-315.plan.md
@@ -1,0 +1,91 @@
+---
+id: FX-PLAN-315
+sprint: 315
+f_items: [F564, F569]
+status: active
+created: 2026-04-22
+---
+
+# Sprint 315 Plan — F564 + F569 (Phase 45 Batch 1)
+
+## 1. 목표
+
+| F-item | 제목 | Milestone |
+|--------|------|-----------|
+| F564 | CLI VITE_API_URL 전환 + Strangler 완결 | Phase 45 MVP M3 |
+| F569 | harness-kit 표준화 (Workers scaffold) | Phase 45 P2 |
+
+**Phase 45 MVP M3 달성 기준**: CLI/Web 모두 fx-gateway 단일 진입점 + foundry-x-api 직결 코드 0건
+
+## 2. 범위
+
+### F564 — Strangler 완결 (FX-REQ-607, P1)
+
+| 항목 | 내용 |
+|------|------|
+| (a) | `packages/shared/src/types.ts`: `FoundryXConfig`에 `apiUrl` 필드 추가 (default: `https://fx-gateway.ktds-axbd.workers.dev`) |
+| (a') | `packages/cli/src/services/config-manager.ts`: `init()` 시 `apiUrl` 저장 |
+| (b) | `packages/web/public/_redirects`: `/api/*` → fx-gateway URL 전환 (foundry-x-api 직결 제거) |
+| (b') | grep 0건 확증: `packages/` 내 foundry-x-api 직결 URL 없음 (wrangler.toml name, eslint plugin 이름, HTTP-Referer 헤더는 제외) |
+| (c) | `packages/web/e2e/`: SSO Hub Token 경로 호환성 E2E 테스트 추가 |
+| (d) | `docs/`: ENV 마이그레이션 가이드 문서 생성 |
+
+### F569 — harness-kit 표준화 (FX-REQ-612, P2)
+
+| 항목 | 내용 |
+|------|------|
+| (a) | harness-kit scaffold 완성 확인 (EventBus, middleware, scaffold templates 존재 검증) |
+| (b-1) | `packages/fx-discovery/src/middleware/auth.ts` → harness-kit `createAuthMiddleware` 적용 |
+| (b-2) | `packages/fx-shaping/src/middleware/auth.ts` → harness-kit `createAuthMiddleware` 적용 |
+| (b-3) | `packages/fx-offering/src/middleware/auth.ts` → harness-kit `createAuthMiddleware` 적용 |
+| (b-4) | `packages/fx-gateway/src/app.ts` → harness-kit `createCorsMiddleware` 적용 (선택적) |
+| (c) | 버전관리: `workspace:*` internal 전략 공식 확정 (package.json 주석 + 문서) |
+| (d) | `scripts/new-worker.sh` scaffold 생성 스크립트 |
+
+### Out-of-scope (Sprint 315)
+
+- F569 (e) CI workflow turbo 경유 전환 — C94 PR #670 후 2주 관찰 후 결정 (Sprint 317 예정)
+- F569 (f) Remote cache 도입 결정 — turbo 전환 확정 후 선택
+- F569 (g) workflow workspace dep 자동 해소 — (e) 완료 후 자동 달성
+- fx-gateway tenant middleware 추가 — scope out (각 도메인 고유 로직 유지)
+- Offering 이관 (F570) — Sprint 316 예정
+
+## 3. 영향 파일 예측
+
+### F564
+- `packages/shared/src/types.ts` — FoundryXConfig.apiUrl 추가
+- `packages/cli/src/services/config-manager.ts` — init()에 apiUrl 포함
+- `packages/cli/src/services/config-manager.test.ts` — apiUrl 테스트
+- `packages/web/public/_redirects` — foundry-x-api → fx-gateway
+- `packages/web/e2e/strangler-gateway.spec.ts` — 신규 E2E
+- `docs/guides/api-url-migration.md` — 신규 문서
+
+### F569
+- `packages/fx-discovery/src/middleware/auth.ts` — createAuthMiddleware 적용
+- `packages/fx-shaping/src/middleware/auth.ts` — createAuthMiddleware 적용
+- `packages/fx-offering/src/middleware/auth.ts` — createAuthMiddleware 적용
+- `packages/fx-discovery/package.json` — @foundry-x/harness-kit dep 추가
+- `packages/fx-shaping/package.json` — @foundry-x/harness-kit dep 추가
+- `packages/fx-offering/package.json` — @foundry-x/harness-kit dep 추가
+- `scripts/new-worker.sh` — 신규 scaffold 스크립트
+
+## 4. 리스크
+
+| 리스크 | 대응 |
+|--------|------|
+| `_redirects` 변경 시 prod 경로 단절 | fx-gateway가 이미 모든 /api/* 처리 중임을 사전 확인 |
+| harness-kit PublicPaths 불일치 | 각 도메인 PUBLIC_PATHS를 HarnessConfig.publicPaths로 정확히 전달 |
+| fx-shaping harness-kit dep 미등록 | pnpm install + typecheck 로 확인 |
+
+## 5. 테스트 계획
+
+### F564 TDD
+- Red: `config-manager.test.ts`에 `apiUrl` 기본값 테스트 (FAIL 확인)
+- Green: 타입 + init() 구현
+
+### F569 TDD
+- Red: `packages/harness-kit/__tests__/middleware.test.ts` 신규 케이스 (createAuthMiddleware 적용 Worker 테스트)
+- Green: 각 Worker middleware 교체
+
+### E2E
+- `strangler-gateway.spec.ts`: health endpoint 200 응답 via fx-gateway 검증

--- a/docs/02-design/features/sprint-315.design.md
+++ b/docs/02-design/features/sprint-315.design.md
@@ -1,0 +1,270 @@
+---
+id: FX-DESIGN-315
+sprint: 315
+f_items: [F564, F569]
+status: active
+created: 2026-04-22
+---
+
+# Sprint 315 Design — F564 + F569
+
+## 1. 개요
+
+Phase 45 Batch 1: Strangler 완결(MVP M3) + harness-kit 표준화
+
+## 2. F564 — Strangler 완결 설계
+
+### 2.1 FoundryXConfig.apiUrl 추가 (a)
+
+**파일**: `packages/shared/src/types.ts`
+
+```typescript
+// 변경 전
+export interface FoundryXConfig {
+  version: string;
+  // ...
+  git: { provider: 'github' | 'gitlab'; remote?: string };
+}
+
+// 변경 후
+export interface FoundryXConfig {
+  version: string;
+  // ...
+  apiUrl: string;  // 신규: fx-gateway 단일 진입점 URL (default: https://fx-gateway.ktds-axbd.workers.dev)
+  git: { provider: 'github' | 'gitlab'; remote?: string };
+}
+```
+
+**파일**: `packages/cli/src/services/config-manager.ts`
+
+```typescript
+// init() 내 config 객체에 apiUrl 추가
+const config: FoundryXConfig = {
+  version: '0.1.0',
+  initialized: new Date().toISOString(),
+  template,
+  mode,
+  repoProfile,
+  apiUrl: 'https://fx-gateway.ktds-axbd.workers.dev',  // 신규
+  plumb: { ... },
+  git: { ... },
+};
+```
+
+### 2.2 _redirects 수정 (b)
+
+**파일**: `packages/web/public/_redirects`
+
+```
+# 변경 전
+/api/*  https://foundry-x-api.ktds-axbd.workers.dev/api/:splat  200
+
+# 변경 후
+/api/*  https://fx-gateway.ktds-axbd.workers.dev/api/:splat  200
+```
+
+**근거**: VITE_API_URL=fx-gateway가 production env에서 설정되더라도, _redirects는 CDN 레벨 폴백 경로로 작동함. foundry-x-api 직결을 완전히 제거하여 Strangler 완결.
+
+**grep 0건 확증 대상** (변경 후):
+- `packages/web/public/_redirects` → fx-gateway로 변경됨
+- `packages/web/.env.production` → 주석(rollback comment)만 남음 (코드 아님)
+- `packages/api/wrangler.toml` → 서비스 이름 정의 (직결 URL 아님, 제외)
+- `packages/api/eslint.config.js` → ESLint plugin 이름 (제외)
+- `packages/fx-gateway/wrangler.toml` → service binding 이름 (제외)
+- `packages/fx-shaping/src/agent/services/openrouter-runner.ts:52` → HTTP-Referer 헤더 (도메인 이름일 뿐, API 직결 아님, 제외)
+- `packages/api/src/core/agent/services/openrouter-runner.ts:51` → 동일 이유 제외
+- `packages/api/src/app.ts:107` → 서비스 이름 리터럴 (제외)
+
+**확증 명령**:
+```bash
+grep -rn "foundry-x-api.ktds-axbd.workers.dev" packages/ \
+  --include="*.ts" --include="*.tsx" \
+  | grep -v "node_modules\|dist/" \
+  | grep -v "HTTP-Referer\|service.*=.*\"foundry-x-api\"" \
+  | grep -v "eslint\|wrangler.toml\|\.env"
+# → 0건 기대
+```
+
+### 2.3 SSO Hub Token E2E (c)
+
+**파일**: `packages/web/e2e/strangler-gateway.spec.ts` (신규)
+
+시나리오:
+1. `GET /api/discovery/health` via fx-gateway → 200 OK
+2. `GET /api/shaping/health` via fx-gateway → 200 OK
+3. `GET /api/offering/health` via fx-gateway → 200 OK
+
+E2E 환경: `page.route()` mock으로 gateway response 검증
+
+### 2.4 ENV 마이그레이션 문서 (d)
+
+**파일**: `docs/guides/api-url-migration.md` (신규)
+
+## 3. F569 — harness-kit 표준화 설계
+
+### 3.1 Worker 미들웨어 적용 계획 (b)
+
+3개 Worker에서 동일하게 중복된 `middleware/auth.ts` → harness-kit `createAuthMiddleware`로 교체
+
+#### fx-discovery 변경
+
+**파일**: `packages/fx-discovery/src/middleware/auth.ts`
+
+```typescript
+// 변경 전: 자체 구현
+import { jwt } from "hono/jwt";
+
+// 변경 후: harness-kit 위임
+import { createAuthMiddleware } from "@foundry-x/harness-kit";
+
+export const authMiddleware = createAuthMiddleware({
+  serviceName: "fx-discovery",
+  serviceId: "discovery-x",
+  corsOrigins: [],
+  publicPaths: ["/api/discovery/health"],
+});
+```
+
+**파일**: `packages/fx-discovery/package.json`
+- `@foundry-x/harness-kit: "workspace:*"` 추가
+
+#### fx-shaping 변경
+
+**파일**: `packages/fx-shaping/src/middleware/auth.ts`
+
+```typescript
+import { createAuthMiddleware } from "@foundry-x/harness-kit";
+
+export const authMiddleware = createAuthMiddleware({
+  serviceName: "fx-shaping",
+  serviceId: "foundry-x",
+  corsOrigins: [],
+  publicPaths: ["/api/shaping/health", "/api/ax-bd/health"],
+});
+```
+
+**파일**: `packages/fx-shaping/package.json` — harness-kit dep 추가
+
+#### fx-offering 변경
+
+**파일**: `packages/fx-offering/src/middleware/auth.ts`
+
+```typescript
+import { createAuthMiddleware } from "@foundry-x/harness-kit";
+
+export const authMiddleware = createAuthMiddleware({
+  serviceName: "fx-offering",
+  serviceId: "foundry-x",
+  corsOrigins: [],
+  publicPaths: ["/api/offering/health"],
+});
+```
+
+**파일**: `packages/fx-offering/package.json` — harness-kit dep 추가
+
+### 3.2 버전관리 전략 (c)
+
+`workspace:*` internal 전략 확정:
+- 이유: Workers간 동일 monorepo → npm publish 불필요, Cloudflare Workers Service Binding으로 배포
+- harness-kit README에 "internal only, not published to npm" 명시
+- `packages/harness-kit/package.json` `private: true` 확인 또는 추가
+
+### 3.3 new-worker.sh (d)
+
+**파일**: `scripts/new-worker.sh` (신규)
+
+```bash
+#!/usr/bin/env bash
+# Usage: bash scripts/new-worker.sh <name> <service-id>
+# Example: bash scripts/new-worker.sh fx-agent foundry-x
+```
+
+기능:
+1. `packages/harness-kit/src/scaffold/generator.ts`의 `generateScaffold()` 호출
+2. `packages/` 하위에 Worker 디렉토리 생성
+3. pnpm-workspace.yaml에 패키지 추가 안내 출력
+
+## 4. TDD 계약 (Red 타겟)
+
+### F564 Red Tests
+
+**파일**: `packages/cli/src/services/config-manager.test.ts` (기존 파일에 추가)
+
+```typescript
+describe('ConfigManager.init — F564', () => {
+  it('should include apiUrl defaulting to fx-gateway', async () => {
+    const mgr = new ConfigManager(tmpDir);
+    const config = await mgr.init('monorepo', 'web-only', 'default');
+    expect(config.apiUrl).toBe('https://fx-gateway.ktds-axbd.workers.dev');
+  });
+
+  it('should persist apiUrl on write/read roundtrip', async () => {
+    const mgr = new ConfigManager(tmpDir);
+    await mgr.init('monorepo', 'web-only', 'default');
+    const read = await mgr.read();
+    expect(read?.apiUrl).toBe('https://fx-gateway.ktds-axbd.workers.dev');
+  });
+});
+```
+
+### F569 Red Tests
+
+**파일**: `packages/harness-kit/__tests__/middleware/jwt.test.ts` (기존에 Worker 적용 케이스 추가)
+
+```typescript
+describe('createAuthMiddleware — worker public path config', () => {
+  it('discovery health is public', async () => {
+    const app = createApp({ publicPaths: ['/api/discovery/health'] });
+    const res = await app.request('/api/discovery/health', undefined, { JWT_SECRET: SECRET });
+    expect(res.status).toBe(200);
+  });
+});
+```
+
+## 5. 파일 매핑 (D1 체크리스트)
+
+| 파일 | 변경 | F-item |
+|------|------|--------|
+| `packages/shared/src/types.ts` | `apiUrl` 필드 추가 | F564(a) |
+| `packages/cli/src/services/config-manager.ts` | `init()`에 `apiUrl` 포함 | F564(a) |
+| `packages/cli/src/services/config-manager.test.ts` | apiUrl TDD Red 테스트 | F564(a) |
+| `packages/web/public/_redirects` | foundry-x-api → fx-gateway | F564(b) |
+| `packages/web/e2e/strangler-gateway.spec.ts` | SSO Hub Token E2E | F564(c) |
+| `docs/guides/api-url-migration.md` | 환경변수 마이그레이션 가이드 | F564(d) |
+| `packages/fx-discovery/src/middleware/auth.ts` | harness-kit 적용 | F569(b-1) |
+| `packages/fx-discovery/package.json` | harness-kit dep 추가 | F569(b-1) |
+| `packages/fx-shaping/src/middleware/auth.ts` | harness-kit 적용 | F569(b-2) |
+| `packages/fx-shaping/package.json` | harness-kit dep 추가 | F569(b-2) |
+| `packages/fx-offering/src/middleware/auth.ts` | harness-kit 적용 | F569(b-3) |
+| `packages/fx-offering/package.json` | harness-kit dep 추가 | F569(b-3) |
+| `packages/harness-kit/package.json` | `private: true` 확인/추가 | F569(c) |
+| `scripts/new-worker.sh` | scaffold 생성 스크립트 | F569(d) |
+| `packages/harness-kit/__tests__/middleware/jwt.test.ts` | Worker 적용 TDD Red | F569(b) |
+
+## 6. Breaking Change 영향도 (D3)
+
+### FoundryXConfig.apiUrl 추가
+
+- **생산자**: `config-manager.ts` `init()` — 항상 `https://fx-gateway.ktds-axbd.workers.dev` 기본값
+- **소비자**: 현재 없음 (forward-looking 필드)
+- **타입 소비자**: `packages/cli/src/commands/init.ts`, `packages/cli/src/commands/status.ts` — 읽기만 하므로 영향 없음
+- **마이그레이션**: 기존 `.foundry-x/config.json`에 apiUrl 없으면 런타임에서 `undefined` → read() 시 null-safe하게 처리 필요
+
+### _redirects 변경
+
+- **영향**: Production Pages CDN 폴백 경로 변경
+- **롤백**: git revert 1줄로 즉시 복구 가능
+- **사전 확인**: fx-gateway가 `/api/discovery/*`, `/api/shaping/*`, `/api/offerings/*` 모두 처리 중임을 확인 (기존 F539b, F540, F541에서 완료)
+
+### auth.ts 교체 (3 Worker)
+
+- **생산자**: harness-kit `createAuthMiddleware`
+- **소비자**: 각 Worker의 `app.ts` — `authMiddleware` import 경로는 `./middleware/auth.js`로 동일 (변경 없음)
+- **동작 일치**: harness-kit JWT 미들웨어가 각 Worker의 기존 `jwt(secret)` 패턴과 동일하게 동작
+- **publicPaths 매핑**: 도메인별 `/api/{domain}/health` → HarnessConfig.publicPaths로 명시적 전달
+
+## 7. Out-of-scope (명시)
+
+- F569 (e)(f)(g): CI turbo 경유 전환 + Remote cache — C94 PR #670 2주 관찰 후 Sprint 317
+- fx-gateway CORS → harness-kit 전환 — 기존 inline cors() 코드 정상 동작 중, 별도 scope
+- tenant.ts 교체 — 도메인 고유 로직, scope out

--- a/docs/04-report/sprint-315-report.md
+++ b/docs/04-report/sprint-315-report.md
@@ -1,0 +1,91 @@
+---
+id: FX-RPRT-315
+sprint: 315
+f_items: [F564, F569]
+match_rate: 100
+status: complete
+created: 2026-04-22
+---
+
+# Sprint 315 Report — F564 + F569 (Phase 45 Batch 1)
+
+## 결과 요약
+
+| 항목 | 결과 |
+|------|------|
+| Sprint | 315 |
+| F-items | F564 (MVP M3), F569 (harness-kit) |
+| Match Rate | **100%** (9/9) |
+| Tests | CLI 175/175 PASS + harness-kit 61/61 PASS |
+| Phase 45 Milestone | **MVP M3 달성** |
+
+## F564 — Strangler 완결 (MVP M3) ✅
+
+### 구현 항목
+
+| 항목 | 파일 | 내용 |
+|------|------|------|
+| (a) apiUrl 타입 | `packages/shared/src/types.ts` | `FoundryXConfig.apiUrl?: string` 추가 |
+| (a) apiUrl 기본값 | `packages/cli/src/services/config-manager.ts` | `DEFAULT_API_URL = 'https://fx-gateway.ktds-axbd.workers.dev'` |
+| (b) _redirects 수정 | `packages/web/public/_redirects` | foundry-x-api → fx-gateway 전환 |
+| (b) grep 0건 확증 | 전체 `packages/` | 직결 URL 0건 (HTTP-Referer 헤더·eslint 플러그인 이름 등 제외) |
+| (c) SSO E2E | `packages/web/e2e/strangler-gateway.spec.ts` | discovery/shaping/offering health + no-direct-call 4 테스트 |
+| (d) 마이그레이션 가이드 | `docs/guides/api-url-migration.md` | 프로덕션/개발/CLI 환경별 설정 + FAQ |
+
+### Phase 45 MVP M3 달성 선언
+
+```
+M3 성공 기준: CLI/Web 모두 VITE_API_URL=fx-gateway + foundry-x-api 직결 코드 0건
+→ ✅ PASS
+```
+
+- `packages/web/.env.production`: `VITE_API_URL=https://fx-gateway.ktds-axbd.workers.dev/api` (F539b, Sprint 295)
+- `packages/web/public/_redirects`: `/api/*` → fx-gateway (F564, Sprint 315)
+- CLI `FoundryXConfig.apiUrl`: `https://fx-gateway.ktds-axbd.workers.dev` (F564, Sprint 315)
+
+**Phase 45 "Discovery 완전 분리" M1+M2+M3 모두 달성.**
+
+## F569 — harness-kit 표준화 ✅
+
+### 구현 항목
+
+| 항목 | 파일 | 내용 |
+|------|------|------|
+| (b-1) fx-discovery auth | `packages/fx-discovery/src/middleware/auth.ts` | `createAuthMiddleware` 교체 |
+| (b-2) fx-shaping auth | `packages/fx-shaping/src/middleware/auth.ts` | `createAuthMiddleware` 교체 |
+| (b-3) fx-offering auth | `packages/fx-offering/src/middleware/auth.ts` | `createAuthMiddleware` 교체 |
+| (b) dep 추가 3건 | 3개 package.json | `@foundry-x/harness-kit: workspace:*` |
+| (c) 버전관리 확정 | `packages/harness-kit/package.json` | `private: true` — workspace internal 전략 확정 |
+| (d) new-worker.sh | `scripts/new-worker.sh` | scaffold 생성 스크립트 (tsx/node 이중 fallback) |
+
+### 코드 중복 제거 현황
+
+fx-discovery, fx-shaping, fx-offering 3개 Worker가 각각 독립적으로 구현하던 JWT 미들웨어 (~20줄 × 3 = 60줄)를 harness-kit `createAuthMiddleware` 위임으로 제거. 신규 Worker 생성 시 auth.ts 복붙 패턴 재발 차단.
+
+### 이월 항목 (Out-of-scope)
+
+| 항목 | 사유 | 예정 |
+|------|------|------|
+| F569(e) CI turbo 경유 전환 | C94 PR #670 2주 관찰 후 결정 (2026-05-06 이후) | Sprint 317 |
+| F569(f) Remote cache 결정 | turbo 전환 확정 후 | Sprint 317 |
+| F569(g) workspace dep 자동 해소 | (e) 완료 후 자동 달성 | Sprint 317 |
+
+## TDD 사이클 기록
+
+| Phase | 커밋 | 내용 |
+|-------|------|------|
+| Red | `f814263c` | config-manager 2 FAIL + harness-kit JWT Worker publicPaths |
+| Green | `00a81e35` | F564+F569 전체 구현 (14파일 변경) |
+
+## Gap Analysis
+
+- **Match Rate**: 100% (9/9)
+- **Added (설계 초과)**: DEFAULT_API_URL 상수화, SSO 4번째 테스트(no-direct-call), new-worker.sh dual runtime fallback
+- **Changed**: `apiUrl?: string` (optional) vs Design의 required — §6 Breaking Change 사유로 정당화
+
+## 다음 단계
+
+1. **Sprint 315 PR merge** → `deploy.yml` CI 자동 배포
+2. **Phase 45 MVP M3 달성 확인 dogfood**: Production에서 `/api/discovery/health` 200 응답 실측
+3. **Sprint 316**: F567 Multi-hop latency + F568 EventBus PoC (Batch 2)
+4. **Sprint 317**: F565 SDD-drift-check CI + F569(e)(f)(g) turbo 전환 (2주 관찰 완료 후)

--- a/docs/guides/api-url-migration.md
+++ b/docs/guides/api-url-migration.md
@@ -1,0 +1,77 @@
+---
+id: FX-GUIDE-API-URL-MIGRATION
+created: 2026-04-22
+sprint: 315
+f_item: F564
+---
+
+# API URL 마이그레이션 가이드 — fx-gateway 단일 진입점
+
+## 배경
+
+Phase 45 MVP M3 (F564) 완결로 모든 API 트래픽이 **fx-gateway 단일 진입점**을 통해 라우팅됩니다.
+
+| 구분 | 변경 전 | 변경 후 |
+|------|---------|---------|
+| Web VITE_API_URL | `https://foundry-x-api.ktds-axbd.workers.dev/api` | `https://fx-gateway.ktds-axbd.workers.dev/api` |
+| Pages `_redirects` 폴백 | `foundry-x-api.ktds-axbd.workers.dev` | `fx-gateway.ktds-axbd.workers.dev` |
+| CLI `apiUrl` 기본값 | (없음) | `https://fx-gateway.ktds-axbd.workers.dev` |
+
+## 환경별 설정
+
+### 1. 프로덕션 (Cloudflare Pages + Workers)
+
+**`packages/web/.env.production`** — 이미 적용됨 (F539b, Sprint 295):
+```bash
+VITE_API_URL=https://fx-gateway.ktds-axbd.workers.dev/api
+```
+
+**`packages/web/public/_redirects`** — F564(b)에서 갱신:
+```
+/api/*  https://fx-gateway.ktds-axbd.workers.dev/api/:splat  200
+```
+
+### 2. 개발 환경
+
+**`packages/web/.env.local`** 또는 **`packages/web/.env`** (로컬 개발):
+```bash
+# 로컬 개발: Workers를 로컬에서 실행 시 gateway 포트 사용
+VITE_API_URL=http://localhost:8788/api
+# (fx-gateway 로컬 포트는 wrangler.toml [dev] port 참조)
+```
+
+### 3. CLI (`foundry-x` 도구)
+
+`foundry-x init` 실행 시 `.foundry-x/config.json`에 자동으로 `apiUrl` 저장:
+```json
+{
+  "apiUrl": "https://fx-gateway.ktds-axbd.workers.dev",
+  ...
+}
+```
+
+직접 변경 시:
+```bash
+# .foundry-x/config.json 수동 편집
+{
+  "apiUrl": "https://fx-gateway.ktds-axbd.workers.dev"
+}
+```
+
+## 롤백
+
+fx-gateway 장애 시 `_redirects`에서 1줄만 되돌리면 즉시 복구 가능:
+```
+/api/*  https://foundry-x-api.ktds-axbd.workers.dev/api/:splat  200
+```
+
+## FAQ
+
+**Q: foundry-x-api Worker는 삭제되나요?**  
+A: 아니요. foundry-x-api는 fx-gateway의 서비스 바인딩(catch-all) 대상으로 계속 존재합니다. 클라이언트가 직접 호출하지 않을 뿐이며, 이관되지 않은 도메인의 요청은 여전히 fx-gateway → foundry-x-api로 포워딩됩니다.
+
+**Q: SSO Hub Token 경로는 어떻게 변경되나요?**  
+A: `/api/auth/*` 경로는 fx-gateway catch-all → foundry-x-api로 투명하게 포워딩됩니다. 클라이언트 코드 변경 불필요.
+
+**Q: Phase 45 이후 도메인 이관 계획은?**  
+A: F570(Offering, Sprint 316), F572(modules, Sprint 317), F571(Agent, Sprint 318) 순서로 순차 이관 예정. 각 이관 후에도 `_redirects`는 변경 없음.

--- a/packages/cli/src/services/config-manager.test.ts
+++ b/packages/cli/src/services/config-manager.test.ts
@@ -81,4 +81,22 @@ describe('ConfigManager', () => {
 
     expect(read).toEqual(config);
   });
+
+  // F564 TDD Red — apiUrl 기본값 검증
+  describe('F564: apiUrl (fx-gateway 단일 진입점)', () => {
+    it('init() should include apiUrl defaulting to fx-gateway', async () => {
+      tmpDir = await mkdtemp(join(tmpdir(), 'fx-cfg-'));
+      const mgr = new ConfigManager(tmpDir);
+      const config = await mgr.init('greenfield', MINIMAL_PROFILE, 'standard');
+      expect(config.apiUrl).toBe('https://fx-gateway.ktds-axbd.workers.dev');
+    });
+
+    it('init() apiUrl should persist through write/read roundtrip', async () => {
+      tmpDir = await mkdtemp(join(tmpdir(), 'fx-cfg-'));
+      const mgr = new ConfigManager(tmpDir);
+      await mgr.init('greenfield', MINIMAL_PROFILE, 'standard');
+      const read = await mgr.read();
+      expect(read?.apiUrl).toBe('https://fx-gateway.ktds-axbd.workers.dev');
+    });
+  });
 });

--- a/packages/cli/src/services/config-manager.ts
+++ b/packages/cli/src/services/config-manager.ts
@@ -7,6 +7,7 @@ const CONFIG_FILE = 'config.json';
 
 const DEFAULT_PLUMB_TIMEOUT = 30_000;
 const DEFAULT_PYTHON_PATH = 'python3';
+const DEFAULT_API_URL = 'https://fx-gateway.ktds-axbd.workers.dev';
 
 export class ConfigManager {
   private readonly dirPath: string;
@@ -51,6 +52,7 @@ export class ConfigManager {
       template,
       mode,
       repoProfile,
+      apiUrl: DEFAULT_API_URL,
       plumb: {
         timeout: DEFAULT_PLUMB_TIMEOUT,
         pythonPath: DEFAULT_PYTHON_PATH,

--- a/packages/fx-discovery/package.json
+++ b/packages/fx-discovery/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.36.3",
+    "@foundry-x/harness-kit": "workspace:*",
     "@foundry-x/shared": "workspace:*",
     "hono": "^4.0.0",
     "nanoid": "^5.0.0",

--- a/packages/fx-discovery/src/middleware/auth.ts
+++ b/packages/fx-discovery/src/middleware/auth.ts
@@ -1,20 +1,9 @@
-/**
- * F538: fx-discovery JWT 인증 미들웨어
- * packages/api/src/middleware/auth.ts 기반 — discovery 도메인 전용 적용
- */
-import { jwt } from "hono/jwt";
-import type { MiddlewareHandler } from "hono";
-import type { DiscoveryEnv } from "../env.js";
+// F569: harness-kit createAuthMiddleware 적용 — F538 중복 구현 교체
+import { createAuthMiddleware } from "@foundry-x/harness-kit";
 
-// discovery health endpoint는 인증 불필요
-const PUBLIC_PATHS = ["/api/discovery/health"];
-
-export const authMiddleware: MiddlewareHandler<{ Bindings: DiscoveryEnv }> = async (c, next) => {
-  const path = c.req.path;
-  if (PUBLIC_PATHS.some((p) => path.startsWith(p))) {
-    return next();
-  }
-  const secret = c.env?.JWT_SECRET ?? "dev-secret";
-  const handler = jwt({ secret, alg: "HS256" });
-  return handler(c, next);
-};
+export const authMiddleware = createAuthMiddleware({
+  serviceName: "fx-discovery",
+  serviceId: "discovery-x",
+  corsOrigins: [],
+  publicPaths: ["/api/discovery/health"],
+});

--- a/packages/fx-offering/package.json
+++ b/packages/fx-offering/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.36.3",
+    "@foundry-x/harness-kit": "workspace:*",
     "@foundry-x/shared": "workspace:*",
     "@hono/zod-openapi": "^0.9.0",
     "hono": "^4.0.0",

--- a/packages/fx-offering/src/middleware/auth.ts
+++ b/packages/fx-offering/src/middleware/auth.ts
@@ -1,19 +1,9 @@
-/**
- * F541: fx-offering JWT 인증 미들웨어
- * packages/api/src/middleware/auth.ts 기반 — offering 도메인 전용
- */
-import { jwt } from "hono/jwt";
-import type { MiddlewareHandler } from "hono";
-import type { OfferingEnv } from "../env.js";
+// F569: harness-kit createAuthMiddleware 적용 — F541 중복 구현 교체
+import { createAuthMiddleware } from "@foundry-x/harness-kit";
 
-const PUBLIC_PATHS = ["/api/offering/health"];
-
-export const authMiddleware: MiddlewareHandler<{ Bindings: OfferingEnv }> = async (c, next) => {
-  const path = c.req.path;
-  if (PUBLIC_PATHS.some((p) => path.startsWith(p))) {
-    return next();
-  }
-  const secret = c.env?.JWT_SECRET ?? "dev-secret";
-  const handler = jwt({ secret, alg: "HS256" });
-  return handler(c, next);
-};
+export const authMiddleware = createAuthMiddleware({
+  serviceName: "fx-offering",
+  serviceId: "foundry-x",
+  corsOrigins: [],
+  publicPaths: ["/api/offering/health"],
+});

--- a/packages/fx-shaping/package.json
+++ b/packages/fx-shaping/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.36.3",
+    "@foundry-x/harness-kit": "workspace:*",
     "@foundry-x/shared": "workspace:*",
     "@hono/zod-openapi": "^0.9.0",
     "hono": "^4.0.0",

--- a/packages/fx-shaping/src/middleware/auth.ts
+++ b/packages/fx-shaping/src/middleware/auth.ts
@@ -1,19 +1,9 @@
-/**
- * F540: fx-shaping JWT 인증 미들웨어
- * packages/api/src/middleware/auth.ts 기반 — shaping 도메인 전용
- */
-import { jwt } from "hono/jwt";
-import type { MiddlewareHandler } from "hono";
-import type { ShapingEnv } from "../env.js";
+// F569: harness-kit createAuthMiddleware 적용 — F540 중복 구현 교체
+import { createAuthMiddleware } from "@foundry-x/harness-kit";
 
-const PUBLIC_PATHS = ["/api/shaping/health"];
-
-export const authMiddleware: MiddlewareHandler<{ Bindings: ShapingEnv }> = async (c, next) => {
-  const path = c.req.path;
-  if (PUBLIC_PATHS.some((p) => path.startsWith(p))) {
-    return next();
-  }
-  const secret = c.env?.JWT_SECRET ?? "dev-secret";
-  const handler = jwt({ secret, alg: "HS256" });
-  return handler(c, next);
-};
+export const authMiddleware = createAuthMiddleware({
+  serviceName: "fx-shaping",
+  serviceId: "foundry-x",
+  corsOrigins: [],
+  publicPaths: ["/api/shaping/health", "/api/ax-bd/health"],
+});

--- a/packages/harness-kit/__tests__/middleware/jwt.test.ts
+++ b/packages/harness-kit/__tests__/middleware/jwt.test.ts
@@ -64,4 +64,35 @@ describe("JWT Middleware", () => {
     }, {});
     expect(res.status).toBe(200);
   });
+
+  // F569 TDD Red — Worker별 public path 설정
+  describe("F569: Worker-specific public paths", () => {
+    it("fx-discovery health is public", async () => {
+      const app = createApp({ publicPaths: ["/api/discovery/health"] });
+      app.get("/api/discovery/health", (c) => c.json({ domain: "discovery", status: "ok" }));
+      const res = await app.request("/api/discovery/health", undefined, { JWT_SECRET: SECRET });
+      expect(res.status).toBe(200);
+    });
+
+    it("fx-shaping health is public", async () => {
+      const app = createApp({ publicPaths: ["/api/shaping/health", "/api/ax-bd/health"] });
+      app.get("/api/shaping/health", (c) => c.json({ domain: "shaping", status: "ok" }));
+      const res = await app.request("/api/shaping/health", undefined, { JWT_SECRET: SECRET });
+      expect(res.status).toBe(200);
+    });
+
+    it("fx-offering health is public", async () => {
+      const app = createApp({ publicPaths: ["/api/offering/health"] });
+      app.get("/api/offering/health", (c) => c.json({ domain: "offering", status: "ok" }));
+      const res = await app.request("/api/offering/health", undefined, { JWT_SECRET: SECRET });
+      expect(res.status).toBe(200);
+    });
+
+    it("protected route still requires JWT even with domain-specific public paths", async () => {
+      const app = createApp({ publicPaths: ["/api/discovery/health"] });
+      app.get("/api/discovery/items", (c) => c.json({ items: [] }));
+      const res = await app.request("/api/discovery/items", undefined, { JWT_SECRET: SECRET });
+      expect(res.status).toBe(401);
+    });
+  });
 });

--- a/packages/harness-kit/package.json
+++ b/packages/harness-kit/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@foundry-x/harness-kit",
   "version": "0.1.0",
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -192,6 +192,8 @@ export interface FoundryXConfig {
   template: string;
   mode: RepoMode;
   repoProfile: RepoProfile;
+  /** F564: fx-gateway 단일 진입점 URL. 미설정 시 fx-gateway 기본값 사용 */
+  apiUrl?: string;
   plumb: {
     timeout: number;
     pythonPath: string;

--- a/packages/web/e2e/strangler-gateway.spec.ts
+++ b/packages/web/e2e/strangler-gateway.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from "@playwright/test";
+
+// F564(c): Strangler 완결 + SSO Hub Token 경로 호환성 E2E
+// CLI/Web 모두 fx-gateway 단일 진입점 전환 후 health + SSO 경로 검증
+
+test.describe("F564: Strangler Gateway — fx-gateway 단일 진입점", () => {
+  test("discovery health via fx-gateway route", async ({ page }) => {
+    await page.route("**/api/discovery/health", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ domain: "discovery", status: "ok" }),
+      }),
+    );
+
+    const response = await page.request.get("/api/discovery/health");
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.status).toBe("ok");
+  });
+
+  test("shaping health via fx-gateway route", async ({ page }) => {
+    await page.route("**/api/shaping/health", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ domain: "shaping", status: "ok" }),
+      }),
+    );
+
+    const response = await page.request.get("/api/shaping/health");
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.status).toBe("ok");
+  });
+
+  test("offering health via fx-gateway route", async ({ page }) => {
+    await page.route("**/api/offering/health", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ domain: "offering", status: "ok" }),
+      }),
+    );
+
+    const response = await page.request.get("/api/offering/health");
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.status).toBe("ok");
+  });
+
+  test("SSO Hub Token delivered via gateway (no direct foundry-x-api call)", async ({ page }) => {
+    let gatewayCallMade = false;
+    let directApiCallMade = false;
+
+    // mock gateway auth endpoint
+    await page.route("**/api/auth/**", (route) => {
+      const url = route.request().url();
+      if (url.includes("foundry-x-api.ktds-axbd.workers.dev")) {
+        directApiCallMade = true;
+      }
+      if (url.includes("fx-gateway.ktds-axbd.workers.dev") || url.includes("/api/auth/")) {
+        gatewayCallMade = true;
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ token: "mock-jwt-token", expiresIn: 3600 }),
+      });
+    });
+
+    await page.goto("/");
+    // no direct calls to foundry-x-api
+    expect(directApiCallMade).toBe(false);
+  });
+});

--- a/packages/web/public/_redirects
+++ b/packages/web/public/_redirects
@@ -1,3 +1,3 @@
 /admin    /admin/   301
-/api/*  https://foundry-x-api.ktds-axbd.workers.dev/api/:splat  200
+/api/*  https://fx-gateway.ktds-axbd.workers.dev/api/:splat  200
 /*      /index.html   200

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,9 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.36.3
         version: 0.36.3
+      '@foundry-x/harness-kit':
+        specifier: workspace:*
+        version: link:../harness-kit
       '@foundry-x/shared':
         specifier: workspace:*
         version: link:../shared
@@ -192,6 +195,9 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.36.3
         version: 0.36.3
+      '@foundry-x/harness-kit':
+        specifier: workspace:*
+        version: link:../harness-kit
       '@foundry-x/shared':
         specifier: workspace:*
         version: link:../shared
@@ -229,6 +235,9 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.36.3
         version: 0.36.3
+      '@foundry-x/harness-kit':
+        specifier: workspace:*
+        version: link:../harness-kit
       '@foundry-x/shared':
         specifier: workspace:*
         version: link:../shared

--- a/scripts/new-worker.sh
+++ b/scripts/new-worker.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# F569(d): new-worker.sh — harness-kit scaffold로 새 Worker 생성
+# Usage: bash scripts/new-worker.sh <name> <service-id>
+# Example: bash scripts/new-worker.sh fx-agent foundry-x
+# Available service-ids: foundry-x | discovery-x | ai-foundry | gate-x | launch-x | eval-x
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: bash scripts/new-worker.sh <name> <service-id>"
+  echo "  name       — kebab-case Worker 이름 (예: fx-agent)"
+  echo "  service-id — ServiceId 타입 (예: foundry-x | discovery-x | ai-foundry | gate-x | launch-x | eval-x)"
+  echo ""
+  echo "Example:"
+  echo "  bash scripts/new-worker.sh fx-agent foundry-x"
+  exit 1
+fi
+
+WORKER_NAME="$1"
+SERVICE_ID="$2"
+OUTPUT_DIR="$PROJECT_ROOT/packages/$WORKER_NAME"
+
+if [[ -d "$OUTPUT_DIR" ]]; then
+  echo "❌ Error: $OUTPUT_DIR already exists"
+  exit 1
+fi
+
+echo "🏗️  Creating Worker scaffold: $WORKER_NAME ($SERVICE_ID)"
+echo "   Output: $OUTPUT_DIR"
+echo ""
+
+# harness-kit scaffold CLI 실행
+npx --yes tsx "$PROJECT_ROOT/packages/harness-kit/src/cli/index.ts" scaffold \
+  --name "$WORKER_NAME" \
+  --service-id "$SERVICE_ID" \
+  --output-dir "$OUTPUT_DIR" \
+  2>/dev/null || node "$PROJECT_ROOT/packages/harness-kit/dist/cli/index.js" scaffold \
+  --name "$WORKER_NAME" \
+  --service-id "$SERVICE_ID" \
+  --output-dir "$OUTPUT_DIR"
+
+echo ""
+echo "✅ Scaffold created: $OUTPUT_DIR"
+echo ""
+echo "📋 다음 단계:"
+echo "  1. pnpm-workspace.yaml에 추가:"
+echo "     - 'packages/$WORKER_NAME'"
+echo ""
+echo "  2. pnpm install"
+echo ""
+echo "  3. wrangler.toml에서 Cloudflare account_id와 D1 database_id 설정"
+echo ""
+echo "  4. Secrets 등록:"
+echo "     npx wrangler secret put JWT_SECRET --env production"
+echo ""
+echo "  5. Deploy:"
+echo "     cd packages/$WORKER_NAME && npx wrangler deploy"


### PR DESCRIPTION
## Sprint 315 — F564 + F569 (Phase 45 Batch 1)

### F564: Strangler 완결 — Phase 45 MVP M3 달성

- **shared/types.ts**: `FoundryXConfig.apiUrl?: string` 추가 (fx-gateway 기본값)
- **config-manager.ts**: `init()`에 `DEFAULT_API_URL` 포함
- **web/public/_redirects**: `/api/*` → fx-gateway 전환 (foundry-x-api 직결 0건)
- **web/e2e/strangler-gateway.spec.ts**: SSO Hub Token 경로 호환성 E2E 4 tests
- **docs/guides/api-url-migration.md**: 환경변수 마이그레이션 가이드

**MVP M3 성공 기준**: CLI/Web VITE_API_URL=fx-gateway + foundry-x-api 직결 코드 0건 ✅

### F569: harness-kit 표준화

- **fx-discovery/fx-shaping/fx-offering** auth.ts → `createAuthMiddleware` 교체 (중복 구현 60줄 제거)
- 3 Worker **package.json**: `@foundry-x/harness-kit: workspace:*` 추가
- **harness-kit**: `private: true` 추가 (workspace internal 전략 확정)
- **scripts/new-worker.sh**: scaffold 생성 스크립트 신규

**이월**: F569(e)(f)(g) turbo 전환 — C94 2주 관찰(2026-05-06) 후 Sprint 317

### 테스트 결과

| 패키지 | 결과 |
|--------|------|
| CLI | 175/175 PASS |
| harness-kit | 61/61 PASS |
| Gap Match Rate | **100%** (9/9) |

### Phase 45 진행 현황

- M1 ✅ F560 (Discovery routes)
- M2 ✅ F561+F562 (D1 PoC + shared-contracts)
- **M3 ✅ F564 (Strangler 완결)** — 이번 PR
- 다음: Sprint 316 F567(latency) + F568(EventBus PoC)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- fx-pr-enrich -->
### Sprint Metadata
- Sprint: 315
- F-items: F564 F569
- Match Rate: 100%
<!-- /fx-pr-enrich -->