### PR TITLE
feat: Sprint 355 — F631 자동화 정책 코드 강제 (core/policy/)

### DIFF
--- a/docs/02-design/features/sprint-355.design.md
+++ b/docs/02-design/features/sprint-355.design.md
@@ -1,0 +1,82 @@
+---
+code: FX-DESIGN-355
+title: Sprint 355 — F631 자동화 정책 코드 강제 (core/policy/ 신규)
+version: 1.0
+status: Active
+category: DESIGN
+created: 2026-05-06
+updated: 2026-05-06
+sprint: 355
+f_item: F631
+req: FX-REQ-696
+priority: P2
+---
+
+# Sprint 355 — F631 자동화 정책 코드 강제 Design
+
+## §1 설계 목표
+
+BeSir 차별화 코어: **whitelist + default-deny** 패턴으로 자동화 액션 유형별 허용 여부를 DB에서 관리.
+F606 audit-bus와 통합하여 `policy.evaluated` + `policy.violation` 이벤트를 기록.
+
+## §2 구조 결정
+
+| 결정 | 선택 | 근거 |
+|------|------|------|
+| 위치 | `core/policy/` 신규 | 5-Asset Policy 자산, F615 Guard-X와 명확 분리 |
+| Router 타입 | `Hono` (not OpenAPIHono) | asset 패턴 재현, 내부 서비스용 |
+| AuditBus 호출 | 즉석 TraceContext 생성 | emit() 시그니처 필수 파라미터 |
+| D1 | migration 0143 | automation_policies + policy_violations |
+
+## §3 테스트 계약 (TDD Red Target)
+
+```typescript
+// packages/api/src/core/policy/policy-engine.test.ts
+describe("F631 PolicyEngine", () => {
+  it("whitelist 통과: allowed=true 정책 → evaluate → allowed=true")
+  it("default-deny: 미등록 action_type → evaluate → allowed=false + violation INSERT")
+  it("policy.evaluated audit 이벤트 발행 (2 case)")
+  it("policy.violation audit 이벤트 발행 (default-deny 시)")
+})
+```
+
+## §4 파일 매핑 (§5 Worker 파일 목록)
+
+| 파일 | 작업 | 비고 |
+|------|------|------|
+| `packages/api/src/db/migrations/0143_automation_policy.sql` | 신규 | 2 테이블 + 2 인덱스 + trigger |
+| `packages/api/src/core/policy/types.ts` | 신규 | AutomationActionType + 2 인터페이스 |
+| `packages/api/src/core/policy/schemas/policy.ts` | 신규 | 3 Zod 스키마 |
+| `packages/api/src/core/policy/services/policy-engine.service.ts` | 신규 | PolicyEngine class |
+| `packages/api/src/core/policy/routes/index.ts` | 신규 | Hono sub-app, 2 endpoints |
+| `packages/api/src/core/policy/policy-engine.test.ts` | 신규 | TDD 4 test cases |
+| `packages/api/src/app.ts` | 수정 | /api/policy mount 1줄 + import |
+
+## §5 API 계약
+
+### POST /api/policy/evaluate
+Request: `{ orgId: string, actionType: AutomationActionType, context?: object }`
+Response 200: `{ allowed: boolean, reason: string, policyId: string|null, evaluatedAt: number }`
+
+### POST /api/policy/register
+Request: `{ orgId: string, actionType: AutomationActionType, allowed: boolean, reason?: string, metadata?: object }`
+Response 201: `{ id: string }`
+
+## §6 AuditBus 통합 계획
+
+```typescript
+// emit 호출 시 TraceContext 즉석 생성
+const ctx = {
+  traceId: generateTraceId(),
+  spanId: generateSpanId(),
+  sampled: true,
+};
+await this.auditBus.emit("policy.evaluated", payload, ctx);
+```
+
+## §7 D1 체크리스트 (Stage 3 Exit)
+
+- D1: 주입 사이트 전수 — PolicyEngine.evaluate + registerPolicy 2곳, app.ts 1줄
+- D2: ID 계약 — policy.id = crypto.randomUUID() (UUID v4)
+- D3: Breaking change 없음 (신규 도메인)
+- D4: TDD Red 파일 존재 → 아래 구현에서 확인

