### PR TITLE
feat(e2e): F651 Sprint 386 — 잔존 9 test .skip 해제 정밀 fix

### DIFF
--- a/docs/01-plan/features/sprint-386.plan.md
+++ b/docs/01-plan/features/sprint-386.plan.md
@@ -1,0 +1,33 @@
+# Sprint 386 — F651 e2e 잔존 9 test 정밀 fix
+
+**Sprint**: 386  
+**F-item**: F651  
+**FX-REQ**: FX-REQ-712  
+**Priority**: P2  
+**Scope**: LOCKED — `packages/web/e2e/*.spec.ts` 만 수정
+
+## 목표
+
+F650 (Sprint 385) 에서 `.skip` 처리된 9개 e2e test의 실제 근본 원인을 진단·수정하고 `.skip` 해제한다.
+
+## 9 test 근본 원인 분석
+
+| # | 파일 | 근본 원인 | 수정 |
+|---|------|-----------|------|
+| 1 | discovery-detail-advanced:152 | (a) `기준 완료` → 컴포넌트는 `기준 충족` 렌더, (b) `분석 시작` 버튼 없음(per-stage `실행` 버튼만 존재), (c) getGraphSessions mock 미등록 | regex 수정 + button assertion 제거 + mock 추가 |
+| 2 | discovery-detail-advanced:214 | TemplateSelector 모달이 열리는데 `기획서 생성 시작` 클릭 단계 누락 + export mock 미등록 | 클릭 단계 추가 + export mock 추가 + assertion을 `v1` 뱃지로 변경 |
+| 3 | discovery-detail-advanced:256 | `aria-label="사업기획서 재생성"` → accessible name이 `재생성` exact 불일치 | `{ name: /재생성/ }` 로 regex 전환 |
+| 4 | discovery-item-list:104 | `getByText("대기")` strict mode — 필터 버튼 + 뱃지 2 elements | `.first()` 추가 |
+| 5 | roadmap-changelog:22 | mock 응답 수신 전 assertion 시도 → `waitForResponse` 대기 필요 | `waitForResponse` 추가 |
+| 6 | roadmap-changelog:105 | `page.evaluate` 이전 `page.goto()` 없음 → `window.location.origin = "null"` → invalid URL | `page.goto("/roadmap")` 선행 |
+| 7 | offering-pipeline:134 | 조기 skip (assertion은 항상 성립) | `.skip` 제거만 |
+| 8 | shaping-html-view:71 | `bp-iframe-item-1` testid 없음 — 컴포넌트는 Sheet + `bp-sheet-iframe` 패턴 | `bp-full-view-item-1` 클릭 → `bp-sheet-iframe` 검증으로 재작성 |
+| 9 | shaping-html-view:85 | 동일 (describe.skip 내) | Sheet Escape 닫기로 재작성 |
+
+## DoD
+
+- P-a: 9개 test 모두 `.skip` 해제
+- P-b: typecheck PASS (e2e spec은 `.ts`, tsc --noEmit 범위)
+- P-c: CI 4 shards GREEN (E2E)
+- P-d: 기존 passing tests 회귀 없음
+- P-e: SPEC.md F651 상태 `✅` 갱신

