### PR TITLE
fix(api): types↔schemas barrel 순환 import 사전 차단 — 6 도메인 (S336)

### DIFF
--- a/packages/api/src/core/asset/types.ts
+++ b/packages/api/src/core/asset/types.ts
@@ -40,4 +40,6 @@ export type Asset = SystemKnowledgeAsset;
 export { SystemKnowledgeService } from "./services/system-knowledge.service.js";
 export { DomainInitService } from "./services/domain-init.service.js";
 export type { DomainInitInput, DomainInitResult, DomainScaffold } from "./services/domain-init.service.js";
-export * from "./schemas/asset.js";
+// NOTE: schemas/asset.js 의 z.enum(ASSET_TYPES/SYSTEM_KNOWLEDGE_CONTENT_TYPES) 가 이 파일을
+// import 하므로 여기서 re-export 하면 순환 import → const=undefined 위험 (S336 entity 선례).
+// schemas 심볼은 호출자가 "./schemas/asset.js" 에서 직접 import.

--- a/packages/api/src/core/cq/types.ts
+++ b/packages/api/src/core/cq/types.ts
@@ -58,4 +58,6 @@ export interface ReviewCycleResult {
 
 export { CQEvaluator } from "./services/cq-evaluator.service.js";
 export { ReviewCycle } from "./services/review-cycle.service.js";
-export * from "./schemas/cq.js";
+// NOTE: schemas/cq.js 의 z.enum(CQ_AXES/REVIEW_CYCLE_STAGES) 가 이 파일을 import 하므로
+// 여기서 re-export 하면 순환 import → const=undefined 위험 (S336 entity 선례).
+// schemas 심볼은 호출자가 "./schemas/cq.js" 에서 직접 import.

--- a/packages/api/src/core/cross-org/types.ts
+++ b/packages/api/src/core/cross-org/types.ts
@@ -47,4 +47,6 @@ export interface GroupStats {
 }
 
 export { CrossOrgEnforcer } from "./services/cross-org-enforcer.service.js";
-export * from "./schemas/cross-org.js";
+// NOTE: schemas/cross-org.js 의 z.enum(CROSS_ORG_GROUPS/ASSET_KINDS/EXPORT_BLOCK_REASONS) 가
+// 이 파일을 import 하므로 여기서 re-export 하면 순환 import → const=undefined 위험
+// (S336 entity 선례). schemas 심볼은 호출자가 "./schemas/cross-org.js" 에서 직접 import.

--- a/packages/api/src/core/diagnostic/types.ts
+++ b/packages/api/src/core/diagnostic/types.ts
@@ -28,4 +28,6 @@ export interface DiagnosticReport {
 }
 
 export { DiagnosticEngine } from "./services/diagnostic-engine.service.js";
-export * from "./schemas/diagnostic.js";
+// NOTE: schemas/diagnostic.js 의 z.enum(DIAGNOSTIC_TYPES/SEVERITIES) 가 이 파일을 import 하므로
+// 여기서 re-export 하면 순환 import → const=undefined 위험 (S336 entity 선례).
+// schemas 심볼은 호출자가 "./schemas/diagnostic.js" 에서 직접 import.

--- a/packages/api/src/core/ethics/types.ts
+++ b/packages/api/src/core/ethics/types.ts
@@ -37,4 +37,6 @@ export interface FPRateResult {
 }
 
 export { EthicsEnforcer } from "./services/ethics-enforcer.service.js";
-export * from "./schemas/ethics.js";
+// NOTE: schemas/ethics.js 의 z.enum(ETHICS_VIOLATION_TYPES) 가 이 파일을 import 하므로
+// 여기서 re-export 하면 순환 import → ETHICS_VIOLATION_TYPES=undefined 위험 (S336 entity 선례).
+// schemas 심볼은 호출자가 "./schemas/ethics.js" 에서 직접 import.

--- a/packages/api/src/core/policy/types.ts
+++ b/packages/api/src/core/policy/types.ts
@@ -26,4 +26,6 @@ export interface PolicyViolation {
 }
 
 export { PolicyEngine } from "./services/policy-engine.service.js";
-export * from "./schemas/policy.js";
+// NOTE: schemas/policy.js 의 z.enum(AUTOMATION_ACTION_TYPES) 가 이 파일을 import 하므로
+// 여기서 re-export 하면 순환 import → AUTOMATION_ACTION_TYPES=undefined 위험 (S336 entity 선례).
+// schemas 심볼은 호출자가 "./schemas/policy.js" 에서 직접 import.


### PR DESCRIPTION
## Summary
S336 entity 도메인에서 발견된 순환 import 안티패턴을 시스템적으로 전수 조사한 결과, 동일 시한폭탄 **6개 도메인** 발견 → 사전 차단.

## 안티패턴
1. `core/{domain}/types.ts` 가 const enum array export (`export const X = [...] as const`)
2. 같은 파일이 `export * from "./schemas/{domain}.js"` 로 schema barrel
3. `schemas/{domain}.ts` 가 const 를 `import { X } from "../types.js"` → `z.enum(X)` 사용

→ 모듈 평가 순서가 schemas 먼저 들어가면 const=undefined → `z.enum(undefined)` → OpenAPI 스펙 생성 시 HTTP 500.

## 처리 대상 (6 도메인)
| 도메인 | const | schema barrel 의존 외부 caller |
|--------|-------|-----|
| policy | AUTOMATION_ACTION_TYPES | 0 (안전 제거) |
| ethics | ETHICS_VIOLATION_TYPES | 0 |
| diagnostic | DIAGNOSTIC_TYPES, SEVERITIES | 0 |
| asset | ASSET_TYPES, SYSTEM_KNOWLEDGE_CONTENT_TYPES | 0 |
| cq | CQ_AXES, REVIEW_CYCLE_STAGES | 0 |
| cross-org | CROSS_ORG_GROUPS, ASSET_KINDS, EXPORT_BLOCK_REASONS | 0 |

각 도메인의 schema 심볼(`*Schema`)을 types.ts barrel 경유로 import 하는 외부 caller가 0건임을 grep으로 사전 검증 → `export * from "./schemas/..."` 제거 안전.

## 왜 entity 만 깨졌나
import 순서가 우연히 `schemas → types` 로 들어가는 entry point가 entity에만 존재 (`app.ts → entity/routes → schemas/entity.ts → types.ts 재진입`). 다른 6 도메인은 우연히 `types → schemas` 순서만 있어서 silent 동작 → 향후 import 순서 한 줄 바뀌면 동일 500.

## Test plan
- [x] `vitest openapi-spec.test.ts` 2/2 PASS (S336 회귀 테스트가 모든 ZodEnum.values 검증)
- [x] 전체 api 스위트 **2362/2362 PASS**
- [x] typecheck PASS
- [ ] CI auto-merge 후 prod `/api/openapi.json` 200 유지

## 후속 권장 (out of scope)
- **ESLint custom rule**: `export * from "./schemas/..."` + 동일 파일 `as const` 배열 동시 발견 시 error
- **다른 packages 점검**: fx-discovery, fx-shaping, fx-offering, fx-agent, modules/portal — 동일 패턴 audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)