### PR TITLE
fix(deploy): deploy-msa — pre-build harness-kit (F569 workspace dep)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -179,6 +179,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter @foundry-x/shared-contracts build
       - run: pnpm --filter @foundry-x/shared build
+      - run: pnpm --filter @foundry-x/harness-kit build
       - name: Secret Preflight Check (C83)
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary
- Sprint 315 F569 migrated fx-* packages to \`@foundry-x/harness-kit\` createAuthMiddleware.
- deploy-msa job was never updated to pre-build harness-kit, so wrangler esbuild bundle fails: \`Could not resolve "@foundry-x/harness-kit"\`.
- PR #676 (C97) added \`shared\` pre-build but missed harness-kit.

## Fix
Add \`pnpm --filter @foundry-x/harness-kit build\` to deploy-msa before worker deploy steps — matches deploy-api line 93 and test job line 93.

## Context
- Run 24775531506 (master 683 merge): test PASS (root cause TS fix working), deploy-msa FAIL at fx-discovery worker deploy.
- Third consecutive hotfix for the Sprint 316 deploy unblock chain (#681 → #682 → #683 → this).

## Test plan
- [ ] master deploy.yml deploy-msa PASS
- [ ] deploy-api/web + smoke-test green → prod redeployed (since PR #678 Sprint 316)

🤖 Generated with [Claude Code](https://claude.com/claude-code)