### PR TITLE
chore(landing): Sprint 329 / Phase 46 콘텐츠 동기화

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Foundry-X가 이를 읽고 분석하고 동기화를 강제해요.
 <!-- README_SYNC_START: daily-check가 SPEC.md 실측값 기준으로 자동 동기화 -->
 | 항목 | 수치 |
 |------|------|
-| Phase | 47 (Sprint 328) |
-| Sprints | 328 완료 |
+| Phase | 46 (Sprint 329) |
+| Sprints | 329 완료 |
 | API Routes | ~11 |
 | API Services | ~43 |
 | API Schemas | ~18 |

--- a/packages/web/content/landing/hero.md
+++ b/packages/web/content/landing/hero.md
@@ -3,8 +3,8 @@ title: Foundry-X
 section: hero
 sort_order: 0
 tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼"
-phase: "Phase 47"
-phaseTitle: "Discovery Infra Recovery"
+phase: "Phase 46"
+phaseTitle: "Phase 46 100% 종결"
 stats:
   - value: "2"
     label: "BD 파이프라인"
@@ -12,7 +12,7 @@ stats:
     label: "AI 에이전트"
   - value: "63"
     label: "자동화 스킬"
-  - value: "328"
+  - value: "329"
     label: "Sprints"
 ---
 

--- a/packages/web/src/components/landing/footer.tsx
+++ b/packages/web/src/components/landing/footer.tsx
@@ -69,7 +69,7 @@ export function Footer() {
             &copy; {new Date().getFullYear()} KTDS AX BD. All rights reserved.
           </p>
           <p className="font-mono text-xs text-muted-foreground/60">
-            Sprint 328 &middot; Phase 47
+            Sprint 329 &middot; Phase 46
           </p>
         </div>
       </div>

--- a/packages/web/src/routes/landing.tsx
+++ b/packages/web/src/routes/landing.tsx
@@ -69,9 +69,9 @@ function getSectionOrder(section: string): number {
    ═══════════════════════════════════════════════ */
 
 const SITE_META_FALLBACK = {
-  sprint: "Sprint 328",
-  phase: "Phase 47",
-  phaseTitle: "Discovery Infra Recovery",
+  sprint: "Sprint 329",
+  phase: "Phase 46",
+  phaseTitle: "Phase 46 100% 종결",
   tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼",
 } as const;
 
@@ -79,7 +79,7 @@ const STATS_FALLBACK = [
   { value: "2", label: "BD 파이프라인" },
   { value: "10+", label: "AI 에이전트" },
   { value: "63", label: "자동화 스킬" },
-  { value: "328", label: "Sprints" },
+  { value: "329", label: "Sprints" },
 ];
 
 // Build-time content from TinaCMS-managed Markdown


### PR DESCRIPTION
## Summary
S320 session-end 콘텐츠 동기화. Sprint 328 Phase 47 → Sprint 329 Phase 46 일괄 갱신.

- README.md README_SYNC block
- packages/web/content/landing/hero.md frontmatter
- packages/web/src/routes/landing.tsx SITE_META_FALLBACK + STATS_FALLBACK
- packages/web/src/components/landing/footer.tsx 표시

## Test plan
- [x] content-sync-check.sh exit 0 (drift 0)
- [ ] CI: typecheck + build
- [ ] auto-merge: squash merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)