### PR TITLE
fix(cross-org): F620/F626 MSA cross-domain 룰 위반 7건 fix

### DIFF
--- a/packages/api/src/core/cross-org/routes/index.ts
+++ b/packages/api/src/core/cross-org/routes/index.ts
@@ -3,9 +3,7 @@
 // F620: policy-embedder + expert-review + launch-blocking-signal (T5 마지막)
 import { Hono } from "hono";
 import type { Env } from "../../../env.js";
-import { AuditBus } from "../../infra/types.js";
-import { KVCacheService } from "../../infra/kv-cache.js";
-import { LLMService } from "../../infra/llm.js";
+import { AuditBus, KVCacheService, LLMService } from "../../infra/types.js";
 import { CrossOrgEnforcer } from "../services/cross-org-enforcer.service.js";
 import { BlockingRateService } from "../services/blocking-rate.service.js";
 import { PolicyEmbedder } from "../services/policy-embedder.service.js";

--- a/packages/api/src/core/cross-org/services/blocking-rate.service.ts
+++ b/packages/api/src/core/cross-org/services/blocking-rate.service.ts
@@ -2,7 +2,7 @@
 // PRD §5.3 "차단율 100% 미달 시 외부 제안 중단" 게이트 측정 메커니즘
 // 의존: F603 cross_org_export_blocks + F606 audit-bus
 import type { AuditBus } from "../../infra/types.js";
-import { generateTraceId, generateSpanId } from "../../infra/audit-bus.js";
+import { generateTraceId, generateSpanId } from "../../infra/types.js";
 
 export interface BlockingRateResult {
   orgId: string;

--- a/packages/api/src/core/cross-org/services/expert-review-manager.service.ts
+++ b/packages/api/src/core/cross-org/services/expert-review-manager.service.ts
@@ -1,7 +1,7 @@
 // F620 CO-I04: ExpertReviewManager — Cross-Org 분류 결정 HITL 라이프사이클
 // SME가 자동 분류 결과(특히 core_differentiator)를 검토 → approve/reject/reclassify
 // F605 HITL Console UI는 외부 — 본 service는 escalation 큐 contract만 제공
-import { generateTraceId, generateSpanId } from "../../infra/audit-bus.js";
+import { generateTraceId, generateSpanId } from "../../infra/types.js";
 import type { AuditBus } from "../../infra/types.js";
 
 export type ReviewStatus = "pending" | "in_review" | "signed_off";

--- a/packages/api/src/core/cross-org/services/launch-blocking-signal.service.ts
+++ b/packages/api/src/core/cross-org/services/launch-blocking-signal.service.ts
@@ -2,7 +2,7 @@
 // F618 Launch-X(release/publish) 시도 시 cross_org default-deny가 만든 block을 발행
 // Minimal: audit emit 1 event (cross_org.launch_blocked).
 // 후속 sprint(CO-I08): F618 LaunchEngine consumer 직접 호출로 release 차단까지 강제.
-import { generateTraceId, generateSpanId } from "../../infra/audit-bus.js";
+import { generateTraceId, generateSpanId } from "../../infra/types.js";
 import type { AuditBus } from "../../infra/types.js";
 
 export interface LaunchBlockingSignal {

--- a/packages/api/src/core/cross-org/services/policy-embedder.service.ts
+++ b/packages/api/src/core/cross-org/services/policy-embedder.service.ts
@@ -1,8 +1,7 @@
 // F620 CO-I01: PolicyEmbedder — 정책 텍스트 임베딩 + KVCache + D1 영속
 // Minimal: 진정 vector embedding은 후속 sprint(CO-I02 LLM 보조 동치 판정)에서 정밀화
 // 본 sprint는 stub 패턴 (sha256 → vector_json) + KVCache + D1 cache 다층 구조
-import type { LLMService } from "../../infra/llm.js";
-import type { KVCacheService } from "../../infra/kv-cache.js";
+import type { LLMService, KVCacheService } from "../../infra/types.js";
 
 const STUB_MODEL = "stub-sha256-v1";
 const STUB_VECTOR_DIM = 8; // Minimal embedding 차원 (real 384/768 미사용)


### PR DESCRIPTION
## Summary

PR #774 + #775 master 안착 후 deploy.yml `lint:msa-baseline` 실패 발견. F620/F626 신규 코드가 `infra/audit-bus.js` / `kv-cache.js` / `llm.js`를 직접 import → `foundry-x-api/no-cross-domain-import` 룰 위반 7건. **cross-org → infra 도메인 경계는 `types.ts`(contract) 경유만 허용**.

## Fix

5 caller의 import path를 `../../infra/{audit-bus,kv-cache,llm}.js` → `../../infra/types.js`로 통합. infra/types.ts에 이미 `KVCacheService` / `LLMService` / `generateTraceId` / `generateSpanId` / `AuditBus` 모두 re-export 되어 있어 추가 변경 0.

## Test plan
- [x] `pnpm vitest run src/core/cross-org` — 25 PASS 유지
- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `bash scripts/lint-baseline-check.sh` — `MSA baseline maintained: 0 violations` (7→0)
- [ ] CI all green → auto-merge → deploy.yml master 회복

🤖 Generated with [Claude Code](https://claude.com/claude-code)