--- a/docs/04-report/sprint-355.report.md
+++ b/docs/04-report/sprint-355.report.md
@@ -1,0 +1,84 @@
+---
+code: FX-RPRT-355
+title: Sprint 355 — F631 자동화 정책 코드 강제 완료 보고서
+version: 1.0
+status: Completed
+category: REPORT
+created: 2026-05-06
+sprint: 355
+f_item: F631
+req: FX-REQ-696
+match_rate: 100%
+---
+
+# Sprint 355 — F631 자동화 정책 코드 강제 완료 보고서
+
+## §1 요약
+
+| 항목 | 결과 |
+|------|------|
+| F-item | F631 AI Foundry BeSir 흡수 4 · 분석X 자동화O 정책 코드 강제 |
+| Match Rate | **100%** (gap-detector 8/8 PASS) |
+| TDD | Red→Green 4 tests (T1~T4) |
+| typecheck | 회귀 0 (F631 파일 오류 없음) |
+| Codex verdict | BLOCK (false positive — FX-REQ-587~590 잘못된 PRD 컨텍스트, F631은 FX-REQ-696) |
+
+## §2 구현 산출물
+
+| 파일 | 분류 | 내용 |
+|------|------|------|
+| `packages/api/src/db/migrations/0143_automation_policy.sql` | 신규 | 2 테이블 + 2 인덱스 + append-only trigger |
+| `packages/api/src/core/policy/types.ts` | 신규 | AutomationActionType(5종) + PolicyEvaluation + PolicyViolation |
+| `packages/api/src/core/policy/schemas/policy.ts` | 신규 | 4 Zod 스키마 (ActionType + Register + Evaluate + Response) |
+| `packages/api/src/core/policy/services/policy-engine.service.ts` | 신규 | PolicyEngine: evaluate + registerPolicy |
+| `packages/api/src/core/policy/routes/index.ts` | 신규 | Hono sub-app: POST /evaluate + POST /register |
+| `packages/api/src/core/policy/policy-engine.test.ts` | 신규 | TDD 4 cases |
+| `packages/api/src/app.ts` | 수정 | import + app.route("/api/policy", policyApp) |
+| `docs/02-design/features/sprint-355.design.md` | 신규 | Design 문서 |
+
+## §3 핵심 설계 결정
+
+### whitelist + default-deny 패턴
+- `automation_policies` 테이블에 정책 없으면 **자동 거부** (default-deny)
+- `allowed = 1` 명시 등록 시만 허용 (whitelist)
+- `UNIQUE(org_id, action_type)` 제약으로 org별 단일 정책 보장
+
+### audit-bus 통합 (F606)
+- `policy.evaluated` — 모든 평가 시 발행 (allowed/denied 모두)
+- `policy.violation` — default-deny 또는 denied 시 추가 발행
+- `policy_violations` 테이블에 위반 이력 append-only 보관 (UPDATE trigger로 강제)
+
+### F615 Guard-X와 책임 분리
+- F631 = 정책 **정의** + 화이트리스트 (provider)
+- F615 = 정책 **평가** 엔진 + ULID+HMAC (consumer)
+
+## §4 Phase Exit P-a~P-l 현황
+
+| ID | 항목 | 판정 | 비고 |
+|----|------|:----:|------|
+| P-a | D1 migration 0143 적용 + 2 테이블 | 수동 필요 | production push 후 확인 |
+| P-b | core/policy/ 5+ files | ✅ | 6 files |
+| P-c | types.ts 3 export | ✅ | 4 export |
+| P-d | schemas/policy.ts 3 schema | ✅ | 4 schema |
+| P-e | PolicyEngine class | ✅ | evaluate + registerPolicy |
+| P-f | 2 endpoints | ✅ | /evaluate + /register |
+| P-g | 2 audit 이벤트 | ✅ | policy.evaluated + policy.violation |
+| P-h | app.ts mount | ✅ | /api/policy |
+| P-i | typecheck + tests GREEN | ✅ | 4/4 GREEN |
+| P-j | dual_ai_reviews 자동 INSERT | 수동 필요 | BLOCK verdict 저장 완료 |
+| P-k | baseline=0 회귀 | 수동 필요 | scripts/lint-baseline-check.sh |
+| P-l | API smoke 2 case | 수동 필요 | production merge 후 |
+
+## §5 Codex Review 기록
+
+- verdict: BLOCK, degraded: false
+- 원인: FX-REQ-587~590 잘못된 PRD context (F631은 FX-REQ-696)
+- prd_coverage.covered: [] (빈 배열 — context 실패 신호)
+- 처리: false positive로 판단, dual_ai_reviews 저장 후 Gap 100% + TDD 기준으로 진행
+- 향후: Codex review 스크립트의 sprint→PRD 매핑 개선 필요 (FX-REQ-696 컨텍스트 주입)
+
+## §6 교훈
+
+- PolicyEngine의 `Pick<AuditBus, "emit">` 타입 사용 → 테스트 시 간단한 vi.fn() mock 주입 가능
+- D1 mock 패턴 (audit-bus.test.ts 재현): `prepare().bind().first() / .run()` 체인 구조
+- 5-Asset Model 첫 번째 자산 'Policy' — T2 두 번째 sprint로 core/policy/ 도메인 확립

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -47,6 +47,7 @@ import { workPublicRoute } from "./core/work/routes/work-public.js";
 import { verificationRoute } from "./core/verification/routes/index.js";
 import { docsApp } from "./core/docs/routes/index.js";
 import { assetApp } from "./core/asset/routes/index.js";
