### PR TITLE
fix(deploy): fx-discovery D1 migration step에 packageManager: pnpm 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,6 +107,7 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           workingDirectory: packages/fx-discovery
           command: d1 migrations apply foundry-x-discovery-db --remote
+          packageManager: pnpm
       - uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary

PR #691 hotfix merge 후 `deploy-api` job FAIL (run 24869642709):
\`\`\`
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type \"workspace:\": workspace:*
\`\`\`

## 근본 원인

`cloudflare/wrangler-action@v3`는 workingDirectory에 wrangler가 pre-installed 아니면 `npm i wrangler@3.90.0` fallback. `packages/fx-discovery/package.json`의 \`@foundry-x/harness-kit: workspace:*\` deps를 npm이 이해하지 못해 실패.

## 수정

\`Apply fx-discovery D1 migrations\` step에 \`packageManager: pnpm\` 1줄 추가.
Deploy web step(line 162)에 이미 적용된 동일 패턴.

## 교훈 (S307 재확인)

pnpm workspace monorepo + cloudflare/wrangler-action 조합에서는 `packageManager: pnpm` 명시 필수. 추후 새 Worker 추가 시 체크리스트.

🤖 Generated with [Claude Code](https://claude.com/claude-code)