### PR TITLE
feat(msa): F613 Pass 6 — core/docs sub-app 신설, no-direct-route-register 0 (Pass 시리즈 종결)

### DIFF
--- a/docs/02-design/features/sprint-347.design.md
+++ b/docs/02-design/features/sprint-347.design.md
@@ -1,0 +1,84 @@
+---
+id: FX-DSGN-347
+sprint: 347
+feature: F613
+req: FX-REQ-677
+status: approved
+date: 2026-05-05
+---
+
+# Sprint 347 Design — F613: MSA 룰 강제 교정 Pass 6 — `/api/docs` sub-app 신설 (Pass 시리즈 종결)
+
+## §1 목표
+
+baseline 1 → 0 달성. `no-direct-route-register` 1건(`src/app.ts:129`) 해소.
+`core/docs/` sub-app 신설 → `app.route("/api/docs", docsApp)` mount 패턴 적용.
+Pass 시리즈(F608~F613) 완전 종결.
+
+## §2 접근 방식
+
+기존 `app.get("/api/docs", swaggerUI(...))` 직접 등록을 sub-app으로 추출.
+- `core/docs/routes/index.ts`에 `docsApp` Hono 인스턴스 생성
+- `docsApp.get("/", swaggerUI({ url: "/api/openapi.json" }))` — sub-app 마운트 후 `/api/docs/` → `/` 매핑
+- `app.ts`에서 `app.route("/api/docs", docsApp)` 1줄로 대체
+
+## §3 변경 파일 매핑
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `packages/api/src/core/docs/routes/index.ts` | 신규 — `docsApp` sub-app |
+| `packages/api/src/app.ts` | 3줄 변경: import 제거 + import 추가 + route 교체 |
+| `packages/api/.eslint-baseline.json` | fingerprint 1건 제거, msa_total/errors 1→0 |
+
+## §4 상세 구현
+
+### 4a. `core/docs/routes/index.ts` (신규)
+
+```typescript
+import { Hono } from "hono";
+import { swaggerUI } from "@hono/swagger-ui";
+import type { Env } from "../../../env.js";
+
+export const docsApp = new Hono<{ Bindings: Env }>();
+docsApp.get("/", swaggerUI({ url: "/api/openapi.json" }));
+```
+
+### 4b. `app.ts` 변경 (3줄)
+
+- L2 제거: `import { swaggerUI } from "@hono/swagger-ui";`
+- 신규 import 추가: `import { docsApp } from "./core/docs/routes/index.js";`
+- L129 교체: `app.get("/api/docs", swaggerUI(...))` → `app.route("/api/docs", docsApp)`
+
+### 4c. baseline JSON 갱신
+
+```json
+{
+  "version": "1.0",
+  "generated_at": "<현재 시각>",
+  "description": "F613 Pass 시리즈 종결 baseline — violations 0, MSA 룰 강제 교정 완결.",
+  "msa_total": 0,
+  "msa_errors": 0,
+  "msa_warnings": 0,
+  "fingerprints": []
+}
+```
+
+## §5 TDD
+
+면제 대상: 단순 라우트 re-export + swaggerUI 핸들러. 회귀 위험 최소 (UI-only).
+기존 typecheck + lint baseline check가 정확성 보증.
+
+## §6 검증 기준 (P-a ~ P-j)
+
+| # | 항목 | 검증 |
+|---|------|------|
+| P-a | `core/docs/routes/index.ts` 신설 + `docsApp` export | `ls` 확인 |
+| P-b | `app.ts` `app.get("/api/docs", ...)` 0건 | grep 확인 |
+| P-c | `app.ts` `app.route("/api/docs", docsApp)` 1건 | grep 확인 |
+| P-d | baseline fingerprints 1 → 0 | JSON 확인 |
+| P-e | `pnpm lint` exit 0 | 직접 실행 |
+| P-f | typecheck PASS | turbo typecheck |
+| P-g | dual_ai_reviews hook 정상 | codex-review.sh |
+| P-h | F608~F612 회귀 0 | baseline check |
+| P-i | Match ≥ 90% | Gap Analysis |
+| P-j | `pnpm lint` errors 0 + warnings 0 (Pass 시리즈 100% 종결) | 직접 실행 |