+import { policyApp } from "./core/policy/routes/index.js";
 import { handleScheduled } from "./scheduled.js";
 import { authMiddleware } from "./middleware/auth.js";
 import { piiMaskerMiddleware } from "./middleware/pii-masker.middleware.js";
@@ -320,6 +321,9 @@ app.route("/api", workRoute);
 
 // Sprint 353: F629 5-Asset Model — System Knowledge (T1 토대)
 app.route("/api/asset", assetApp);
+
+// Sprint 355: F631 자동화 정책 코드 강제 (whitelist + default-deny)
+app.route("/api/policy", policyApp);
 
 // Sprint 47: PII masker middleware — AI API 경로에만 적용
 app.use("/api/agents/*", piiMaskerMiddleware);

--- a/packages/api/src/core/policy/policy-engine.test.ts
+++ b/packages/api/src/core/policy/policy-engine.test.ts
@@ -1,0 +1,83 @@
+// F631: PolicyEngine TDD Red Phase — whitelist + default-deny
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PolicyEngine } from "./services/policy-engine.service.js";
+import type { AutomationActionType } from "./types.js";
+
+function makeD1Mock(policyRow: unknown = null) {
+  let violationInsertCount = 0;
+  const mock = {
+    violationInsertCount: () => violationInsertCount,
+    prepare: vi.fn().mockImplementation((sql: string) => ({
+      bind: vi.fn().mockImplementation(() => ({
+        run: vi.fn().mockImplementation(() => {
+          if (sql.includes("policy_violations")) violationInsertCount++;
+          return Promise.resolve({ success: true });
+        }),
+        first: vi.fn().mockResolvedValue(policyRow),
+      })),
+    })),
+  };
+  return mock;
+}
+
+function makeAuditBusMock() {
+  return { emit: vi.fn().mockResolvedValue(undefined) };
+}
+
+describe("F631 PolicyEngine", () => {
+  const orgId = "org-test";
+  const allowedAction: AutomationActionType = "read_only";
+  const deniedAction: AutomationActionType = "state_change";
+
+  it("T1: whitelist 통과 — allowed=true 정책 → evaluate → allowed=true", async () => {
+    const db = makeD1Mock({ id: "pol-1", allowed: 1, reason: "읽기 허용" });
+    const bus = makeAuditBusMock();
+    const engine = new PolicyEngine(db as unknown as D1Database, bus as any);
+
+    const result = await engine.evaluate(orgId, allowedAction);
+
+    expect(result.allowed).toBe(true);
+    expect(result.policyId).toBe("pol-1");
+    expect(result.evaluatedAt).toBeGreaterThan(0);
+  });
+
+  it("T2: default-deny — 미등록 action_type → allowed=false + violation INSERT", async () => {
+    const db = makeD1Mock(null);
+    const bus = makeAuditBusMock();
+    const engine = new PolicyEngine(db as unknown as D1Database, bus as any);
+
+    const result = await engine.evaluate(orgId, deniedAction);
+
+    expect(result.allowed).toBe(false);
+    expect(result.policyId).toBeNull();
+    expect(result.reason).toMatch(/default-deny/);
+    expect(db.violationInsertCount()).toBeGreaterThanOrEqual(1);
+  });
+
+  it("T3: evaluate → policy.evaluated audit 이벤트 발행", async () => {
+    const db = makeD1Mock({ id: "pol-2", allowed: 1, reason: null });
+    const bus = makeAuditBusMock();
+    const engine = new PolicyEngine(db as unknown as D1Database, bus as any);
+
+    await engine.evaluate(orgId, allowedAction);
+
+    expect(bus.emit).toHaveBeenCalledWith(
+      "policy.evaluated",
+      expect.objectContaining({ orgId, actionType: allowedAction }),
+      expect.objectContaining({ traceId: expect.any(String) }),
+    );
+  });
+
+  it("T4: default-deny → policy.violation audit 이벤트 발행", async () => {
+    const db = makeD1Mock(null);
+    const bus = makeAuditBusMock();
+    const engine = new PolicyEngine(db as unknown as D1Database, bus as any);
+
+    await engine.evaluate(orgId, deniedAction);
+
+    const calls = (bus.emit as ReturnType<typeof vi.fn>).mock.calls;
+    const violationCall = calls.find((c: unknown[]) => c[0] === "policy.violation");
+    expect(violationCall).toBeDefined();
+    expect(violationCall?.[1]).toMatchObject({ orgId, actionType: deniedAction });
+  });
+});

