### PR TITLE
chore(landing): Sprint 334 + Phase 47 sync (S325)

### DIFF
--- a/docs/metrics/velocity/sprint-334.json
+++ b/docs/metrics/velocity/sprint-334.json
@@ -1,0 +1,11 @@
+{
+  "sprint": 334,
+  "phase": 47,
+  "f_items": "F588",
+  "f_count": 1,
+  "match_rate": 100,
+  "duration_minutes": 0,
+  "test_result": "pass",
+  "created": "2026-05-04T18:01:19+09:00",
+  "recorded_at": "2026-05-04T18:01:35+09:00"
+}

--- a/packages/web/content/landing/hero.md
+++ b/packages/web/content/landing/hero.md
@@ -12,7 +12,7 @@ stats:
     label: "AI 에이전트"
   - value: "63"
     label: "자동화 스킬"
-  - value: "333"
+  - value: "334"
     label: "Sprints"
 ---
 

--- a/packages/web/src/components/landing/footer.tsx
+++ b/packages/web/src/components/landing/footer.tsx
@@ -69,7 +69,7 @@ export function Footer() {
             &copy; {new Date().getFullYear()} KTDS AX BD. All rights reserved.
           </p>
           <p className="font-mono text-xs text-muted-foreground/60">
-            Sprint 333 &middot; Phase 47
+            Sprint 334 &middot; Phase 47
           </p>
         </div>
       </div>

--- a/packages/web/src/routes/landing.tsx
+++ b/packages/web/src/routes/landing.tsx
@@ -69,7 +69,7 @@ function getSectionOrder(section: string): number {
    ═══════════════════════════════════════════════ */
 
 const SITE_META_FALLBACK = {
-  sprint: "Sprint 333",
+  sprint: "Sprint 334",
   phase: "Phase 47",
   phaseTitle: "Phase 47 동시 진행",
   tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼",
@@ -79,7 +79,7 @@ const STATS_FALLBACK = [
   { value: "2", label: "BD 파이프라인" },
   { value: "10+", label: "AI 에이전트" },
   { value: "63", label: "자동화 스킬" },
-  { value: "333", label: "Sprints" },
+  { value: "334", label: "Sprints" },
 ];
 
 // Build-time content from TinaCMS-managed Markdown


### PR DESCRIPTION
## Summary

- Sprint 333 → 334 sync (hero.md / landing.tsx 2건 / footer.tsx)
- velocity sprint-334.json autopilot 자동 생성 추가

## Context

F588 ✅ Sprint 334 — work 도메인 본격 분리 완결 (PR #722, autopilot ~8분 15초 F587(8분 14초)와 거의 동일, Match 100%, OBSERVED 9/9 PASS, 18 세션 연속 성공 S306~S325).

services/ 루트 .ts 29→27 (-2 work* services), core/work/ 5 files closure 완성 (F587 traceability seed + routes 2 + services 2).

## Test plan

- [ ] CI green (build + e2e)
- [ ] 자동 squash merge (--auto)