### PR TITLE
feat(api): ESLint rule no-types-schema-barrel — 순환 import 시한폭탄 영구 차단 (S336)

### DIFF
--- a/packages/api/eslint.config.js
+++ b/packages/api/eslint.config.js
@@ -23,6 +23,8 @@ export default tseslint.config(
       'foundry-x-api/use-model-ssot': 'error',
       // C75: D1 크로스도메인 테이블 접근 차단 (forward-only, 기존 23건 위반은 별도 fix PR)
       'foundry-x-api/no-cross-domain-d1': 'warn',
+      // S336: types.ts 의 schemas barrel re-export 차단 (순환 import → openapi.json 500 시한폭탄)
+      'foundry-x-api/no-types-schema-barrel': 'error',
     },
   },
   {

--- a/packages/api/src/core/docs/types.ts
+++ b/packages/api/src/core/docs/types.ts
@@ -1,2 +1,3 @@
 export { ShardDocService } from "./services/shard-doc.js";
-export * from "./schemas/shard-doc.js";
+// NOTE: schemas barrel re-export 금지 (S336 — foundry-x-api/no-types-schema-barrel).
+// schemas 심볼은 호출자가 "./schemas/shard-doc.js" 에서 직접 import.

--- a/packages/api/src/core/guard/types.ts
+++ b/packages/api/src/core/guard/types.ts
@@ -81,4 +81,5 @@ export interface GuardDecisionRecord {
 export { GuardEngine } from "./services/guard-engine.service.js";
 export { WorkflowHookService } from "./services/workflow-hook.service.js";
 export { RuleEngine } from "./services/rule-engine.service.js";
-export * from "./schemas/guard.js";
+// NOTE: schemas barrel re-export 금지 (S336 — foundry-x-api/no-types-schema-barrel).
+// schemas 심볼은 호출자가 "./schemas/guard.js" 에서 직접 import.

--- a/packages/api/src/core/launch/types.ts
+++ b/packages/api/src/core/launch/types.ts
@@ -72,4 +72,5 @@ export { LaunchEngine } from "./services/launch-engine.service.js";
 export { SkillRegistryService } from "./services/skill-registry.service.js";
 export { ObjectStoreService } from "./services/object-store.service.js";
 export { RollbackService } from "./services/rollback.service.js";
-export * from "./schemas/launch.js";
+// NOTE: schemas barrel re-export 금지 (S336 — foundry-x-api/no-types-schema-barrel).
+// schemas 심볼은 호출자가 "./schemas/launch.js" 에서 직접 import.

--- a/packages/api/src/eslint-rules/index.mjs
+++ b/packages/api/src/eslint-rules/index.mjs
@@ -1,6 +1,7 @@
 import { noCrossDomainD1 } from './no-cross-domain-d1.mjs';
 import { noCrossDomainImport } from './no-cross-domain-import.mjs';
 import { noDirectRouteRegister } from './no-direct-route-register.mjs';
+import { noTypesSchemaBarrel } from './no-types-schema-barrel.mjs';
 import { useModelSsot } from './use-model-ssot.mjs';
 
 export const foundryXApiPlugin = {
@@ -9,6 +10,7 @@ export const foundryXApiPlugin = {
     'no-cross-domain-d1': noCrossDomainD1,
     'no-cross-domain-import': noCrossDomainImport,
     'no-direct-route-register': noDirectRouteRegister,
+    'no-types-schema-barrel': noTypesSchemaBarrel,
     'use-model-ssot': useModelSsot,
   },
 };

--- a/packages/api/src/eslint-rules/no-types-schema-barrel.mjs
+++ b/packages/api/src/eslint-rules/no-types-schema-barrel.mjs
@@ -1,0 +1,54 @@
+// S336: types.ts 에서 schemas barrel re-export 차단
+//
+// 안티패턴:
+//   core/{domain}/types.ts:
+//     export const FOO_TYPES = [...] as const;            // ① const enum 배열
+//     export * from "./schemas/{domain}.js";              // ② schemas barrel
+//   core/{domain}/schemas/{domain}.ts:
+//     import { FOO_TYPES } from "../types.js";            // ③ const import
+//     z.enum(FOO_TYPES)                                   // ④ enum 사용
+//
+// 평가 순서가 우연히 schemas → types 로 들어가면 ② 재진입 시점에 ① 가 아직 평가 전 →
+// FOO_TYPES = undefined → z.enum(undefined) → ZodEnum._def.values=undefined →
+// OpenAPI 스펙 생성 시 `joinValues(undefined).map(...)` TypeError → /api/openapi.json HTTP 500.
+//
+// 실제 사례 (S336):
+//   - F628 entity 도메인이 14 sprint silent fail 끝에 production 500 surface
+//   - 같은 시한폭탄 6 도메인 (policy/ethics/diagnostic/asset/cq/cross-org) 사전 발견
+//
+// Fix: schemas 는 항상 호출자가 "./schemas/{file}" 에서 직접 import (barrel re-export 금지).
+
+const SCHEMAS_PATH_RE = /^\.\/schemas(\/|$)/;
+
+export const noTypesSchemaBarrel = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'In core/**/types.ts, disallow `export * from "./schemas/..."`. Such barrel re-export creates a circular dependency with schemas/ files that import const arrays from types.ts (z.enum(undefined) at module evaluation time → /api/openapi.json HTTP 500).',
+    },
+    messages: {
+      noBarrel:
+        'types.ts 에서 `export * from "{{source}}"` 금지: schemas 가 types.ts 의 const 를 import 하면 순환 import → 평가 시점에 const=undefined → z.enum(undefined) → /api/openapi.json HTTP 500 위험 (S336 entity 선례). schemas 는 호출자가 "./schemas/{file}" 에서 직접 import.',
+    },
+    schema: [],
+  },
+  create(context) {
+    const filename = context.filename;
+    // types.ts 파일에만 적용 (Windows 경로 호환)
+    if (!filename.endsWith('/types.ts') && !filename.endsWith('\\types.ts')) return {};
+
+    return {
+      ExportAllDeclaration(node) {
+        const source = node.source && typeof node.source.value === 'string' ? node.source.value : '';
+        // ./schemas 또는 ./schemas/... 만 차단
+        if (!SCHEMAS_PATH_RE.test(source)) return;
+        context.report({
+          node,
+          messageId: 'noBarrel',
+          data: { source },
+        });
+      },
+    };
+  },
+};