--- a/packages/api/src/core/policy/routes/index.ts
+++ b/packages/api/src/core/policy/routes/index.ts
@@ -1,0 +1,34 @@
+import { Hono } from "hono";
+import { AuditBus } from "../../infra/audit-bus.js";
+import { PolicyEngine } from "../services/policy-engine.service.js";
+import { EvaluatePolicySchema, RegisterPolicySchema } from "../schemas/policy.js";
+import type { Env } from "../../../env.js";
+
+export const policyApp = new Hono<{ Bindings: Env }>();
+
+function getEngine(env: Env): PolicyEngine {
+  const bus = new AuditBus(env.DB, env.AUDIT_HMAC_KEY ?? "default-hmac-key-32chars-pad");
+  return new PolicyEngine(env.DB, bus);
+}
+
+policyApp.post("/evaluate", async (c) => {
+  const body = await c.req.json();
+  const parsed = EvaluatePolicySchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: parsed.error.issues }, 400);
+  }
+  const engine = getEngine(c.env);
+  const result = await engine.evaluate(parsed.data.orgId, parsed.data.actionType, parsed.data.context);
+  return c.json(result, 200);
+});
+
+policyApp.post("/register", async (c) => {
+  const body = await c.req.json();
+  const parsed = RegisterPolicySchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: parsed.error.issues }, 400);
+  }
+  const engine = getEngine(c.env);
+  const result = await engine.registerPolicy(parsed.data);
+  return c.json(result, 201);
+});

--- a/packages/api/src/core/policy/schemas/policy.ts
+++ b/packages/api/src/core/policy/schemas/policy.ts
@@ -1,0 +1,31 @@
+import { z } from "@hono/zod-openapi";
+import { AUTOMATION_ACTION_TYPES } from "../types.js";
+
+export const AutomationActionTypeSchema = z.enum(AUTOMATION_ACTION_TYPES);
+
+export const RegisterPolicySchema = z
+  .object({
+    orgId: z.string().min(1),
+    actionType: AutomationActionTypeSchema,
+    allowed: z.boolean(),
+    reason: z.string().optional(),
+    metadata: z.record(z.unknown()).optional(),
+  })
+  .openapi("RegisterPolicy");
+
+export const EvaluatePolicySchema = z
+  .object({
+    orgId: z.string().min(1),
+    actionType: AutomationActionTypeSchema,
+    context: z.record(z.unknown()).optional(),
+  })
+  .openapi("EvaluatePolicy");
+
+export const PolicyEvaluationResponseSchema = z
+  .object({
+    allowed: z.boolean(),
+    reason: z.string(),
+    policyId: z.string().nullable(),
+    evaluatedAt: z.number(),
+  })
+  .openapi("PolicyEvaluationResponse");

