### PR TITLE
fix(e2e): F656 — Vite deps cache CI 최적화 (shard 1 race 해소, Sprint 391)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,6 +26,15 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Restore Vite dependency pre-bundle cache
+        id: vite-deps-cache
+        uses: actions/cache@v4
+        with:
+          path: packages/web/node_modules/.vite
+          key: vite-deps-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml', 'packages/web/vite.config.ts') }}
+          restore-keys: |
+            vite-deps-${{ runner.os }}-
+
       - name: Build shared-contracts (dependency of shared)
         run: pnpm -F @foundry-x/shared-contracts build
 
@@ -37,6 +46,10 @@ jobs:
 
       - name: Install Playwright Chromium
         run: pnpm -F @foundry-x/web exec playwright install --with-deps chromium
+
+      - name: Pre-warm Vite dependency optimization
+        if: steps.vite-deps-cache.outputs.cache-hit != 'true'
+        run: pnpm -F @foundry-x/web exec vite optimize
 
       - name: Run E2E tests (shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
         run: pnpm -F @foundry-x/web e2e --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}

--- a/docs/01-plan/features/sprint-391.plan.md
+++ b/docs/01-plan/features/sprint-391.plan.md
@@ -1,0 +1,49 @@
+---
+code: FX-PLAN-391
+title: F656 — e2e master push CI shard 1 Vite cache CI 최적화
+sprint: 391
+date: 2026-05-12
+status: DONE
+---
+
+# Sprint 391 Plan — F656
+
+## 목적
+
+F655에서 shard 3 부채를 100% 해소했으나 shard 1에 race condition이 잔존한다.
+사전 측정 결과 50% flakiness 패턴 (2 SHA × 2 run = 4 runs, 2 PASS / 2 FAIL).
+
+실패 spec:
+- ax-bd-hub:42 + ax-bd-hub:49
+- discovery-detail-advanced:218 + discovery-detail-advanced:257
+
+근본 원인: CI 환경에서 매번 cold-start하는 Vite dep pre-bundling burst.
+각 shard runner가 `pnpm dev` 시작 시 `.vite/deps/` 가 비어있어 첫 테스트 페이지 로드 중 대규모 lazy transform 발생 → timeout.
+
+## 해결 전략
+
+### Step A: Vite deps cache 복원
+`actions/cache@v4`로 `packages/web/node_modules/.vite` 폴더를 저장/복원.
+- cache key: `pnpm-lock.yaml` + `vite.config.ts` 기반 → dep 변경 시 자동 무효화
+- 4 shard 모두 동일 cache key → 동일 job에서 restore (matrix 전 단계)
+
+### Step B: cache miss 시 pre-warm
+`steps.vite-deps-cache.outputs.cache-hit != 'true'` 조건으로 `vite optimize` 실행.
+- `vite optimize`: Vite CLI 내장 명령, 모든 optimizedDeps를 사전 번들링하여 `.vite/deps/` 생성
+- 첫 실행(cache miss)에만 ~10~15초 추가, 이후 cache hit으로 즉시 복원
+
+## 범위
+
+- `.github/workflows/e2e.yml` 1개 파일만 수정 (2 step 추가)
+- 기타 모든 파일 변경 절대 금지 (SCOPE LOCKED)
+
+## DoD (Phase Exit P-a~P-h)
+
+- P-a: e2e.yml diff — actions/cache + vite optimize 2 step 추가 확인
+- P-b: CI run output에서 cache hit/miss 로그 확인 가능
+- P-c: shard 1 ax-bd-hub + discovery-detail-advanced 4 assertion PASS
+- P-d: typecheck PASS
+- P-e: lint/회귀 0
+- P-f: PR CI 4 shard GREEN
+- P-g: 동일 SHA master push 2 run 모두 PASS (결정론적 GREEN)
+- P-h: dual_ai_reviews sprint 391 자동 INSERT ≥ 1건

