### PR TITLE
chore(web): landing sprint 368→370 sync (S340 routine)

### DIFF
--- a/packages/web/content/landing/hero.md
+++ b/packages/web/content/landing/hero.md
@@ -12,7 +12,7 @@ stats:
     label: "AI 에이전트"
   - value: "63"
     label: "자동화 스킬"
-  - value: "368"
+  - value: "370"
     label: "Sprints"
 ---
 

--- a/packages/web/src/components/landing/footer.tsx
+++ b/packages/web/src/components/landing/footer.tsx
@@ -69,7 +69,7 @@ export function Footer() {
             &copy; {new Date().getFullYear()} KTDS AX BD. All rights reserved.
           </p>
           <p className="font-mono text-xs text-muted-foreground/60">
-            Sprint 368 &middot; Phase 47
+            Sprint 370 &middot; Phase 47
           </p>
         </div>
       </div>

--- a/packages/web/src/routes/landing.tsx
+++ b/packages/web/src/routes/landing.tsx
@@ -69,7 +69,7 @@ function getSectionOrder(section: string): number {
    ═══════════════════════════════════════════════ */
 
 const SITE_META_FALLBACK = {
-  sprint: "Sprint 368",
+  sprint: "Sprint 370",
   phase: "Phase 47",
   phaseTitle: "Phase 47 동시 진행",
   tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼",
@@ -79,7 +79,7 @@ const STATS_FALLBACK = [
   { value: "2", label: "BD 파이프라인" },
   { value: "10+", label: "AI 에이전트" },
   { value: "63", label: "자동화 스킬" },
-  { value: "368", label: "Sprints" },
+  { value: "370", label: "Sprints" },
 ];
 
 // Build-time content from TinaCMS-managed Markdown


### PR DESCRIPTION
## Summary

- F635 Sprint 370 ✅ MERGED 직후 routine landing sync
- 4 hardcoded "368" 참조를 "370"으로 갱신
- content-sync-check.sh 자동 감지 결과 (S340 session-end Phase 0c-3)

## Files

- `packages/web/content/landing/hero.md` — stats Sprints "368" → "370"
- `packages/web/src/routes/landing.tsx` — SITE_META_FALLBACK.sprint + STATS_FALLBACK
- `packages/web/src/components/landing/footer.tsx` — footer Sprint label

## Test plan

- [x] content-sync-check.sh exit 0 (master에서 verified)
- [ ] CI green
- [ ] auto-merge on green

🤖 S340 routine