--- a/packages/api/.eslint-baseline.json
+++ b/packages/api/.eslint-baseline.json
@@ -1,11 +1,9 @@
 {
   "version": "1.0",
-  "generated_at": "2026-05-05T07:13:58.048Z",
-  "description": "F608 Forward-only MSA baseline — known violations as of 2026-05-05. Do NOT add entries here; use scripts/lint-baseline-update.sh after fixing.",
-  "msa_total": 1,
-  "msa_errors": 1,
+  "generated_at": "2026-05-05T18:30:00.000Z",
+  "description": "F613 Pass 시리즈 종결 baseline — violations 0, MSA 룰 강제 교정 완결 (F608~F613).",
+  "msa_total": 0,
+  "msa_errors": 0,
   "msa_warnings": 0,
-  "fingerprints": [
-    "src/app.ts:129:foundry-x-api/no-direct-route-register"
-  ]
+  "fingerprints": []
 }

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -1,5 +1,4 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
-import { swaggerUI } from "@hono/swagger-ui";
 import { cors } from "hono/cors";
 import { Toucan } from "toucan-js";
 // Modules: auth (S181) — portal/gate/launch moved to fx-modules (F572, Sprint 319)
@@ -46,6 +45,7 @@ import { eventStatusRoute } from "./routes/event-status.js";
 import { workRoute } from "./core/work/routes/work.js";
 import { workPublicRoute } from "./core/work/routes/work-public.js";
 import { verificationRoute } from "./core/verification/routes/index.js";
+import { docsApp } from "./core/docs/routes/index.js";
 import { handleScheduled } from "./scheduled.js";
 import { authMiddleware } from "./middleware/auth.js";
 import { piiMaskerMiddleware } from "./middleware/pii-masker.middleware.js";
@@ -126,7 +126,7 @@ app.doc("/api/openapi.json", {
     { name: "NPS", description: "NPS survey scheduling and team analytics" },
   ],
 });
-app.get("/api/docs", swaggerUI({ url: "/api/openapi.json" }));
+app.route("/api/docs", docsApp);
 
 // Auth routes (public — /auth/sso/verify is public, /auth/sso/token needs auth via JWT)
 app.route("/api", authRoute);

--- a/packages/api/src/core/docs/routes/index.ts
+++ b/packages/api/src/core/docs/routes/index.ts
@@ -1,0 +1,6 @@
+import { Hono } from "hono";
+import { swaggerUI } from "@hono/swagger-ui";
+import type { Env } from "../../../env.js";
+
+export const docsApp = new Hono<{ Bindings: Env }>();
+docsApp.get("/", swaggerUI({ url: "/api/openapi.json" }));


### PR DESCRIPTION
## F613 — MSA 룰 강제 교정 Pass 6 (Pass 시리즈 종결)

### 변경 내용
- `packages/api/src/core/docs/routes/index.ts` 신설: `docsApp` Hono sub-app (swaggerUI 라우트 이관)
- `app.ts:129`: `app.get("/api/docs", swaggerUI(...))` → `app.route("/api/docs", docsApp)` 교체
- `app.ts:2`: `import { swaggerUI } from "@hono/swagger-ui"` 제거 (sub-app으로 이전)
- `.eslint-baseline.json`: fingerprint 1건 제거 → `msa_total: 0` (Pass 시리즈 종결)

### Pass 시리즈 완결
F608~F613 6 Pass: baseline **161 → 0** (100% 해소)
| Pass | F-item | 해소 |
|------|--------|------|
| Pass 1 | F608 | lint script 확장 + baseline 160 등록 |
| Pass 2 | F609 | types.ts 13 도메인 + single-domain 44 fix |
| Pass 3 | F610 | biz-items.ts 19건 fix |
| Pass 4 | F611 | cross-domain-d1 31건 fix |
| Pass 5 | F612 | multi-domain 26건 fix |
| **Pass 6** | **F613** | **no-direct-route-register 1건 fix → baseline 0** |

### 검증 체크리스트
- [x] P-a: `core/docs/routes/index.ts` 신설 + `docsApp` export
- [x] P-b: `app.ts` `app.get("/api/docs", ...)` 0건
- [x] P-c: `app.route("/api/docs", docsApp)` 1건
- [x] P-d: baseline fingerprints 1 → 0
- [ ] P-e: `pnpm lint` exit 0 (CI 확인)
- [ ] P-f: typecheck PASS (CI 확인)

---
🤖 Auto-generated from Sprint autopilot

<!-- fx-pr-enrich -->
### Sprint Metadata
- Sprint: 347
- F-items: F613
- Match Rate: 100%
<!-- /fx-pr-enrich -->