### PR TITLE
chore(web): 랜딩 Phase 46 / Sprint 323 동기화 (S314)

### DIFF
--- a/packages/web/content/landing/hero.md
+++ b/packages/web/content/landing/hero.md
@@ -3,8 +3,8 @@ title: Foundry-X
 section: hero
 sort_order: 0
 tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼"
-phase: "Phase 45"
-phaseTitle: "MSA 3rd Separation"
+phase: "Phase 46"
+phaseTitle: "Agent Domain Separation"
 stats:
   - value: "2"
     label: "BD 파이프라인"
@@ -12,7 +12,7 @@ stats:
     label: "AI 에이전트"
   - value: "63"
     label: "자동화 스킬"
-  - value: "320"
+  - value: "323"
     label: "Sprints"
 ---
 

--- a/packages/web/src/components/landing/footer.tsx
+++ b/packages/web/src/components/landing/footer.tsx
@@ -69,7 +69,7 @@ export function Footer() {
             &copy; {new Date().getFullYear()} KTDS AX BD. All rights reserved.
           </p>
           <p className="font-mono text-xs text-muted-foreground/60">
-            Sprint 320 &middot; Phase 45
+            Sprint 323 &middot; Phase 46
           </p>
         </div>
       </div>

--- a/packages/web/src/routes/landing.tsx
+++ b/packages/web/src/routes/landing.tsx
@@ -69,9 +69,9 @@ function getSectionOrder(section: string): number {
    ═══════════════════════════════════════════════ */
 
 const SITE_META_FALLBACK = {
-  sprint: "Sprint 320",
-  phase: "Phase 45",
-  phaseTitle: "MSA 3rd Separation",
+  sprint: "Sprint 323",
+  phase: "Phase 46",
+  phaseTitle: "Agent Domain Separation",
   tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼",
 } as const;
 
@@ -79,7 +79,7 @@ const STATS_FALLBACK = [
   { value: "2", label: "BD 파이프라인" },
   { value: "10+", label: "AI 에이전트" },
   { value: "63", label: "자동화 스킬" },
-  { value: "320", label: "Sprints" },
+  { value: "323", label: "Sprints" },
 ];
 
 // Build-time content from TinaCMS-managed Markdown


### PR DESCRIPTION
## Summary
content-sync-check.sh DRIFT 5건을 0건으로 해소.

- hero.md: Phase 45 → 46, phaseTitle "MSA 3rd Separation" → "Agent Domain Separation", Sprints 320 → 323
- landing.tsx: SITE_META_FALLBACK + STATS_FALLBACK
- footer.tsx: Sprint 320 / Phase 45 → Sprint 323 / Phase 46

Phase 46 본격 진입 반영 (F575 ✅ Sprint 322, F576 등록 Sprint 323).

## Test plan
- [x] content-sync-check.sh: OK (Sprint 323, Phase 46)
- CI: deploy-web smoke-test PASS 후 auto-merge