### PR TITLE
feat(eslint): no-types-schema-barrel 룰 5 fx-* 패키지로 확산 (S336 후속)

### DIFF
--- a/packages/fx-agent/eslint.config.js
+++ b/packages/fx-agent/eslint.config.js
@@ -1,11 +1,14 @@
 import eslint from '@eslint/js';
 import tseslint from 'typescript-eslint';
+// S336: foundry-x-api 플러그인의 no-types-schema-barrel 룰 공유 (모노리포 상대경로)
+import { foundryXApiPlugin } from '../api/src/eslint-rules/index.mjs';
 
 export default tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
   {
     files: ['src/**/*.{ts,tsx}'],
+    plugins: { 'foundry-x-api': foundryXApiPlugin },
     rules: {
       '@typescript-eslint/no-unused-vars': ['error', {
         argsIgnorePattern: '^_',
@@ -14,6 +17,8 @@ export default tseslint.config(
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/consistent-type-imports': 'error',
       'no-console': 'off',
+      // S336: types.ts 의 schemas barrel re-export 차단 (순환 import → openapi.json 500 시한폭탄)
+      'foundry-x-api/no-types-schema-barrel': 'error',
     },
   },
   {

--- a/packages/fx-discovery/eslint.config.js
+++ b/packages/fx-discovery/eslint.config.js
@@ -1,11 +1,14 @@
 import eslint from '@eslint/js';
 import tseslint from 'typescript-eslint';
+// S336: foundry-x-api 플러그인의 no-types-schema-barrel 룰 공유 (모노리포 상대경로)
+import { foundryXApiPlugin } from '../api/src/eslint-rules/index.mjs';
 
 export default tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
   {
     files: ['src/**/*.{ts,tsx}'],
+    plugins: { 'foundry-x-api': foundryXApiPlugin },
     rules: {
       '@typescript-eslint/no-unused-vars': ['error', {
         argsIgnorePattern: '^_',
@@ -14,6 +17,8 @@ export default tseslint.config(
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/consistent-type-imports': 'error',
       'no-console': 'off',
+      // S336: types.ts 의 schemas barrel re-export 차단 (순환 import → openapi.json 500 시한폭탄)
+      'foundry-x-api/no-types-schema-barrel': 'error',
     },
   },
   {

--- a/packages/fx-modules/eslint.config.js
+++ b/packages/fx-modules/eslint.config.js
@@ -1,11 +1,14 @@
 import eslint from '@eslint/js';
 import tseslint from 'typescript-eslint';
+// S336: foundry-x-api 플러그인의 no-types-schema-barrel 룰 공유 (모노리포 상대경로)
+import { foundryXApiPlugin } from '../api/src/eslint-rules/index.mjs';
 
 export default tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
   {
     files: ['src/**/*.{ts,tsx}'],
+    plugins: { 'foundry-x-api': foundryXApiPlugin },
     rules: {
       '@typescript-eslint/no-unused-vars': ['error', {
         argsIgnorePattern: '^_',
@@ -14,6 +17,8 @@ export default tseslint.config(
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/consistent-type-imports': 'error',
       'no-console': 'off',
+      // S336: types.ts 의 schemas barrel re-export 차단 (순환 import → openapi.json 500 시한폭탄)
+      'foundry-x-api/no-types-schema-barrel': 'error',
     },
   },
   {

--- a/packages/fx-offering/eslint.config.js
+++ b/packages/fx-offering/eslint.config.js
@@ -1,11 +1,14 @@
 import eslint from '@eslint/js';
 import tseslint from 'typescript-eslint';
+// S336: foundry-x-api 플러그인의 no-types-schema-barrel 룰 공유 (모노리포 상대경로)
+import { foundryXApiPlugin } from '../api/src/eslint-rules/index.mjs';
 
 export default tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
   {
     files: ['src/**/*.{ts,tsx}'],
+    plugins: { 'foundry-x-api': foundryXApiPlugin },
     rules: {
       '@typescript-eslint/no-unused-vars': ['error', {
         argsIgnorePattern: '^_',
@@ -14,6 +17,8 @@ export default tseslint.config(
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/consistent-type-imports': 'error',
       'no-console': 'off',
+      // S336: types.ts 의 schemas barrel re-export 차단 (순환 import → openapi.json 500 시한폭탄)
+      'foundry-x-api/no-types-schema-barrel': 'error',
     },
   },
   {

--- a/packages/fx-shaping/eslint.config.js
+++ b/packages/fx-shaping/eslint.config.js
@@ -1,11 +1,14 @@
 import eslint from '@eslint/js';
 import tseslint from 'typescript-eslint';
+// S336: foundry-x-api 플러그인의 no-types-schema-barrel 룰 공유 (모노리포 상대경로)
+import { foundryXApiPlugin } from '../api/src/eslint-rules/index.mjs';
 
 export default tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
   {
     files: ['src/**/*.{ts,tsx}'],
+    plugins: { 'foundry-x-api': foundryXApiPlugin },
     rules: {
       '@typescript-eslint/no-unused-vars': ['error', {
         argsIgnorePattern: '^_',
@@ -14,6 +17,8 @@ export default tseslint.config(
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/consistent-type-imports': 'error',
       'no-console': 'off',
+      // S336: types.ts 의 schemas barrel re-export 차단 (순환 import → openapi.json 500 시한폭탄)
+      'foundry-x-api/no-types-schema-barrel': 'error',
     },
   },
   {


### PR DESCRIPTION
## Summary
PR #771 에서 `packages/api` 에 도입한 `foundry-x-api/no-types-schema-barrel` 룰을 모노리포 다른 패키지로 확산.

## 점검 결과
| 패키지 | schemas/ | z.enum | 룰 | 비고 |
|--------|:------:|:----:|:--:|------|
| api | ✅ | ✅ | ✅ | PR #771 |
| **fx-agent** | ✅ | ✅ | ✅ | 본 PR |
| **fx-discovery** | ✅ | ✅ | ✅ | 본 PR |
| **fx-modules** | ✅ | ✅ | ✅ | 본 PR |
| **fx-offering** | ✅ | ✅ | ✅ | 본 PR |
| **fx-shaping** | ✅ | ✅ | ✅ | 본 PR |
| fx-gateway | ❌ | n/a | ⏭ | schemas 없음 |
| 그 외 8 패키지 (cli, gate-x*, harness-kit, shared*, web) | ❌ | n/a | ⏭ | schemas 없음 |

**현재 위반 0건** — 5 fx-* 모두 schemas/ 사용하지만 types.ts barrel 패턴은 없음. 미래 신규 schemas 추가 시 시한폭탄 차단 목적.

## 적용 방식
각 fx-* `eslint.config.js` 에서 packages/api 플러그인을 상대경로로 import:

```js
import { foundryXApiPlugin } from '../api/src/eslint-rules/index.mjs';

// ...
plugins: { 'foundry-x-api': foundryXApiPlugin },
rules: {
  'foundry-x-api/no-types-schema-barrel': 'error',
}
```

cross-package import 는 ESLint config 한정이라 빌드/runtime 영향 없음.

## Test plan
- [x] 5개 fx-* 패키지 `eslint src/` errors 0
- [x] **Negative test 통과**: 의도적 위반 (`export * from \"./schemas/discovery-progress.js\"`) 을 fx-discovery/src/types.ts 에 배치 → 정확히 1 error 로 잡힘 + 한국어 fix 가이드 메시지 출력
- [x] typecheck 5 패키지 PASS
- [ ] CI auto-merge 후 prod smoke 정상

## Out of scope
- 더 깔끔한 공유 방식 — `packages/eslint-config` 신규 패키지 분리는 별건 PR 후보

🤖 Generated with [Claude Code](https://claude.com/claude-code)