--- a/packages/api/src/eslint-rules/no-types-schema-barrel.test.ts
+++ b/packages/api/src/eslint-rules/no-types-schema-barrel.test.ts
@@ -1,0 +1,82 @@
+// S336 no-types-schema-barrel ESLint 룰 단위 테스트
+// ESLint v9+ RuleTester는 전역 describe/it을 감지하여 개별 테스트를 등록함
+import { RuleTester } from 'eslint';
+import { describe } from 'vitest';
+import { noTypesSchemaBarrel } from './no-types-schema-barrel.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+});
+
+describe('S336 foundry-x-api/no-types-schema-barrel', () => {
+  ruleTester.run('no-types-schema-barrel', noTypesSchemaBarrel, {
+    valid: [
+      // types.ts 가 아닌 파일은 검사 대상 외
+      {
+        code: 'export * from "./schemas/foo.js";',
+        filename: '/project/src/index.ts',
+      },
+      {
+        code: 'export * from "./schemas/foo.js";',
+        filename: '/project/src/core/discovery/routes/biz-items.ts',
+      },
+      // types.ts 지만 schemas 가 아닌 다른 경로의 barrel 은 허용
+      {
+        code: 'export * from "./services/registry.js";',
+        filename: '/project/src/core/entity/types.ts',
+      },
+      {
+        code: 'export * from "../shared.js";',
+        filename: '/project/src/core/entity/types.ts',
+      },
+      // types.ts 에서 const 만 export — 안전
+      {
+        code: 'export const FOO_TYPES = ["a", "b"];',
+        filename: '/project/src/core/entity/types.ts',
+      },
+      // types.ts 에서 명시적 named import (barrel 아님)
+      {
+        code: 'export { FooSchema } from "./schemas/foo.js";',
+        filename: '/project/src/core/entity/types.ts',
+      },
+    ],
+    invalid: [
+      // 정확한 안티패턴 — types.ts 에서 ./schemas barrel
+      {
+        code: 'export * from "./schemas/entity.js";',
+        filename: '/project/src/core/entity/types.ts',
+        errors: [{ messageId: 'noBarrel' }],
+      },
+      {
+        code: 'export * from "./schemas/policy.js";',
+        filename: '/project/src/core/policy/types.ts',
+        errors: [{ messageId: 'noBarrel' }],
+      },
+      // 확장자 없는 형태도 차단
+      {
+        code: 'export * from "./schemas/foo";',
+        filename: '/project/src/core/asset/types.ts',
+        errors: [{ messageId: 'noBarrel' }],
+      },
+      // 하위 디렉토리도 차단 (./schemas/sub/bar)
+      {
+        code: 'export * from "./schemas/sub/bar.js";',
+        filename: '/project/src/core/cq/types.ts',
+        errors: [{ messageId: 'noBarrel' }],
+      },
+      // 다른 export 와 섞여 있어도 ./schemas barrel 만 정확히 잡음
+      {
+        code: [
+          'export const FOO = [];',
+          'export { Service } from "./services/foo.js";',
+          'export * from "./schemas/foo.js";',
+        ].join('\n'),
+        filename: '/project/src/core/entity/types.ts',
+        errors: [{ messageId: 'noBarrel' }],
+      },
+    ],
+  });
+});

