### PR TITLE
fix(deploy): fx-modules Worker deploy step 추가 (F572)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,9 @@ jobs:
               - 'packages/fx-discovery/**'
               - 'packages/fx-shaping/**'
               - 'packages/fx-offering/**'
+              - 'packages/fx-modules/**'
               - 'packages/shared/**'
+              - 'packages/harness-kit/**'
               - '.github/workflows/deploy.yml'
 
   # 코드 변경 시에만 test 실행 (SPEC.md, scripts, docs 변경은 skip)
@@ -204,6 +206,11 @@ jobs:
         run: ../api/node_modules/.bin/wrangler deploy
       - name: Deploy fx-shaping Worker
         working-directory: packages/fx-shaping
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: ../api/node_modules/.bin/wrangler deploy
+      - name: Deploy fx-modules Worker (F572)
+        working-directory: packages/fx-modules
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: ../api/node_modules/.bin/wrangler deploy


### PR DESCRIPTION
## Summary

PR #691+#692 merge 후 deploy-msa FAIL (run 24869824964):
- fx-gateway Service Binding MODULES → fx-modules Worker 미존재 → Cloudflare API error

## 근본

F572 autopilot이 fx-gateway wrangler.toml에 `MODULES` binding은 추가했으나, `deploy.yml`에 `Deploy fx-modules Worker` step을 추가하지 않음.

## 수정

- `Deploy fx-modules Worker` step 추가 (fx-shaping 다음, fx-gateway 전)
- `msa` paths-filter에 `packages/fx-modules/**` + `packages/harness-kit/**` 추가 (누락 방지)

## 후속

- 사용자 수동 작업 필요: `wrangler secret put JWT_SECRET --name fx-modules` + `GITHUB_TOKEN` (C99 제안)
- C83 preflight 매트릭스에 fx-modules 추가 권장 (TD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)