### PR TITLE
chore(landing): Sprint 330 → 331 sync

### DIFF
--- a/packages/web/content/landing/hero.md
+++ b/packages/web/content/landing/hero.md
@@ -12,7 +12,7 @@ stats:
     label: "AI 에이전트"
   - value: "63"
     label: "자동화 스킬"
-  - value: "330"
+  - value: "331"
     label: "Sprints"
 ---
 

--- a/packages/web/src/components/landing/footer.tsx
+++ b/packages/web/src/components/landing/footer.tsx
@@ -69,7 +69,7 @@ export function Footer() {
             &copy; {new Date().getFullYear()} KTDS AX BD. All rights reserved.
           </p>
           <p className="font-mono text-xs text-muted-foreground/60">
-            Sprint 330 &middot; Phase 46
+            Sprint 331 &middot; Phase 46
           </p>
         </div>
       </div>

--- a/packages/web/src/routes/landing.tsx
+++ b/packages/web/src/routes/landing.tsx
@@ -69,7 +69,7 @@ function getSectionOrder(section: string): number {
    ═══════════════════════════════════════════════ */
 
 const SITE_META_FALLBACK = {
-  sprint: "Sprint 330",
+  sprint: "Sprint 331",
   phase: "Phase 46",
   phaseTitle: "Phase 46 100% 종결",
   tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼",
@@ -79,7 +79,7 @@ const STATS_FALLBACK = [
   { value: "2", label: "BD 파이프라인" },
   { value: "10+", label: "AI 에이전트" },
   { value: "63", label: "자동화 스킬" },
-  { value: "330", label: "Sprints" },
+  { value: "331", label: "Sprints" },
 ];
 
 // Build-time content from TinaCMS-managed Markdown


### PR DESCRIPTION
## Summary

F584 Sprint 331 MERGED 후 landing 3 파일 Sprint 번호 동기화 (S322 session-end content-sync).

- packages/web/content/landing/hero.md: stats Sprints 330 → 331
- packages/web/src/routes/landing.tsx: SITE_META_FALLBACK + STATS_FALLBACK
- packages/web/src/components/landing/footer.tsx: Sprint 330 → 331

## Test plan

- [x] content-sync-check.sh: OK (Sprint 331, Phase 46)
- [ ] CI: typecheck + build
- [ ] Auto-merge → fx.minu.best 랜딩 페이지 Sprint 331 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)