### PR TITLE
fix(test): F604 KPI test 2건 bug fix (Sprint 377 hotfix #2)

### DIFF
--- a/packages/api/src/__tests__/kpi-calculator.service.test.ts
+++ b/packages/api/src/__tests__/kpi-calculator.service.test.ts
@@ -66,8 +66,8 @@ describe("KpiCalculatorService — F604", () => {
   });
 
   it("calculateCriticalInconsistencyRate computes rate", async () => {
-    await db.exec("INSERT INTO feedback_queue VALUES ('q1','org1',1,'http://u1','t1',null,'[]','failed',datetime('now'),datetime('now'))");
-    await db.exec("INSERT INTO feedback_queue VALUES ('q2','org1',2,'http://u2','t2',null,'[]','done',datetime('now'),datetime('now'))");
+    await db.exec("INSERT INTO feedback_queue (id, org_id, github_issue_number, github_issue_url, title, body, labels, status, created_at, updated_at) VALUES ('q1','org1',1,'http://u1','t1',null,'[]','failed',datetime('now'),datetime('now'))");
+    await db.exec("INSERT INTO feedback_queue (id, org_id, github_issue_number, github_issue_url, title, body, labels, status, created_at, updated_at) VALUES ('q2','org1',2,'http://u2','t2',null,'[]','done',datetime('now'),datetime('now'))");
     const result = await svc.calculateCriticalInconsistencyRate();
     expect(result.value).toBe(50);
   });
@@ -116,7 +116,7 @@ describe("KpiCalculatorService — F604", () => {
       await db.exec("INSERT INTO agent_run_metrics VALUES ('m" + i + "','s1','a1','completed',0,100,10,1,null," + v + ",null,'2026-01-01',null,'2026-01-01')");
     }
     const result = await svc.calculateApiP95();
-    expect(result.value).toBe(950);
+    expect(result.value).toBe(1000);
   });
 
   it("calculateCoreDiffBlockingRate returns null on empty table", async () => {


### PR DESCRIPTION
## Summary
PR #797 deploy fail 분석 결과: PR #795 본체에 잠재한 KPI test 2건 bug. PR #796 hotfix 시 turbo cache hit로 silent merge.

- **Bug 1**: `feedback_queue` INSERT — mock-d1 15 columns vs fixture 10 values mismatch → explicit columns 명시
- **Bug 2**: `calculateApiP95` expected 950 → 1000 (nearest-rank 정확)

## Impact
Production 0건 (KPI implementation 정상 배포 + smoke ALL PASS). master CI red 회복용.

## Test plan
- [x] Local `vitest run kpi-calculator.service.test.ts` 13/13 PASS
- [ ] CI Deploy success
- [ ] master CI green 회복

🤖 Generated with [Claude Code](https://claude.com/claude-code)