### PR TITLE
fix(F660): msa-lint 5 errors 해소 (sprint-394 follow-up)

### DIFF
--- a/packages/api/src/core/cross-org/services/cross-org-enforcer.service.ts
+++ b/packages/api/src/core/cross-org/services/cross-org-enforcer.service.ts
@@ -9,7 +9,6 @@ import type {
   ExportCheckResult,
   GroupStats,
 } from "../types.js";
-import { CROSS_ORG_GROUPS } from "../types.js";
 
 export class CrossOrgEnforcer {
   constructor(

--- a/packages/api/src/core/diagnostic/routes/index.ts
+++ b/packages/api/src/core/diagnostic/routes/index.ts
@@ -1,6 +1,6 @@
 // F602: core/diagnostic sub-app — POST /diagnostic/run + GET /diagnostic/findings
 import { Hono } from "hono";
-import { AuditBus, generateTraceId, generateSpanId } from "../../infra/types.js";
+import { AuditBus } from "../../infra/types.js";
 import { DiagnosticEngine } from "../services/diagnostic-engine.service.js";
 import { RunDiagnosticSchema } from "../schemas/diagnostic.js";
 import type { Env } from "../../../env.js";

--- a/packages/api/src/core/ethics/services/ethics-enforcer.service.ts
+++ b/packages/api/src/core/ethics/services/ethics-enforcer.service.ts
@@ -1,33 +1,13 @@
-import {
-  AuditBus,
-  generateTraceId,
-  generateSpanId,
-} from "../../infra/types.js";
+import type { AuditBus } from "../../infra/types.js";
+import { generateTraceId, generateSpanId } from "../../infra/types.js";
 import {
   CONFIDENCE_THRESHOLD,
-  type EthicsViolationType,
-  type EthicsViolation,
   type KillSwitchState,
   type FPRateResult,
 } from "../types.js";
 
 function makeCtx(traceId?: string) {
   return { traceId: traceId ?? generateTraceId(), spanId: generateSpanId(), sampled: true };
-}
-
-function mapViolationRow(row: Record<string, unknown>): EthicsViolation {
-  return {
-    id: row.id as string,
-    orgId: row.org_id as string,
-    agentId: row.agent_id as string,
-    violationType: row.violation_type as EthicsViolationType,
-    thresholdValue: row.threshold_value as number,
-    actualValue: row.actual_value as number,
-    traceId: (row.trace_id as string | null) ?? null,
-    escalatedToHuman: row.escalated_to_human === 1,
-    metadata: row.metadata ? JSON.parse(row.metadata as string) : null,
-    createdAt: row.created_at as number,
-  };
 }
 
 function mapKillSwitchRow(row: Record<string, unknown>): KillSwitchState {


### PR DESCRIPTION
## Summary
- Sprint 394 F660 PR #817 MERGED 후 CI msa-lint workflow (run 25834683681) FAILURE — autopilot이 (b) traceId propagation 변경 시 unused import + dead helper 잔존
- 3 파일에 5 lint errors 해소: unused imports 4 + dead helper function 1

## Changes
1. `core/cross-org/services/cross-org-enforcer.service.ts:12` — `CROSS_ORG_GROUPS` unused import 제거
2. `core/diagnostic/routes/index.ts:3` — `generateTraceId`, `generateSpanId` unused 제거 (route는 service에 traceId 전달만)
3. `core/ethics/services/ethics-enforcer.service.ts:1-5` — `AuditBus` type-only import 분리 (consistent-type-imports)
4. `core/ethics/services/ethics-enforcer.service.ts:18-31` — `mapViolationRow` dead helper 제거 (0 callers) + EthicsViolationType/EthicsViolation unused import 동반 제거

## Local Verification
- ✅ `pnpm exec eslint <3 files>`: 0 errors
- ✅ `pnpm lint:msa-baseline`: 5/5 in baseline (회귀 0)
- ✅ `pnpm exec tsc --noEmit -p packages/api`: 0 errors
- ✅ `grep mapViolationRow`: 외부 ref 0건 (dead 확정)

## Risk
- 회귀 위험 **0** (import 정리 + dead code 제거만, behavior 변경 0)
- 5/15 BeSir D-day 시연 영향 **0**
- rules "lint-fail-hotfix-forward" S348 패턴 19회차 변종 정착화 적용

## Test plan
- [ ] CI msa-lint PASS (5 → 0 errors)
- [ ] CI test workflow 회귀 0건
- [ ] Lint baseline 5/5 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)