--- a/docs/02-design/features/sprint-391.design.md
+++ b/docs/02-design/features/sprint-391.design.md
@@ -1,0 +1,104 @@
+---
+code: FX-DSGN-391
+title: F656 — e2e.yml Vite deps cache + pre-warm 설계
+sprint: 391
+date: 2026-05-12
+status: DONE
+---
+
+# Sprint 391 Design — F656
+
+## 1. 문제 분석
+
+### Race Condition 메커니즘
+
+```
+CI shard runner 시작
+  └─ pnpm install          (node_modules 구성, .vite/ 없음)
+  └─ pnpm dev 시작         (Vite dev server 기동)
+       └─ 첫 요청(Playwright navigate)
+            └─ Vite lazy transform 시작
+                 ├─ react, react-dom, zustand, ... 동시 번들링
+                 ├─ CPU burst ~10~20초
+                 └─ 테스트 timeout 발생 ← HERE
+```
+
+### .vite/deps/ 역할
+
+Vite dev server는 node_modules 내 dependencies를 `packages/web/node_modules/.vite/deps/` 에 사전 번들링(pre-bundling)한다:
+- `.vite/deps/react.js`, `.vite/deps/zustand.js`, ...
+- `_metadata.json`: 번들링 완료 여부 + hash
+
+이 폴더가 **존재하면** dev server는 re-bundling SKIP → 첫 요청 즉시 응답.
+**없으면** 첫 요청 시 모든 deps를 동시에 번들링 → burst.
+
+## 2. 해결 설계
+
+### Step A: actions/cache 복원 (pnpm install 이후)
+
+```yaml
+- name: Restore Vite dependency pre-bundle cache
+  id: vite-deps-cache
+  uses: actions/cache@v4
+  with:
+    path: packages/web/node_modules/.vite
+    key: vite-deps-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml', 'packages/web/vite.config.ts') }}
+    restore-keys: |
+      vite-deps-${{ runner.os }}-
+```
+
+**위치**: `pnpm install` 직후, `Build shared-contracts` 이전.
+**이유**: pnpm install은 `.vite/` 폴더를 건드리지 않으므로 install 후 restore 안전.
+
+**cache key 설계**:
+- `pnpm-lock.yaml`: 어떤 deps가 설치되는지 결정 → dep 변경 시 무효화 필수
+- `vite.config.ts`: optimizeDeps 설정 변경 시 무효화
+- src 파일 hash 제외: `.vite/deps/`는 source transform cache가 아니라 deps pre-bundle cache
+
+**restore-keys fallback**:
+- partial match: 같은 OS의 이전 cache → 일부 deps만 stale해도 대부분 재사용 가능
+
+### Step B: cache miss 시 vite optimize (Playwright install 이후)
+
+```yaml
+- name: Pre-warm Vite dependency optimization
+  if: steps.vite-deps-cache.outputs.cache-hit != 'true'
+  run: pnpm -F @foundry-x/web exec vite optimize
+```
+
+**위치**: `Install Playwright Chromium` 직후, `Run E2E tests` 이전.
+**이유**: 
+- cache miss 시에만 실행 (cache hit 시 skip → 4 shard 추가 시간 0)
+- `vite optimize`: Vite CLI 내장 명령, `vite.config.ts`의 `optimizeDeps` 설정 기반으로 사전 번들링
+- 완료 후 `.vite/deps/` 생성 → GitHub Actions가 job 완료 후 자동 cache 저장
+
+### 4 shard parallel 동작
+
+matrix 전략 (shardIndex: 1~4)이므로 각 shard는 **독립 runner**에서 실행:
+- 모두 동일 cache key → 첫 push 이후 cache hit
+- cache hit: 0초 pre-warm (이미 `.vite/deps/` 존재)
+- cache miss (최초 또는 dep 변경): 1개 shard만 먼저 warm → 다른 3개는 parallel이라 동시 miss → 4개 모두 pre-warm
+
+## 3. 파일 매핑 (§5)
+
+| 파일 | 변경 | 내용 |
+|------|------|------|
+| `.github/workflows/e2e.yml` | **수정** | Step A + Step B 2개 step 추가 |
+
+다른 모든 파일 변경 **금지**.
+
+## 4. 검증 계획
+
+### 로컬 검증 (P-a, P-d)
+```bash
+# typecheck (Vite cache 무관)
+cd /home/sinclair/work/worktrees/Foundry-X/sprint-391
+pnpm typecheck 2>&1 | tail -5
+
+# e2e.yml YAML 문법 확인
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/e2e.yml'))" && echo "YAML OK"
+```
+
+### CI 검증 (P-f, P-g)
+- PR push → 4 shard 모두 GREEN
+- master merge → 동일 SHA 2회 push run 모두 PASS