--- a/packages/api/src/core/policy/services/policy-engine.service.ts
+++ b/packages/api/src/core/policy/services/policy-engine.service.ts
@@ -1,0 +1,24 @@
+// stub — TDD Red Phase
+import type { AutomationActionType, PolicyEvaluation } from "../types.js";
+
+export class PolicyEngine {
+  constructor(_db: D1Database, _auditBus: unknown) {}
+
+  async evaluate(
+    _orgId: string,
+    _actionType: AutomationActionType,
+    _context: Record<string, unknown> = {},
+  ): Promise<PolicyEvaluation> {
+    throw new Error("not implemented");
+  }
+
+  async registerPolicy(_input: {
+    orgId: string;
+    actionType: AutomationActionType;
+    allowed: boolean;
+    reason?: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<{ id: string }> {
+    throw new Error("not implemented");
+  }
+}

--- a/packages/api/src/core/policy/services/policy-engine.service.ts
+++ b/packages/api/src/core/policy/services/policy-engine.service.ts
@@ -1,24 +1,77 @@
-// stub — TDD Red Phase
+import { AuditBus, generateTraceId, generateSpanId } from "../../infra/audit-bus.js";
 import type { AutomationActionType, PolicyEvaluation } from "../types.js";
 
 export class PolicyEngine {
-  constructor(_db: D1Database, _auditBus: unknown) {}
+  constructor(
+    private readonly db: D1Database,
+    private readonly auditBus: Pick<AuditBus, "emit">,
+  ) {}
 
   async evaluate(
-    _orgId: string,
-    _actionType: AutomationActionType,
-    _context: Record<string, unknown> = {},
+    orgId: string,
+    actionType: AutomationActionType,
+    context: Record<string, unknown> = {},
   ): Promise<PolicyEvaluation> {
-    throw new Error("not implemented");
+    const row = await this.db
+      .prepare(
+        `SELECT id, allowed, reason FROM automation_policies WHERE org_id = ? AND action_type = ?`,
+      )
+      .bind(orgId, actionType)
+      .first<{ id: string; allowed: number; reason: string | null }>();
+
+    const allowed = row?.allowed === 1;
+    const reason =
+      row?.reason ?? (row ? "denied by policy" : "default-deny: no policy registered");
+    const policyId = row?.id ?? null;
+    const evaluatedAt = Date.now();
+
+    const ctx = { traceId: generateTraceId(), spanId: generateSpanId(), sampled: true };
+
+    await this.auditBus.emit("policy.evaluated", { orgId, actionType, allowed, policyId, context }, ctx);
+
+    if (!allowed) {
+      const violationId = crypto.randomUUID();
+      await this.db
+        .prepare(
+          `INSERT INTO policy_violations (id, org_id, action_type, reason, metadata)
+           VALUES (?, ?, ?, ?, ?)`,
+        )
+        .bind(violationId, orgId, actionType, reason, JSON.stringify(context))
+        .run();
+
+      await this.auditBus.emit("policy.violation", { violationId, orgId, actionType, reason }, ctx);
+    }
+
+    return { allowed, reason, policyId, evaluatedAt };
   }
 
-  async registerPolicy(_input: {
+  async registerPolicy(input: {
     orgId: string;
     actionType: AutomationActionType;
     allowed: boolean;
     reason?: string;
     metadata?: Record<string, unknown>;
   }): Promise<{ id: string }> {
-    throw new Error("not implemented");
+    const id = crypto.randomUUID();
+    await this.db
+      .prepare(
+        `INSERT INTO automation_policies (id, org_id, action_type, allowed, reason, metadata)
+         VALUES (?, ?, ?, ?, ?, ?)
+         ON CONFLICT (org_id, action_type) DO UPDATE SET
+           allowed = excluded.allowed,
+           reason = excluded.reason,
+           metadata = excluded.metadata,
+           updated_at = unixepoch('now') * 1000`,
+      )
+      .bind(
+        id,
+        input.orgId,
+        input.actionType,
+        input.allowed ? 1 : 0,
+        input.reason ?? null,
+        JSON.stringify(input.metadata ?? {}),
+      )
+      .run();
+    return { id };
   }
 }

--- a/packages/api/src/core/policy/types.ts
+++ b/packages/api/src/core/policy/types.ts
@@ -1,0 +1,29 @@
+export const AUTOMATION_ACTION_TYPES = [
+  "read_only",
+  "data_query",
+  "state_change",
+  "external_api_call",
+  "destructive_op",
+] as const;
+
+export type AutomationActionType = (typeof AUTOMATION_ACTION_TYPES)[number];
+
+export interface PolicyEvaluation {
+  allowed: boolean;
+  reason: string;
+  policyId: string | null;
+  evaluatedAt: number;
+}
+
+export interface PolicyViolation {
+  id: string;
+  orgId: string;
+  actionType: AutomationActionType;
+  attemptedBy: string | null;
+  reason: string;
+  traceId: string | null;
+  createdAt: number;
+}
+
+export { PolicyEngine } from "./services/policy-engine.service.js";
+export * from "./schemas/policy.js";

--- a/packages/api/src/db/migrations/0143_automation_policy.sql
+++ b/packages/api/src/db/migrations/0143_automation_policy.sql
@@ -1,0 +1,35 @@
+-- F631: 분析X 자동화O 정책 코드 (whitelist + default-deny)
+
+CREATE TABLE automation_policies (
+  id TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL,
+  action_type TEXT NOT NULL,
+  allowed INTEGER NOT NULL DEFAULT 0,
+  reason TEXT,
+  metadata TEXT,
+  created_by TEXT,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch('now') * 1000),
+  updated_at INTEGER NOT NULL DEFAULT (unixepoch('now') * 1000),
+
+  CHECK (action_type IN ('read_only','data_query','state_change','external_api_call','destructive_op')),
+  CHECK (allowed IN (0, 1)),
+  UNIQUE (org_id, action_type)
+);
+
+CREATE INDEX idx_automation_policies_org ON automation_policies(org_id);
+
+CREATE TABLE policy_violations (
+  id TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL,
+  action_type TEXT NOT NULL,
+  attempted_by TEXT,
+  reason TEXT NOT NULL,
+  trace_id TEXT,
+  metadata TEXT,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch('now') * 1000)
+);
+
+CREATE INDEX idx_policy_violations_org_created ON policy_violations(org_id, created_at DESC);
+
+CREATE TRIGGER policy_violations_no_update BEFORE UPDATE ON policy_violations
+BEGIN SELECT RAISE(FAIL, 'policy_violations is append-only'); END;


### PR DESCRIPTION
## Sprint 355 — F631 자동화 정책 코드 강제

### F-items
F631 (FX-REQ-696, P2) — AI Foundry BeSir 흡수 4 · whitelist + default-deny 정책 코드 강제

### 구현 산출물
- `core/policy/` 신규 도메인 (types + schemas + services + routes)
- D1 migration `0143_automation_policy.sql` (automation_policies + policy_violations)
- PolicyEngine: evaluate (whitelist/default-deny) + registerPolicy
- POST /api/policy/evaluate + POST /api/policy/register
- F606 audit-bus 통합: policy.evaluated + policy.violation 이벤트
- TDD 4 tests: T1 whitelist, T2 default-deny, T3~T4 audit 이벤트

### Match Rate
100% (gap-detector 8/8 PASS)

### Tests
4/4 GREEN (vitest)

---
🤖 Auto-generated from Sprint autopilot

<!-- fx-pr-enrich -->
### Sprint Metadata
- Sprint: 355
- F-items: F631
- Match Rate: 100%
<!-- /fx-pr-enrich -->