--- a/packages/api/src/eslint-rules/no-types-schema-barrel.ts
+++ b/packages/api/src/eslint-rules/no-types-schema-barrel.ts
@@ -1,0 +1,56 @@
+import type { Rule } from 'eslint';
+
+// S336: types.ts 에서 schemas barrel re-export 차단
+//
+// 안티패턴:
+//   core/{domain}/types.ts:
+//     export const FOO_TYPES = [...] as const;            // ① const enum 배열
+//     export * from "./schemas/{domain}.js";              // ② schemas barrel
+//   core/{domain}/schemas/{domain}.ts:
+//     import { FOO_TYPES } from "../types.js";            // ③ const import
+//     z.enum(FOO_TYPES)                                   // ④ enum 사용
+//
+// 평가 순서가 우연히 schemas → types 로 들어가면 ② 재진입 시점에 ① 가 아직 평가 전 →
+// FOO_TYPES = undefined → z.enum(undefined) → ZodEnum._def.values=undefined →
+// OpenAPI 스펙 생성 시 `joinValues(undefined).map(...)` TypeError → /api/openapi.json HTTP 500.
+//
+// 실제 사례 (S336):
+//   - F628 entity 도메인이 14 sprint silent fail 끝에 production 500 surface
+//   - 같은 시한폭탄 6 도메인 (policy/ethics/diagnostic/asset/cq/cross-org) 사전 발견
+//
+// Fix: schemas 는 항상 호출자가 "./schemas/{file}" 에서 직접 import (barrel re-export 금지).
+
+const SCHEMAS_PATH_RE = /^\.\/schemas(\/|$)/;
+
+export const noTypesSchemaBarrel: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'In core/**/types.ts, disallow `export * from "./schemas/..."`. Such barrel re-export creates a circular dependency with schemas/ files that import const arrays from types.ts (z.enum(undefined) at module evaluation time → /api/openapi.json HTTP 500).',
+    },
+    messages: {
+      noBarrel:
+        'types.ts 에서 `export * from "{{source}}"` 금지: schemas 가 types.ts 의 const 를 import 하면 순환 import → 평가 시점에 const=undefined → z.enum(undefined) → /api/openapi.json HTTP 500 위험 (S336 entity 선례). schemas 는 호출자가 "./schemas/{file}" 에서 직접 import.',
+    },
+    schema: [],
+  },
+  create(context) {
+    const filename = context.filename;
+    // types.ts 파일에만 적용 (Windows 경로 호환)
+    if (!filename.endsWith('/types.ts') && !filename.endsWith('\\types.ts')) return {};
+
+    return {
+      ExportAllDeclaration(node) {
+        const source = node.source && typeof node.source.value === 'string' ? node.source.value : '';
+        // ./schemas 또는 ./schemas/... 만 차단
+        if (!SCHEMAS_PATH_RE.test(source)) return;
+        context.report({
+          node,
+          messageId: 'noBarrel',
+          data: { source },
+        });
+      },
+    };
+  },
+};


