### PR TITLE
fix(auth): F636 followup — login null guard + 4 input coverage tests

### DIFF
--- a/packages/api/src/__tests__/auth.test.ts
+++ b/packages/api/src/__tests__/auth.test.ts
@@ -177,4 +177,52 @@ describe("auth routes (D1)", () => {
     );
     expect(res.status).toBe(401);
   });
+
+  describe("POST /api/auth/login — F637 input coverage", () => {
+    it("plain POST no body → 4xx (never 5xx)", async () => {
+      const res = await app.request("/api/auth/login", { method: "POST" }, env);
+      expect(res.status).toBeGreaterThanOrEqual(400);
+      expect(res.status).toBeLessThan(500);
+    });
+
+    it("empty JSON body → 400", async () => {
+      const res = await app.request(
+        "/api/auth/login",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        },
+        env,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("partial body email only → 400", async () => {
+      const res = await app.request(
+        "/api/auth/login",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: "x" }),
+        },
+        env,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("malformed JSON → 4xx", async () => {
+      const res = await app.request(
+        "/api/auth/login",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: "{invalid json",
+        },
+        env,
+      );
+      expect(res.status).toBeGreaterThanOrEqual(400);
+      expect(res.status).toBeLessThan(500);
+    });
+  });
 });

--- a/packages/api/src/modules/auth/routes/auth.ts
+++ b/packages/api/src/modules/auth/routes/auth.ts
@@ -146,6 +146,9 @@ const login = createRoute({
 
 authRoute.openapi(login, async (c) => {
   const { email, password } = c.req.valid("json");
+  if (!email || !password) {
+    return c.json({ error: "email and password are required", errorCode: "VALIDATION_001" }, 400);
+  }
   const db = getDb(c.env.DB);
 
   const [user] = await db.select().from(users).where(eq(users.email, email));


### PR DESCRIPTION
## Summary
- F637 PoC(Sprint 372, S343)에서 확증된 root cause 대비 미래 보험
- auth.ts login handler에 `if (!email || !password) → 400` null guard 추가 (line 149)
- auth.test.ts F637 input coverage describe — 4 신규 회귀 test (plain POST / empty / partial / malformed)
- 0.18.4 마이그레이션 0건 (현재 0.9.0 유지, 5 packages 변경 0건)

## 배경 (F636 production downtime ~4h41m, S341)

`@hono/zod-openapi 0.9.0 → 0.18.4` 버전업 sprint(F636) 머지 후 production에서 `POST /api/auth/login` plain POST(no body) HTTP 500 발생 → revert PR #784.

F637 PoC(Sprint 372, PR #785 closed)에서 정밀 확증:
- 0.18.4 middleware behavior change: Content-Type 없는 요청은 body validation을 **skip** (defaultHook 미호출)
- handler가 `c.req.valid("json")` 호출 시 `{email: undefined, password: undefined}` 수신
- `eq(users.email, undefined)` → D1_TYPE_ERROR → HTTP 500
- **autopilot codemod `c.json(data, 200)`는 무관** (F636 분석 정정)

## Fix logic

```typescript
// packages/api/src/modules/auth/routes/auth.ts (line 149)
authRoute.openapi(login, async (c) => {
  const { email, password } = c.req.valid("json");
  if (!email || !password) {
    return c.json({ error: "email and password are required", errorCode: "VALIDATION_001" }, 400);
  }
  const db = getDb(c.env.DB);
  ...
```

0.9.0 환경에서는 zod validation hook이 이미 catch하므로 무해 — 미래 0.18+ 마이그레이션 시 안전 보장.

## Test plan

- [x] `pnpm exec tsc --noEmit` packages/api PASS (turbo 우회, S337 함정 회피)
- [x] `pnpm vitest run src/__tests__/auth.test.ts` 12/12 PASS
  - 기존 8 tests 유지 (회귀 0건)
  - F637 input coverage 4 신규: plain POST / empty JSON / partial body / malformed JSON 모두 4xx
- [x] CI typecheck/lint/test 통과 후 auto-merge

## 후속 (out of scope)

- **F638 본 통합 sprint**: 0.18.4 5 packages 마이그레이션 + 17 files × 35 handlers null guard + multi-input smoke probe CI 자동화
- 본 PR은 0.9.0 환경 안전 + F638 prep용 보험

Refs: F637 PoC reports/sprint-372-master-validation-2026-05-09.md / SPEC.md F636 + F637 row

🤖 Generated with [Claude Code](https://claude.com/claude-code)