### PR TITLE
fix(ci): F649 hotfix — e2e.yml harness-kit build step (Sprint 384)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Build shared package
         run: pnpm -F @foundry-x/shared build
 
+      - name: Build harness-kit (api dev-server dep, F649)
+        run: pnpm -F @foundry-x/harness-kit build
+
       - name: Install Playwright Chromium
         run: pnpm -F @foundry-x/web exec playwright install --with-deps chromium
 


### PR DESCRIPTION
## F649 hotfix — e2e.yml harness-kit build step 추가

PR #805 (Sprint 384 F649 H5 fix) merge 후 e2e 4 shards 전부 FAILURE.
근본 원인: api `routes/proxy.ts`가 `@foundry-x/harness-kit/dist/index.js` import →
CI에서 harness-kit이 build 안 됨 → `ERR_MODULE_NOT_FOUND` → webServer timeout 120s.

## CI 로그 핵심

```
[WebServer] Error [ERR_MODULE_NOT_FOUND]: Cannot find module 
'/home/runner/work/Foundry-X/Foundry-X/packages/api/node_modules/@foundry-x/harness-kit/dist/index.js' 
imported from /home/runner/work/Foundry-X/Foundry-X/packages/api/src/routes/proxy.ts
```

## Fix

`.github/workflows/e2e.yml`의 `Build shared` step 다음에 `Build harness-kit` step 1줄 추가.
api dev-server.ts가 e2e용 webServer로 시동될 때 harness-kit dist가 필요.

## 패턴 분석

S307 `feedback_pnpm_filter_workspace_dep` 패턴 재현. 
- local: monorepo full install + harness-kit 미리 build → PASS
- CI: first install + harness-kit 미build → ERR_MODULE_NOT_FOUND

이전엔 api 패키지가 e2e 차원에서 로드 안 됐기 때문에 harness-kit 의존성도 표면화 안 됨. F649가 api dev-server를 처음 e2e webServer로 시동하면서 의존성 노출.

## 메타 학습

**16회차 변종 패턴 추가**: rules/development-workflow.md "Autopilot Production Smoke Test" 변종으로 분류 — autopilot 아닌 Master 직접 모드라도 fix가 다른 의존성을 표면화하여 회귀 유발. local 검증으로는 잡히지 않음 (monorepo 환경 차이).

🤖 Generated with [Claude Code](https://claude.com/claude-code)