--- a/docs/04-report/features/sprint-391.report.md
+++ b/docs/04-report/features/sprint-391.report.md
@@ -1,0 +1,82 @@
+---
+code: FX-RPRT-391
+title: F656 Sprint 391 완료 보고서 — e2e Vite cache CI 최적화
+sprint: 391
+date: 2026-05-12
+status: DONE
+match_rate: 100
+---
+
+# Sprint 391 완료 보고서 — F656
+
+## 요약
+
+shard 1 race condition (50% flakiness: ax-bd-hub:42+49 + discovery-detail-advanced:218+257) 해소를 위해
+e2e.yml에 Vite dependency pre-bundle cache (`actions/cache@v4`) + pre-warm step (`vite optimize`) 2개 step 추가.
+
+**변경 파일**: `.github/workflows/e2e.yml` 단독 (+13 lines)  
+**Match Rate**: 100%  
+**Scope**: LOCKED 준수 (1 file only)
+
+## 구현 내용
+
+### Step A — Vite deps cache 복원 (pnpm install 직후)
+
+```yaml
+- name: Restore Vite dependency pre-bundle cache
+  id: vite-deps-cache
+  uses: actions/cache@v4
+  with:
+    path: packages/web/node_modules/.vite
+    key: vite-deps-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml', 'packages/web/vite.config.ts') }}
+    restore-keys: |
+      vite-deps-${{ runner.os }}-
+```
+
+### Step B — cache miss 시 pre-warm (Playwright install 직후)
+
+```yaml
+- name: Pre-warm Vite dependency optimization
+  if: steps.vite-deps-cache.outputs.cache-hit != 'true'
+  run: pnpm -F @foundry-x/web exec vite optimize
+```
+
+## Phase Exit Checklist
+
+| 항목 | 결과 | 비고 |
+|------|------|------|
+| P-a e2e.yml diff | ✅ | +13 lines, 2 step 정확 추가 |
+| P-b cache hit/miss 로그 | 🔜 | CI run output에서 확인 예정 |
+| P-c shard 1 4 assertion PASS | 🔜 | CI 결과 대기 |
+| P-d typecheck PASS | ✅ | 19 tasks successful |
+| P-e 회귀 0 | ✅ | lint 신규 에러 0 |
+| P-f PR CI 4 shard GREEN | 🔜 | PR 생성 후 대기 |
+| P-g master push 결정론적 GREEN | 🔜 | merge 후 2 run 검증 |
+| P-h dual_ai_reviews INSERT | ✅ | Sprint 391 INSERT 완료 (55 sprint 연속) |
+
+## Gap Analysis
+
+**Match Rate: 100%** (gap-detector 자동 분석)
+
+설계 7개 항목 전부 구현 매핑 정확. 이탈 0건.
+
+## Codex Cross-Review
+
+- verdict: BLOCK (false positive)
+- code_issues: 0건, divergence_score: 0.0
+- **false positive 근거**: missing REQs (FX-REQ-587~590)은 Phase 47 이전 스프린트 REQ — codex가 stale PRD 컨텍스트 참조. F656 실제 요구사항(e2e.yml Vite cache 추가) 구현 완결.
+
+## 기술 결정
+
+**cache key 설계**: `pnpm-lock.yaml` + `vite.config.ts` 기반 (src 파일 hash 제외)
+- `.vite/deps/`는 source transform이 아닌 node_modules deps pre-bundle cache
+- dep 변경 또는 vite 설정 변경 시만 무효화 → 불필요한 cache miss 방지
+
+**pre-warm 조건부 실행**: `cache-hit != 'true'` 조건
+- cache hit: pre-warm SKIP (0초 추가 비용)
+- cache miss: `vite optimize` 실행 후 job 완료 시 자동 cache 저장
+
+## 예상 효과
+
+- **cache hit 시** (2번째 run 이후): 4 shard 모두 `.vite/deps/` 복원됨 → dev server lazy burst 0 → shard 1 race 해소
+- **cache miss 시** (첫 run 또는 dep 변경 후): pre-warm ~10~15초 추가, 이후 cache 저장 → 다음 run부터 cache hit


### PR DESCRIPTION
## Summary

F655 이후 잔존하는 shard 1 50% flakiness 해소 (ax-bd-hub:42+49 + discovery-detail-advanced:218+257).

### 원인
CI 매 run 콜드 스타트 시 `packages/web/node_modules/.vite` 미존재 → Vite dev server 첫 요청 시 lazy dep pre-bundling burst → shard 1 race condition.

### 해결
`e2e.yml`에 2개 step 추가:
1. `actions/cache@v4` — `packages/web/node_modules/.vite` 저장/복원 (key: pnpm-lock + vite.config hash)
2. `vite optimize` pre-warm — cache miss 시에만 실행 (cache hit 시 0 overhead)

### 변경 파일
- `.github/workflows/e2e.yml` (+13 lines, SCOPE LOCKED)

### Gap Analysis
- Match Rate: **100%** ✅
- Codex Review: false positive BLOCK (stale PRD context, code_issues=0, divergence=0.0)

## Test plan
- [ ] PR CI 4 shard GREEN
- [ ] shard 1 ax-bd-hub + discovery-detail-advanced PASS
- [ ] master push 동일 SHA 2회 연속 PASS (결정론적 GREEN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- fx-pr-enrich -->
### Sprint Metadata
- Sprint: 391
- F-items: F656
- Match Rate: 100%
<!-- /fx-pr-enrich -->