--- a/docs/02-design/features/sprint-386.design.md
+++ b/docs/02-design/features/sprint-386.design.md
@@ -1,0 +1,48 @@
+# Sprint 386 Design — F651 e2e 잔존 9 test 정밀 fix
+
+**Sprint**: 386 | **F-item**: F651 | **Scope**: e2e spec files only
+
+## §1 변경 파일 매핑
+
+| 파일 | 변경 유형 | 변경 내용 |
+|------|----------|----------|
+| `packages/web/e2e/discovery-detail-advanced.spec.ts` | modify | setupDetailMocks에 getGraphSessions + export mock 추가; test 1/2/3 skip 해제 + 수정 |
+| `packages/web/e2e/discovery-item-list.spec.ts` | modify | test 4 skip 해제 + `.first()` 추가 |
+| `packages/web/e2e/roadmap-changelog.spec.ts` | modify | test 5 waitForResponse + test 6 goto 추가 + skip 해제 |
+| `packages/web/e2e/offering-pipeline.spec.ts` | modify | test 7 skip 해제만 |
+| `packages/web/e2e/shaping-html-view.spec.ts` | modify | describe.skip → describe + test 8/9 재작성 |
+
+## §2 각 수정 상세
+
+### discovery-detail-advanced.spec.ts
+
+**setupDetailMocks 추가**:
+```typescript
+page.route("**/api/biz-items/biz-1/discovery-graph/sessions", (route) =>
+  route.fulfill({ json: { sessions: [] } }),
+),
+page.route("**/api/biz-items/biz-1/business-plan/export*", (route) =>
+  route.fulfill({
+    status: 200,
+    contentType: "text/html",
+    body: "<html><body><h1>AI 문서 자동화 사업기획서</h1></body></html>",
+  }),
+),
+```
+
+**Test 1**: regex `기준 완료` → `기준 충족`; `분석 시작` button assertion 제거
+
+**Test 2**: "생성하기" 클릭 후 TemplateSelector "기획서 생성 시작" 클릭 추가;
+assertion `getByText(/AI 문서 자동화 사업기획서/).first()` → `getByText("v1").first()`
+
+**Test 3**: `getByRole("button", { name: "재생성" })` → `{ name: /재생성/ }`
+
+### shaping-html-view.spec.ts
+
+**Test 8** (iframe 표시) 재작성:
+- `bp-card-item-1` click → `bp-full-view-item-1` click
+- `bp-iframe-item-1` → `bp-sheet-iframe`
+- 내용 검증은 `iframe.contentFrame()` 패턴 유지
+
+**Test 9** (닫기) 재작성:
+- 전체 보기 열기 → `bp-sheet-iframe` 확인 → Escape로 Sheet 닫기 → not.toBeVisible

--- a/packages/web/e2e/discovery-detail-advanced.spec.ts
+++ b/packages/web/e2e/discovery-detail-advanced.spec.ts
@@ -116,6 +116,16 @@ function setupDetailMocks(page: import("@playwright/test").Page, withPlan = fals
     page.route("**/api/help-agent/**", (route) =>
       route.fulfill({ json: { content: "mock" } }),
     ),
+    page.route("**/api/biz-items/biz-1/discovery-graph/sessions", (route) =>
+      route.fulfill({ json: { sessions: [] } }),
+    ),
+    page.route("**/api/biz-items/biz-1/business-plan/export*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: "<html><body><h1>AI 문서 자동화 사업기획서</h1></body></html>",
+      }),
+    ),
   ]);
 }
 
@@ -147,9 +157,7 @@ test.describe("F439 — 아이템 상세 허브 3탭", () => {
     await expect(page.getByText("wizard")).toBeVisible();
   });
 
