### PR TITLE
chore(web): /ax:daily-check S314 — 랜딩 콘텐츠 Sprint 320 동기화

### DIFF
--- a/packages/web/content/landing/hero.md
+++ b/packages/web/content/landing/hero.md
@@ -12,7 +12,7 @@ stats:
     label: "AI 에이전트"
   - value: "63"
     label: "자동화 스킬"
-  - value: "319"
+  - value: "320"
     label: "Sprints"
 ---
 

--- a/packages/web/src/components/landing/footer.tsx
+++ b/packages/web/src/components/landing/footer.tsx
@@ -69,7 +69,7 @@ export function Footer() {
             &copy; {new Date().getFullYear()} KTDS AX BD. All rights reserved.
           </p>
           <p className="font-mono text-xs text-muted-foreground/60">
-            Sprint 319 &middot; Phase 45
+            Sprint 320 &middot; Phase 45
           </p>
         </div>
       </div>

--- a/packages/web/src/routes/landing.tsx
+++ b/packages/web/src/routes/landing.tsx
@@ -69,7 +69,7 @@ function getSectionOrder(section: string): number {
    ═══════════════════════════════════════════════ */
 
 const SITE_META_FALLBACK = {
-  sprint: "Sprint 319",
+  sprint: "Sprint 320",
   phase: "Phase 45",
   phaseTitle: "MSA 3rd Separation",
   tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼",
@@ -79,7 +79,7 @@ const STATS_FALLBACK = [
   { value: "2", label: "BD 파이프라인" },
   { value: "10+", label: "AI 에이전트" },
   { value: "63", label: "자동화 스킬" },
-  { value: "319", label: "Sprints" },
+  { value: "320", label: "Sprints" },
 ];
 
 // Build-time content from TinaCMS-managed Markdown


### PR DESCRIPTION
## Summary
- Phase 45 Batch 6 완결(F571 fx-agent prod LIVE) 반영
- 랜딩 3파일의 Sprint 표기 319 → 320 동기화
- 기존 \`98dccc18\`(SPEC §2 마지막 실측 + README SYNC) meta-only commit의 code 파일 후속

## Changes
- \`packages/web/content/landing/hero.md\` — stats Sprints 319 → 320
- \`packages/web/src/routes/landing.tsx\` — SITE_META_FALLBACK.sprint + STATS_FALLBACK 319 → 320
- \`packages/web/src/components/landing/footer.tsx\` — "Sprint 319 · Phase 45" → "Sprint 320 · Phase 45"

## Test plan
- [x] @foundry-x/web typecheck PASS (13s)
- [ ] CI deploy.yml 통과 후 fx.minu.best 랜딩 footer "Sprint 320" 확인

## 관련
- /ax:daily-check S314 자동 보정에서 발견 (code 변경이라 PR 경유)

🤖 Generated with [Claude Code](https://claude.com/claude-code)