### PR DESCRIPTION
## Summary
S336 entity 도메인 production 장애 ([HTTP 500 fix #769](https://github.com/KTDS-AXBD/Foundry-X/pull/769))의 근본 원인이었던 `types.ts ↔ schemas/` 순환 import 안티패턴을 **ESLint 룰로 영구 차단**.

## 새 룰
**`foundry-x-api/no-types-schema-barrel`** (severity: error)

- 대상: `**/types.ts` 파일
- 검출: `export * from \"./schemas/...\"` 패턴
- 메시지: 한국어로 명확한 fix 가이드 + S336 선례 링크

## 왜 필요한가
사후 fix 6 도메인 (PR #770) + 본 PR 3 도메인 = 9 도메인 모두 정리했지만, **미래 신규 도메인이 같은 패턴 반복할 위험**이 잔존:

```ts
// 신규 도메인 추가 시 흔히 작성하는 패턴 (위험!)
export const NEW_TYPES = [\"a\", \"b\"] as const;
export * from \"./schemas/new.js\";  // ← schemas 가 NEW_TYPES import 시 시한폭탄
```

ESLint 룰 활성화 후 PR CI에서 자동 차단 → entity 사례 (14 sprint silent fail) 재발 불가.

## 동시 처리 — 잔존 3 도메인 fix
룰 활성화로 추가 검출된 3 도메인 (이전 점검에서 const 없어 'safe' 분류):

| 도메인 | 처리 |
|--------|------|
| `core/docs/types.ts` | `export * from \"./schemas/shard-doc.js\"` 제거 |
| `core/guard/types.ts` | `export * from \"./schemas/guard.js\"` 제거 |
| `core/launch/types.ts` | `export * from \"./schemas/launch.js\"` 제거 |

const 가 없어 즉시 위험은 아니지만, 미래 const 추가 시 시한폭탄으로 변할 수 있어 일관성 적용. 외부 caller 가 schema 심볼을 types barrel 경유로 import 하지 않음을 사전 grep 검증.

## 룰 단위 테스트 (11 cases)
**Valid (6)** — 룰 작동 안 함:
- types.ts 가 아닌 파일에서 export *
- types.ts 에서 다른 경로 (./services, ../shared 등) barrel
- types.ts 에서 const 만 export
- types.ts 에서 명시적 named import (barrel 아님)

**Invalid (5)** — 정확히 차단:
- types.ts 에서 `export * from \"./schemas/foo.js\"`
- 확장자 없는 형태 `\"./schemas/foo\"`
- 하위 디렉토리 `\"./schemas/sub/bar.js\"`
- 다른 export 와 섞여 있어도 ./schemas barrel 만 정확히 잡음

## Test plan
- [x] 룰 단위 테스트 **11/11 PASS**
- [x] openapi-spec 회귀 (S336 도입) **2/2 PASS**
- [x] 전체 api 스위트 **2373/2373 PASS**
- [x] `pnpm lint` baseline **0 violations** (이전 3 → 0)
- [x] typecheck PASS
- [ ] CI auto-merge 후 prod `/api/openapi.json` HTTP 200 유지

## Out of scope
- **타 패키지 audit**: 본 룰은 `packages/api` 만 적용 (eslint.config.js scope 한정).
  fx-discovery / fx-shaping / fx-offering / fx-agent / modules/portal 패키지에도
  동일 패턴 점검 + 룰 확산 필요시 별도 PR.

## 파일 변경 요약 (8)
- 신규: `eslint-rules/no-types-schema-barrel.{mjs,ts,test.ts}` (3)
- 수정: `eslint-rules/index.mjs`, `eslint.config.js` (2)
- fix: `core/{docs,guard,launch}/types.ts` (3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)