### PR TITLE
chore: content-sync Sprint 314 → 315 (post PR #673 merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Foundry-X가 이를 읽고 분석하고 동기화를 강제해요.
 <!-- README_SYNC_START: daily-check가 SPEC.md 실측값 기준으로 자동 동기화 -->
 | 항목 | 수치 |
 |------|------|
-| Phase | 45 (Sprint 314) |
-| Sprints | 314 완료 |
+| Phase | 45 (Sprint 315) |
+| Sprints | 315 완료 |
 | API Routes | ~11 |
 | API Services | ~31 |
 | API Schemas | ~14 |

--- a/packages/web/content/landing/hero.md
+++ b/packages/web/content/landing/hero.md
@@ -12,7 +12,7 @@ stats:
     label: "AI 에이전트"
   - value: "63"
     label: "자동화 스킬"
-  - value: "314"
+  - value: "315"
     label: "Sprints"
 ---
 

--- a/packages/web/src/components/landing/footer.tsx
+++ b/packages/web/src/components/landing/footer.tsx
@@ -69,7 +69,7 @@ export function Footer() {
             &copy; {new Date().getFullYear()} KTDS AX BD. All rights reserved.
           </p>
           <p className="font-mono text-xs text-muted-foreground/60">
-            Sprint 314 &middot; Phase 45
+            Sprint 315 &middot; Phase 45
           </p>
         </div>
       </div>

--- a/packages/web/src/routes/landing.tsx
+++ b/packages/web/src/routes/landing.tsx
@@ -69,7 +69,7 @@ function getSectionOrder(section: string): number {
    ═══════════════════════════════════════════════ */
 
 const SITE_META_FALLBACK = {
-  sprint: "Sprint 314",
+  sprint: "Sprint 315",
   phase: "Phase 45",
   phaseTitle: "MSA 3rd Separation",
   tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼",
@@ -79,7 +79,7 @@ const STATS_FALLBACK = [
   { value: "2", label: "BD 파이프라인" },
   { value: "10+", label: "AI 에이전트" },
   { value: "63", label: "자동화 스킬" },
-  { value: "314", label: "Sprints" },
+  { value: "315", label: "Sprints" },
 ];
 
 // Build-time content from TinaCMS-managed Markdown


### PR DESCRIPTION
## Summary

Sprint 315 (F564 Strangler MVP M3 + F569 harness-kit 표준화, PR #673 merged) 직후 content-sync drift 5건 해소.

## Changes

- `packages/web/content/landing/hero.md` — stats.Sprints `314 → 315`
- `packages/web/src/routes/landing.tsx` — `SITE_META_FALLBACK.sprint` + `STATS_FALLBACK[Sprints]` `314 → 315`
- `packages/web/src/components/landing/footer.tsx` — footer 캡션 `Sprint 314 · Phase 45 → Sprint 315 · Phase 45`
- `README.md` — `45 (Sprint 314) → 45 (Sprint 315)`, `314 완료 → 315 완료`

## Verification

Local `bash scripts/content-sync-check.sh` → `content sync: OK (Sprint 315, Phase 45)` (drift 0건).

**C89 fix (PR #664) 첫 실전 dogfood** — 이전 버그(미래 PLANNED row를 expected max로 취함)는 `grep '✅'` 필터로 정확히 해소됨을 확증(5건 drift 정확 식별 + 수정 후 0건).

## Test plan

- [x] `content-sync-check.sh` → OK
- [ ] CI (msa-lint + test + deploy-verify) 자동 통과 대기
- [ ] auto-merge squash

🤖 Generated with [Claude Code](https://claude.com/claude-code)