### PR TITLE
chore: content-sync Sprint 315 → 316 (post PR #678 merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Foundry-X가 이를 읽고 분석하고 동기화를 강제해요.
 <!-- README_SYNC_START: daily-check가 SPEC.md 실측값 기준으로 자동 동기화 -->
 | 항목 | 수치 |
 |------|------|
-| Phase | 45 (Sprint 315) |
-| Sprints | 315 완료 |
+| Phase | 45 (Sprint 316) |
+| Sprints | 316 완료 |
 | API Routes | ~11 |
 | API Services | ~31 |
 | API Schemas | ~14 |

--- a/packages/web/content/landing/hero.md
+++ b/packages/web/content/landing/hero.md
@@ -12,7 +12,7 @@ stats:
     label: "AI 에이전트"
   - value: "63"
     label: "자동화 스킬"
-  - value: "315"
+  - value: "316"
     label: "Sprints"
 ---
 

--- a/packages/web/src/components/landing/footer.tsx
+++ b/packages/web/src/components/landing/footer.tsx
@@ -69,7 +69,7 @@ export function Footer() {
             &copy; {new Date().getFullYear()} KTDS AX BD. All rights reserved.
           </p>
           <p className="font-mono text-xs text-muted-foreground/60">
-            Sprint 315 &middot; Phase 45
+            Sprint 316 &middot; Phase 45
           </p>
         </div>
       </div>

--- a/packages/web/src/routes/landing.tsx
+++ b/packages/web/src/routes/landing.tsx
@@ -69,7 +69,7 @@ function getSectionOrder(section: string): number {
    ═══════════════════════════════════════════════ */
 
 const SITE_META_FALLBACK = {
-  sprint: "Sprint 315",
+  sprint: "Sprint 316",
   phase: "Phase 45",
   phaseTitle: "MSA 3rd Separation",
   tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼",
@@ -79,7 +79,7 @@ const STATS_FALLBACK = [
   { value: "2", label: "BD 파이프라인" },
   { value: "10+", label: "AI 에이전트" },
   { value: "63", label: "자동화 스킬" },
-  { value: "315", label: "Sprints" },
+  { value: "316", label: "Sprints" },
 ];
 
 // Build-time content from TinaCMS-managed Markdown


### PR DESCRIPTION
## Summary

Sprint 316 (F567 Multi-hop latency + F568 EventBus D1 PoC, PR #678 merged) 직후 content-sync drift 5건 해소.

## Changes

- `packages/web/content/landing/hero.md` — stats.Sprints `315 → 316`
- `packages/web/src/routes/landing.tsx` — `SITE_META_FALLBACK.sprint` + `STATS_FALLBACK[Sprints]` `315 → 316`
- `packages/web/src/components/landing/footer.tsx` — footer 캡션 `Sprint 315 · Phase 45 → Sprint 316 · Phase 45`
- `README.md` — `45 (Sprint 315) → 45 (Sprint 316)`, `315 완료 → 316 완료`

## Verification

Local `bash scripts/content-sync-check.sh` → `content sync: OK (Sprint 316, Phase 45)` (drift 0건).

**C89 fix 두 번째 실전 dogfood** — Sprint 315 (PR #674) 성공 이후 재실행. `grep '✅'` 필터가 F567/F568 ✅ 전환 직후 expected=316 정확 산출.

## Test plan

- [x] `content-sync-check.sh` → OK
- [ ] CI 자동 통과 대기
- [ ] auto-merge squash

🤖 Generated with [Claude Code](https://claude.com/claude-code)