### PR TITLE
fix(fx-shaping): TS2769 in src tenant + ax-bd-prototypes (PR #681 follow-up)

### DIFF
--- a/packages/fx-shaping/src/middleware/tenant.ts
+++ b/packages/fx-shaping/src/middleware/tenant.ts
@@ -15,7 +15,7 @@ export async function tenantGuard(
   c: Context<{ Bindings: ShapingEnv; Variables: TenantVariables }>,
   next: Next,
 ) {
-  const payload = c.get("jwtPayload") as
+  const payload = c.get("jwtPayload" as never) as
     | { sub?: string; orgId?: string; orgRole?: string }
     | undefined;
 

--- a/packages/fx-shaping/src/routes/ax-bd-prototypes.ts
+++ b/packages/fx-shaping/src/routes/ax-bd-prototypes.ts
@@ -115,7 +115,7 @@ axBdPrototypesRoute.post("/ax-bd/prototypes/:id/sections/:sectionId/review", asy
   const orgId = c.get("orgId");
   const prototypeId = c.req.param("id");
   const sectionId = c.req.param("sectionId");
-  const userId = (c.get("jwtPayload") as Record<string, string> | undefined)?.sub ?? (c.get("userId") as string) ?? "";
+  const userId = (c.get("jwtPayload" as never) as Record<string, string> | undefined)?.sub ?? (c.get("userId") as string) ?? "";
 
   const body = await c.req.json();
   const parsed = sectionReviewSchema.safeParse({ ...body, sectionId });


### PR DESCRIPTION
## Summary
- PR #681 (`16bcddb6`) only fixed `__tests__/*` but production source 2 sites still failed typecheck → master deploy.yml run 24774713928 FAIL → deploy-api/web/msa + smoke-test skipped (prod unDeployed since PR #678 Sprint 316 merge).
- `c.get("jwtPayload")` key not in `TenantVariables` → TS2769 overload + TS2352 cast.
- Fix: `"jwtPayload" as never` same pattern as test hotfix (2 lines).

## Test plan
- [x] `pnpm --filter @foundry-x/fx-shaping typecheck` PASS locally
- [x] `pnpm --filter @foundry-x/fx-shaping test` 40/40 PASS
- [ ] master deploy.yml `test job` PASS after merge
- [ ] deploy-api/web/msa + smoke-test green

## Note
`packages/api/src/middleware/tenant.ts:22` has the identical pattern yet passes typecheck — root cause (tsconfig / module augmentation divergence) unresolved. C-track candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)