### PR TITLE
fix(fx-offering): F570 hotfix — offering-packs.ts unused userId lint

### DIFF
--- a/packages/fx-offering/src/routes/offering-packs.ts
+++ b/packages/fx-offering/src/routes/offering-packs.ts
@@ -88,7 +88,7 @@ offeringPacksRoute.post("/offering-packs/:id/items", async (c) => {
 // PATCH /offering-packs/:id/status — 상태 변경
 offeringPacksRoute.patch("/offering-packs/:id/status", async (c) => {
   const orgId = c.get("orgId");
-  const userId = (c.get("jwtPayload") as Record<string, string> | undefined)?.sub ?? "";
+  const _userId = (c.get("jwtPayload") as Record<string, string> | undefined)?.sub ?? "";
   const id = c.req.param("id");
 
   const body = await c.req.json();


### PR DESCRIPTION
## Summary

F570 Sprint 318 Offering 이관(PR #687, `4c12cd84`)의 deploy run `24864789952` **test job FAIL** → deploy 4 job skip → prod 미배포 해소.

**원인**: `packages/fx-offering/src/routes/offering-packs.ts:91` `userId` 변수 unused (PATCH handler에서 audit 사용처 없음). ESLint `@typescript-eslint/no-unused-vars` 에러.

**Fix**: `userId` → `_userId` (unused prefix 규칙 `/^_/u` 충족, 향후 audit log 확장 여지 유지)

## Context

- Autopilot lint pre-check 누락 (S297 F540 8 ESLint errors 패턴 재현)
- Match Rate 97% + autopilot 34분 완결에도 deploy.yml test job에서 최초 감지 
- feedback `autopilot_lint_gap.md` 재관찰

## Test plan

- [x] Local `pnpm --filter @foundry-x/fx-offering lint` PASS
- [ ] CI test job PASS
- [ ] deploy-api / deploy-msa / deploy-web / smoke-test 전부 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)