### PR TITLE
fix(api): AuditBus empty-key CI blocker — 14 sprint master deploy 회복

### DIFF
--- a/packages/api/src/__tests__/biz-items-sixhats.test.ts
+++ b/packages/api/src/__tests__/biz-items-sixhats.test.ts
@@ -122,6 +122,19 @@ const BIZ_TABLES_SQL = `
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     UNIQUE(debate_id, turn_number)
   );
+  CREATE TABLE IF NOT EXISTS audit_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    trace_id TEXT NOT NULL,
+    span_id TEXT NOT NULL,
+    parent_span_id TEXT,
+    event_type TEXT NOT NULL,
+    timestamp INTEGER NOT NULL,
+    tenant_id TEXT,
+    actor TEXT,
+    payload TEXT NOT NULL,
+    hmac_signature TEXT NOT NULL,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch('now') * 1000)
+  );
 `;
 
 function seedBizItem(id = "item-1") {

--- a/packages/api/src/__tests__/helpers/test-app.ts
+++ b/packages/api/src/__tests__/helpers/test-app.ts
@@ -43,6 +43,7 @@ export function createTestEnv() {
     GITHUB_REPO: "KTDS-AXBD/Foundry-X",
     CACHE: new MockKVNamespace() as unknown as KVNamespace,
     AI: {} as Ai,
+    AUDIT_HMAC_KEY: "test-hmac-key-32-chars-padding",
   };
 }
 

--- a/packages/api/src/core/discovery/routes/biz-items.ts
+++ b/packages/api/src/core/discovery/routes/biz-items.ts
@@ -881,7 +881,7 @@ bizItemsRoute.post("/biz-items/:id/prd/:prdId/sixhats", async (c) => {
 
   const sixhatsPolicy = new SixHatsLLMPolicy(
     new KVCacheService(c.env.CACHE),
-    new AuditBus(c.env.DB, c.env.AUDIT_HMAC_KEY ?? ""),
+    new AuditBus(c.env.DB, c.env.AUDIT_HMAC_KEY ?? "default-hmac-key-32chars-pad"),
   );
   const service = new SixHatsDebateService(c.env.DB, c.env, sixhatsPolicy);
   try {

--- a/packages/api/src/core/infra/audit-bus.ts
+++ b/packages/api/src/core/infra/audit-bus.ts
@@ -60,6 +60,12 @@ export class AuditBus {
     private readonly db: D1Database,
     hmacKey: string,
   ) {
+    if (!hmacKey || hmacKey.length === 0) {
+      throw new Error(
+        "AuditBus: hmacKey must be a non-empty string. " +
+          "Set AUDIT_HMAC_KEY env var or pass an explicit fallback at call site.",
+      );
+    }
     this.keyPromise = crypto.subtle.importKey(
       "raw",
       new TextEncoder().encode(hmacKey),


### PR DESCRIPTION
## TL;DR
**P0 CI blocker fix.** F624 (Sprint 356 cherry-pick)에서 `biz-items.ts:884` AuditBus 주입의 fallback이 빈 문자열(`?? ""`)이라 테스트 환경에서 `crypto.subtle.importKey` zero-length key 에러를 발생. 결과: **Sprint 355 (2026-05-06 06:52)부터 14 master deploy 연속 실패**, production Workers가 Sprint 354 시점 코드로 고착.

## Root cause

10개 호출 사이트 vs 1개 outlier:

```ts
// 10 곳 (정상 컨벤션)
new AuditBus(env.DB, env.AUDIT_HMAC_KEY ?? "default-hmac-key-32chars-pad")

// biz-items.ts:884 (outlier — 본 PR fix 대상)
new AuditBus(c.env.DB, c.env.AUDIT_HMAC_KEY ?? "")
```

`createTestEnv()`에는 `AUDIT_HMAC_KEY` 자체가 없어서 fallback 트리거 → 빈 키 → `DataError: Zero-length key is not supported` at `crypto.subtle.importKey`.

## 영향 (silent fail history)
| Sprint | F-item | Deploy |
|:------:|--------|:------:|
| 355 | F631 PolicyEngine | ❌ 첫 실패 |
| 357 | F602 4대 진단 PoC | ❌ |
| 358 | F632 CQ 5축 | ❌ |
| 360 | F615 Guard-X Solo | ❌ |
| 361 | F616 Launch-X Solo | ❌ |
| 362 | F623 cherry-pick | ❌ |
| 363 | F603 Cross-Org default-deny | ❌ |
| 365 | F617 Guard-X Integration | ❌ |
| 366 | F618 Launch-X Integration | ❌ |
| — | S336 PR #765 content sync | ❌ |

→ S335 "17 sprint 시동 신기록"의 master 안착 13건 중 다수가 Workers production에 배포되지 않음. `wrangler tail` 또는 deployed code version 검증 권장.

## Changes (4 files)
1. **biz-items.ts:884** — `?? ""` → `?? "default-hmac-key-32chars-pad"` (컨벤션 정합)
2. **__tests__/helpers/test-app.ts** — `createTestEnv()`에 `AUDIT_HMAC_KEY: "test-hmac-key-32-chars-padding"` 주입
3. **__tests__/biz-items-sixhats.test.ts** — `BIZ_TABLES_SQL`에 `audit_events` 테이블 DDL 추가
4. **core/infra/audit-bus.ts** — 생성자에 빈 키 early throw (silent DataError → clear Error 메시지)

## Verification
- ✅ `vitest run biz-items-sixhats.test.ts` 0→**7/7 PASS**
- ✅ 전체 api 스위트 **2355/2355 PASS**
- ✅ `turbo typecheck --filter=@foundry-x/api` PASS

## 후속 권장 (out of scope)
- F624 도입 시 PR review에서 outlier fallback 못 잡은 점 → ESLint custom rule 추가 검토
- 14 sprint silent CI 실패 누적 → master deploy 실패 알림 강화 (현재는 GitHub email만)
- production Workers 배포 본 PR merge 후 즉시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)