### PR TITLE
fix(api): F638 hotfix — 4 routes에 400 response 선언 (zod-openapi 0.18.4 strict)

### DIFF
--- a/packages/api/src/modules/auth/routes/sso.ts
+++ b/packages/api/src/modules/auth/routes/sso.ts
@@ -93,6 +93,10 @@ const verifyHubToken = createRoute({
       content: { "application/json": { schema: VerifyResponseSchema } },
       description: "Token verification result",
     },
+    400: {
+      content: { "application/json": { schema: z.object({ error: z.string(), errorCode: z.string() }) } },
+      description: "잘못된 요청",
+    },
   },
 });
 
@@ -149,6 +153,10 @@ const updateOrgService = createRoute({
     200: {
       content: { "application/json": { schema: OrgServiceSchema } },
       description: "Service updated",
+    },
+    400: {
+      content: { "application/json": { schema: z.object({ error: z.string(), errorCode: z.string() }) } },
+      description: "잘못된 요청",
     },
   },
 });

--- a/packages/api/src/modules/portal/routes/feedback.ts
+++ b/packages/api/src/modules/portal/routes/feedback.ts
@@ -1,4 +1,4 @@
-import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import {
   FeedbackSubmitRequestSchema,
   FeedbackSubmitResponseSchema,
@@ -31,6 +31,10 @@ const submitFeedback = createRoute({
     200: {
       content: { "application/json": { schema: FeedbackSubmitResponseSchema } },
       description: "피드백 제출 결과",
+    },
+    400: {
+      content: { "application/json": { schema: z.object({ error: z.string(), errorCode: z.string() }) } },
+      description: "잘못된 요청",
     },
   },
 });

--- a/packages/api/src/modules/portal/routes/kpi.ts
+++ b/packages/api/src/modules/portal/routes/kpi.ts
@@ -49,6 +49,10 @@ const trackEvent = createRoute({
       content: { "application/json": { schema: KpiTrackResponseSchema } },
       description: "이벤트 기록 결과",
     },
+    400: {
+      content: { "application/json": { schema: z.object({ error: z.string(), errorCode: z.string() }) } },
+      description: "잘못된 요청",
+    },
   },
 });
 

--- a/packages/api/src/modules/portal/routes/nps.ts
+++ b/packages/api/src/modules/portal/routes/nps.ts
@@ -59,6 +59,10 @@ const dismissSurvey = createRoute({
       content: { "application/json": { schema: z.object({ success: z.boolean() }).openapi("NpsDismissResponse") } },
       description: "닫기 결과",
     },
+    400: {
+      content: { "application/json": { schema: z.object({ error: z.string(), errorCode: z.string() }) } },
+      description: "잘못된 요청",
+    },
   },
 });
 


### PR DESCRIPTION
## Summary

PR #789 (F638 본 통합) 후속 hotfix. zod-openapi 0.18.4 strict typing이 handler emit `{error, errorCode}` 400 응답을 route OpenAPI spec에 미선언 상태로 detect하여 deploy.yml test job typecheck FAIL → **deploy SKIPPED**.

Production은 이전 배포(0.9.0 + S343 auth.ts null guard)로 그대로 살아있어 영향 없음. 본 hotfix 머지 후 0.18.4 본 통합 deploy 비로소 production 반영.

## 변경 (4 files, 5 type errors)

- `packages/api/src/modules/auth/routes/sso.ts`: POST `/auth/sso/verify` + PUT `/orgs/:orgId/services/:serviceId`
- `packages/api/src/modules/portal/routes/feedback.ts`: POST `/feedback` (+ `z` import)
- `packages/api/src/modules/portal/routes/kpi.ts`: POST `/kpi/track`
- `packages/api/src/modules/portal/routes/nps.ts`: POST `/nps/dismiss`

각 route `responses`에 추가:
```ts
400: {
  content: { "application/json": { schema: z.object({ error: z.string(), errorCode: z.string() }) } },
  description: "잘못된 요청",
}
```

## 검증

- `pnpm turbo run typecheck --force`: **19/19 PASS, cache 0건** (S337 함정 회피)
- 변경 21 insertions / 1 deletion

## Test plan

- [x] Local typecheck PASS (--force)
- [ ] CI test job PASS
- [ ] CI deploy-api PASS (0.18.4 본 배포 첫 성공)
- [ ] Production multi-input smoke 5xx 0건 (배포 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)