### PR TITLE
fix(fx-shaping): TS2769 test c.set() 'as never' — Sprint 316 prod deploy 복구

### DIFF
--- a/packages/fx-shaping/src/__tests__/shaping-d1-insert.test.ts
+++ b/packages/fx-shaping/src/__tests__/shaping-d1-insert.test.ts
@@ -12,8 +12,8 @@ function createTestApp(db: AnyDb) {
   const app = new Hono();
   app.use("*", async (c, next) => {
     (c as any).env = { DB: db };
-    c.set("orgId" as any, "org_test");
-    c.set("userId" as any, "user-test");
+    c.set("orgId" as never, "org_test" as never);
+    c.set("userId" as never, "user-test" as never);
     await next();
   });
   app.route("/api", shapingRoute);

--- a/packages/fx-shaping/src/__tests__/shaping-routes-functional.test.ts
+++ b/packages/fx-shaping/src/__tests__/shaping-routes-functional.test.ts
@@ -10,8 +10,8 @@ function createTestApp(db: AnyDb) {
   const app = new Hono();
   app.use("*", async (c, next) => {
     (c as any).env = { DB: db };
-    c.set("orgId" as any, "org_test");
-    c.set("userId" as any, "user-test");
+    c.set("orgId" as never, "org_test" as never);
+    c.set("userId" as never, "user-test" as never);
     await next();
   });
   app.route("/api", shapingRoute);


### PR DESCRIPTION
## Summary

Sprint 316 PR #678 merge 직후 master `deploy.yml` test job FAIL 확인 → prod 미배포 복구 hotfix.

## Root Cause

Sprint 314 fx-shaping 테스트 추가 시 Hono `ContextVariableMap` 우회용 `c.set("orgId" as any, ...)` 패턴이 TS2769 overload mismatch 유발:

```
Overload 1 of 2, '(key: never, value: unknown): void'
Overload 2 of 2, '(key: never, value: never): void'
```

PR CI(`msa-lint` + `e2e`)는 이 path를 안 타서 통과했지만, master push → `deploy.yml` test job(`pnpm turbo typecheck lint test`)에서 탐지.

## Impact

- Run [24766064015](https://github.com/KTDS-AXBD/Foundry-X/actions/runs/24766064015) (PR #678 master push) — test FAIL → deploy-{api,web,msa} + smoke-test skipped
- Run [24773536346](https://github.com/KTDS-AXBD/Foundry-X/actions/runs/24773536346) (PR #680 content-sync) — 동일 원인 연쇄 실패
- **prod(fx.minu.best)는 Sprint 314 수준 잔류** — F567/F568 신규 기능 미배포

## Fix

4 lines 변경: `as any` → `as never` (양쪽 key/value 모두):

```diff
- c.set("orgId" as any, "org_test");
- c.set("userId" as any, "user-test");
+ c.set("orgId" as never, "org_test" as never);
+ c.set("userId" as never, "user-test" as never);
```

overload 1 (never args) 자명 충족, 런타임 `c.set()` 정상 실행.

## Test plan

- [x] 파일 변경 확인 (4 lines)
- [ ] CI test job 통과 (msa-lint + e2e + deploy.yml test)
- [ ] master auto-merge
- [ ] deploy-{api,web,msa} 실행 + smoke-test
- [ ] prod(fx.minu.best) F567/F568 기능 확인 (수동)

🤖 Generated with [Claude Code](https://claude.com/claude-code)