### PR TITLE
chore(landing): content sync Sprint 339 → 340 (S331)

### DIFF
--- a/packages/web/content/landing/hero.md
+++ b/packages/web/content/landing/hero.md
@@ -12,7 +12,7 @@ stats:
     label: "AI 에이전트"
   - value: "63"
     label: "자동화 스킬"
-  - value: "339"
+  - value: "340"
     label: "Sprints"
 ---
 

--- a/packages/web/src/components/landing/footer.tsx
+++ b/packages/web/src/components/landing/footer.tsx
@@ -69,7 +69,7 @@ export function Footer() {
             &copy; {new Date().getFullYear()} KTDS AX BD. All rights reserved.
           </p>
           <p className="font-mono text-xs text-muted-foreground/60">
-            Sprint 339 &middot; Phase 47
+            Sprint 340 &middot; Phase 47
           </p>
         </div>
       </div>

--- a/packages/web/src/routes/landing.tsx
+++ b/packages/web/src/routes/landing.tsx
@@ -69,7 +69,7 @@ function getSectionOrder(section: string): number {
    ═══════════════════════════════════════════════ */
 
 const SITE_META_FALLBACK = {
-  sprint: "Sprint 339",
+  sprint: "Sprint 340",
   phase: "Phase 47",
   phaseTitle: "Phase 47 동시 진행",
   tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼",
@@ -79,7 +79,7 @@ const STATS_FALLBACK = [
   { value: "2", label: "BD 파이프라인" },
   { value: "10+", label: "AI 에이전트" },
   { value: "63", label: "자동화 스킬" },
-  { value: "339", label: "Sprints" },
+  { value: "340", label: "Sprints" },
 ];
 
 // Build-time content from TinaCMS-managed Markdown


### PR DESCRIPTION
## Summary
Phase 0c-3 content drift 4건 보정 (Sprint 339 → 340).

- `packages/web/content/landing/hero.md`: stats sprint 339 → 340
- `packages/web/src/routes/landing.tsx`: SITE_META_FALLBACK.sprint + STATS_FALLBACK
- `packages/web/src/components/landing/footer.tsx`: Sprint 340

## Context
PR #735 `chore/landing-340-sync` (README/CLAUDE/CHANGELOG/velocity)에 이어 web 콘텐츠 추가 동기화. session-end Phase 0c-3 drift check가 잡아냄.

🤖 Generated with [Claude Code](https://claude.com/claude-code)