### PR TITLE
fix(fx-msa): import 'hono/jwt' in fx-offering + fx-discovery (root cause)

### DIFF
--- a/packages/fx-discovery/src/app.ts
+++ b/packages/fx-discovery/src/app.ts
@@ -1,6 +1,7 @@
 // fx-discovery app (F518: FX-REQ-546, F523: FX-REQ-551)
 // F538: 3개 clean route 추가 (discovery, discovery-report, discovery-reports)
 // F539c: 7 라우트 추가 (biz-items 3 + discovery-stages 2 + discovery-pipeline GET 2)
+import "hono/jwt"; // side-effect: augment ContextVariableMap with jwtPayload
 import { Hono } from "hono";
 import type { DiscoveryEnv } from "./env.js";
 import { authMiddleware } from "./middleware/auth.js";

--- a/packages/fx-offering/src/app.ts
+++ b/packages/fx-offering/src/app.ts
@@ -1,5 +1,6 @@
 // fx-offering app (F541: FX-REQ-580)
 // Offering 도메인 독립 Worker — 12 routes, 29 services
+import "hono/jwt"; // side-effect: augment ContextVariableMap with jwtPayload
 import { Hono } from "hono";
 import type { OfferingEnv } from "./env.js";
 import { authMiddleware } from "./middleware/auth.js";


### PR DESCRIPTION
## Summary
- **Root cause finally identified**: packages/api imports \`hono/jwt\` directly in auth.ts → module augmentation adds \`jwtPayload\` to Hono's \`ContextVariableMap\`. fx-* packages use harness-kit's compiled \`createAuthMiddleware\` wrapper → augmentation doesn't propagate across dist boundary → \`c.get(\"jwtPayload\")\` fails TS2769+TS2352.
- Fix: 1-line side-effect import in each fx-* package's \`app.ts\` entry point (+2 total).
- Replaces whack-a-mole \`as never\` patching.

## Context
- Run 24774713928 (PR #681): fx-shaping 2 sites failed → fixed with \`as never\` (PR #682).
- Run 24775227168 (PR #682): fx-offering 9 sites failed → this PR.
- Previous PRs (#681, #682) patched \`as never\` symptom; this PR fixes the cause.

## Test plan
- [x] \`pnpm turbo typecheck\` — 17/17 PASS locally
- [x] \`pnpm --filter @foundry-x/fx-offering typecheck\` PASS
- [x] \`pnpm --filter @foundry-x/fx-discovery typecheck\` PASS
- [ ] master deploy.yml \`test job\` PASS
- [ ] deploy-api/web/msa + smoke-test green → prod redeployed (since PR #678 Sprint 316)

## Follow-up (C-track candidate)
- fx-shaping still carries 2 \`as never\` patches from PR #682. Revert to \`c.get(\"jwtPayload\")\` + add \`import \"hono/jwt\"\` to app.ts for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)