-  // F650 (S354): 발굴분석 탭 컨텐츠 drift — 분석 스텝퍼/9기준 체크리스트 위치 변경 또는 mock 데이터 정합성 이슈
-  // F651 후속 정밀 진단 위임 (mock route 보강 또는 컴포넌트 selector 재확인 필요)
-  test.skip("발굴분석 탭 클릭 → 분석 스텝퍼 + 9기준 체크리스트 표시", async ({ authenticatedPage: page }) => {
+  test("발굴분석 탭 클릭 → 분석 스텝퍼 + 9기준 체크리스트 표시", async ({ authenticatedPage: page }) => {
     await setupDetailMocks(page);
     await page.goto("/discovery/items/biz-1");
 
@@ -160,12 +168,10 @@ test.describe("F439 — 아이템 상세 허브 3탭", () => {
 
     // 분석 스텝퍼 헤딩
     await expect(page.getByText("발굴 분석 실행")).toBeVisible();
-    // 분석 시작 버튼
-    await expect(page.getByRole("button", { name: "분석 시작" })).toBeVisible();
     // 9기준 체크리스트 헤딩
     await expect(page.getByText("발굴 9기준 체크리스트")).toBeVisible();
-    // 완료 수 표시 — "3 / 9 기준 완료"
-    await expect(page.getByText(/3\s*\/\s*9\s*기준\s*완료/)).toBeVisible();
+    // 완료 수 표시 — "3 / 9 기준 충족" (DiscoveryCriteriaPanel:100 기준 충족)
+    await expect(page.getByText(/3\s*\/\s*9\s*기준\s*충족/).first()).toBeVisible();
   });
 
   test("형상화 탭 클릭 → 파이프라인 표시 (기획서 미생성 상태)", async ({ authenticatedPage: page }) => {
@@ -209,9 +215,7 @@ test.describe("F439 — 아이템 상세 허브 3탭", () => {
 });
 
 test.describe("F440 — 사업기획서 생성 + 열람", () => {
-  // F650 (S354): 기획서 생성 후 BusinessPlanViewer 컨텐츠 drift — mock 응답 후 viewer mount 타이밍 또는 컴포넌트 변경
-  // F651 후속 정밀 진단 위임 (generate-business-plan mock 응답 정합성 + BusinessPlanViewer prop 확인 필요)
-  test.skip("형상화 탭에서 생성하기 클릭 → 기획서 생성 후 BusinessPlanViewer 표시", async ({ authenticatedPage: page }) => {
+  test("형상화 탭에서 생성하기 클릭 → 기획서 생성 후 BusinessPlanViewer 표시", async ({ authenticatedPage: page }) => {
     await setupDetailMocks(page, false);
 
     // 기획서 생성 API mock
@@ -243,17 +247,21 @@ test.describe("F440 — 사업기획서 생성 + 열람", () => {
     await page.getByRole("tab", { name: "형상화" }).click();
     await expect(page.getByText("형상화 파이프라인")).toBeVisible();
 
-    // 생성하기 버튼 클릭
+    // 생성하기 버튼 클릭 → TemplateSelector 모달 열림
     const generateBtn = page.getByRole("button", { name: "생성하기" }).first();
     await expect(generateBtn).toBeVisible();
     await generateBtn.click();
 
-    // 기획서 콘텐츠 표시
-    await expect(page.getByText(/AI 문서 자동화 사업기획서/).first()).toBeVisible({ timeout: 15000 });
+    // TemplateSelector 모달 → 기획서 생성 시작 클릭
+    const startBtn = page.getByRole("button", { name: "기획서 생성 시작" });
+    await expect(startBtn).toBeVisible({ timeout: 5000 });
+    await startBtn.click();
+
+    // BusinessPlanViewer 표시 확인 — v1 뱃지
+    await expect(page.getByText("v1").first()).toBeVisible({ timeout: 15000 });
   });
 
-  // F650 hotfix (S354): 잔존 fail — 본 test 다른 assertion이 fail (v1 .first() fix는 적용했지만 페이지 mount 또는 form ation 탭 클릭 후 다른 element 미렌더). F651 후속 정밀 진단 위임.
-  test.skip("기획서 있는 경우 형상화 탭에 BusinessPlanViewer 바로 표시", async ({ authenticatedPage: page }) => {
+  test("기획서 있는 경우 형상화 탭에 BusinessPlanViewer 바로 표시", async ({ authenticatedPage: page }) => {
     await setupDetailMocks(page, true);
 
     await page.goto("/discovery/items/biz-1");
@@ -263,9 +271,8 @@ test.describe("F440 — 사업기획서 생성 + 열람", () => {
     await page.getByRole("tab", { name: "형상화" }).click();
 
     // 기획서 뷰어 — v1 뱃지
-    // F650 (S354): strict mode 회피 — v1 이 badge + viewer 2 elements로 resolved
     await expect(page.getByText("v1").first()).toBeVisible({ timeout: 10000 });
-    // 재생성 버튼
-    await expect(page.getByRole("button", { name: "재생성" })).toBeVisible();
+    // 재생성 버튼 — aria-label="사업기획서 재생성" → accessible name 포함 매칭
+    await expect(page.getByRole("button", { name: /재생성/ }).first()).toBeVisible();
   });
 });

--- a/packages/web/e2e/discovery-item-list.spec.ts
+++ b/packages/web/e2e/discovery-item-list.spec.ts
@@ -100,13 +100,12 @@ test.describe("F436 — 내 아이템 목록", () => {
     await expect(page.getByText("고객 데이터 플랫폼")).toBeVisible();
   });
 
-  // F650 hotfix (S354): 신규 발견 fail — F435 위자드 page 부재로 인한 데이터 미생성? 상태 뱃지 selector drift. F651 후속 위임.
-  test.skip("상태 뱃지가 올바르게 표시된다", async ({ authenticatedPage: page }) => {
+  test("상태 뱃지가 올바르게 표시된다", async ({ authenticatedPage: page }) => {
     await page.goto("/discovery");
     // "분석 중" 뱃지 (status: analyzing)
     await expect(page.getByText("분석 중").first()).toBeVisible();
-    // "대기" 뱃지 (status: draft)
-    await expect(page.getByText("대기")).toBeVisible();
+    // "대기" 뱃지 (status: draft) — strict mode: 필터 버튼 + 뱃지 2 elements → .first()
+    await expect(page.getByText("대기").first()).toBeVisible();
   });
 
   test("새 아이템 버튼이 getting-started로 링크된다", async ({ authenticatedPage: page }) => {

--- a/packages/web/e2e/offering-pipeline.spec.ts
+++ b/packages/web/e2e/offering-pipeline.spec.ts
@@ -129,9 +129,7 @@ test.describe("Offering Pipeline E2E", () => {
     await expect(page.getByText("보고용").first()).toBeVisible();
   });
 
-  // F650 (S354): button '다음' disabled — wizard 1단계 mock 데이터 미정합 (createWizard 진행 조건 미충족)
-  // F651 후속 정밀 진단 위임 (offering-create-wizard mock 데이터 + button enable 조건 확인 필요)
-  test.skip("offering-create-wizard — 위자드 1단계 표시", async ({
+  test("offering-create-wizard — 위자드 1단계 표시", async ({
     authenticatedPage: page,
   }) => {
     await setupOfferingMocks(page);

--- a/packages/web/e2e/roadmap-changelog.spec.ts
+++ b/packages/web/e2e/roadmap-changelog.spec.ts
@@ -18,8 +18,7 @@ test.describe("Public Roadmap (F518)", () => {
     await expect(page.getByRole("heading", { name: "Roadmap" })).toBeVisible();
   });
 
-  // F650 hotfix (S354): `.first()` fix 후에도 잔존 fail — 페이지 mount 또는 mock 응답 미수신 가능성. F651 후속 정밀 진단.
-  test.skip("Roadmap 페이지에 Phase 정보가 표시된다", async ({ page }) => {
+  test("Roadmap 페이지에 Phase 정보가 표시된다", async ({ page }) => {
     await page.route("**/api/work/public/roadmap", async route => {
       await route.fulfill({
         status: 200,
@@ -34,9 +33,11 @@ test.describe("Public Roadmap (F518)", () => {
       });
     });
 
+    // waitForResponse 보장 — mock 응답 수신 후 assertion
+    const responsePromise = page.waitForResponse("**/api/work/public/roadmap");
     await page.goto("/roadmap");
-    // F650 (S354): strict mode 회피 — Phase 37 이 헤딩+카드 2 elements로 resolved
-    await expect(page.getByText("Phase 37").first()).toBeVisible();
+    await responsePromise;
+    await expect(page.getByText("Phase 37").first()).toBeVisible({ timeout: 10000 });
     await expect(page.getByText("Work Lifecycle Platform")).toBeVisible();
   });
 
@@ -101,8 +102,7 @@ test.describe("Public Changelog (F518)", () => {
 });
 
 test.describe("Public KG Trace API (F518)", () => {
-  // F650 hotfix (S354): `window.location.origin` fix 후에도 잔존 fail — page.evaluate 환경에서 다른 assert 또는 mock 응답 정합성. F651 후속 위임.
-  test.skip("공개 KG trace API는 인증 없이 접근 가능하다", async ({ page }) => {
+  test("공개 KG trace API는 인증 없이 접근 가능하다", async ({ page }) => {
     await page.route("**/api/work/public/kg/trace?*", async route => {
       await route.fulfill({
         status: 200,
@@ -120,8 +120,9 @@ test.describe("Public KG Trace API (F518)", () => {
       });
     });
 
-    // API 직접 호출 (페이지 컨텍스트에서 fetch)
-    // F650 (S354): page.evaluate 내부에서 relative URL parse fail → window.location.origin 사용
+    // page.goto 선행 — about:blank 상태에서 window.location.origin = "null" → invalid URL 방지
+    await page.goto("/roadmap");
+
     const response = await page.evaluate(async () => {
       const res = await fetch(
         `${window.location.origin}/api/work/public/kg/trace?id=F518&depth=2`,

--- a/packages/web/e2e/shaping-html-view.spec.ts
+++ b/packages/web/e2e/shaping-html-view.spec.ts
@@ -39,9 +39,7 @@ async function dismissOverlays(page: import("@playwright/test").Page) {
 // 1. 사업기획서 (/shaping/business-plan)
 // ════════════════════════════════════════════════════════════
 
-// F650 (S354): shaping HTML view iframe sandbox selector drift — 2 spec fail (F648 측정 동일)
-// F651 후속 정밀 진단 위임 (iframe sandbox 패턴 + content selector 확인 필요)
-test.describe.skip("사업기획서 HTML 미리보기", () => {
+test.describe("사업기획서 HTML 미리보기", () => {
   test.beforeEach(async ({ authenticatedPage: page }) => {
     await dismissOverlays(page);
 
@@ -68,29 +66,33 @@ test.describe.skip("사업기획서 HTML 미리보기", () => {
     await expect(page.getByText("스마트 팩토리 솔루션")).toBeVisible();
   });
 
-  test("카드 클릭 시 iframe으로 HTML이 표시돼요", async ({ authenticatedPage: page }) => {
+  test("전체 보기 클릭 시 Sheet에서 iframe으로 HTML이 표시돼요", async ({ authenticatedPage: page }) => {
     await page.goto("/shaping/business-plan");
     await expect(page.getByText("AI 헬스케어 플랫폼")).toBeVisible({ timeout: 10000 });
 
-    await page.getByTestId("bp-card-item-1").click();
+    // 전체 보기 버튼 클릭 → Sheet 열림
+    await page.getByTestId("bp-full-view-item-1").click();
 
-    const iframe = page.getByTestId("bp-iframe-item-1");
+    // Sheet 내 공유 iframe 확인 (bp-sheet-iframe)
+    const iframe = page.getByTestId("bp-sheet-iframe");
     await expect(iframe).toBeVisible({ timeout: 10000 });
 
-    // Verify iframe has content
+    // iframe 내 콘텐츠 확인
     const frame = iframe.contentFrame();
     await expect(frame.locator("body")).toContainText("테스트 기획서", { timeout: 5000 });
   });
 
-  test("카드를 다시 클릭하면 iframe이 닫혀요", async ({ authenticatedPage: page }) => {
+  test("전체 보기 Sheet를 닫으면 iframe이 사라져요", async ({ authenticatedPage: page }) => {
     await page.goto("/shaping/business-plan");
     await expect(page.getByText("AI 헬스케어 플랫폼")).toBeVisible({ timeout: 10000 });
 
-    await page.getByTestId("bp-card-item-1").click();
-    await expect(page.getByTestId("bp-iframe-item-1")).toBeVisible({ timeout: 10000 });
+    // 전체 보기 열기 → Sheet + iframe 확인
+    await page.getByTestId("bp-full-view-item-1").click();
+    await expect(page.getByTestId("bp-sheet-iframe")).toBeVisible({ timeout: 10000 });
 
-    await page.getByTestId("bp-card-item-1").click();
-    await expect(page.getByTestId("bp-iframe-item-1")).not.toBeVisible();
+    // Escape로 Sheet 닫기
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("bp-sheet-iframe")).not.toBeVisible({ timeout: 5000 });
   });
 
   test("새 창 버튼 클릭 시 window.open이 호출돼요", async ({ authenticatedPage: page }) => {


### PR DESCRIPTION
## Summary

F651 — F650(Sprint 385)에서 `.skip` 처리된 9개 e2e test 근본 원인 정밀 진단 및 수정.

### 수정 내용 (9 tests)

| # | 파일 | 근본 원인 | 수정 |
|---|------|-----------|------|
| 1 | discovery-detail-advanced:152 | `기준 완료` → 컴포넌트는 `기준 충족` / `분석 시작` 버튼 없음 | regex + assertion 수정 |
| 2 | discovery-detail-advanced:214 | TemplateSelector `기획서 생성 시작` 클릭 단계 누락 | 클릭 추가 + v1 뱃지 assertion |
| 3 | discovery-detail-advanced:256 | `aria-label="사업기획서 재생성"` exact 불일치 | regex `{ name: /재생성/ }` |
| 4 | discovery-item-list:104 | 필터 버튼 + 뱃지 strict mode | `.first()` 추가 |
| 5 | roadmap-changelog:22 | mock 응답 수신 전 assertion | `waitForResponse` 보장 |
| 6 | roadmap-changelog:105 | `page.goto` 없어 `origin = "null"` | `page.goto("/roadmap")` 선행 |
| 7 | offering-pipeline:134 | 조기 skip (assertion 항상 성립) | `.skip` 제거만 |
| 8 | shaping-html-view:71 | `bp-iframe-item-1` testid 없음 | `bp-full-view` → `bp-sheet-iframe` |
| 9 | shaping-html-view:85 | 동일 (describe.skip) | Sheet Escape 닫기로 재작성 |

## Scope

LOCKED: `packages/web/e2e/*.spec.ts` only (+ plan/design docs)

## Test plan

- [ ] CI E2E 4 shards GREEN
- [ ] 기존 passing tests 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- fx-pr-enrich -->
### Sprint Metadata
- Sprint: 386
- F-items: F651
- Match Rate: 100%
<!-- /fx-pr-enrich -->