### PR TITLE
fix(content): S360 daily-check content sync — Sprint 393→394 + services drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Foundry-X가 이를 읽고 분석하고 동기화를 강제해요.
 | Phase | 47 (Sprint 394) |
 | Sprints | 394 완료 |
 | API Routes | ~4 |
-| API Services | ~0 (F641 closure) |
+| API Services | ~1 |
 | API Schemas | ~13 |
 | Tests | ~3,174 + E2E 273 |
 | D1 Migrations | 164 (latest: 0154) |

--- a/packages/web/content/landing/hero.md
+++ b/packages/web/content/landing/hero.md
@@ -12,7 +12,7 @@ stats:
     label: "AI 에이전트"
   - value: "63"
     label: "자동화 스킬"
-  - value: "393"
+  - value: "394"
     label: "Sprints"
 ---
 

--- a/packages/web/src/components/landing/footer.tsx
+++ b/packages/web/src/components/landing/footer.tsx
@@ -69,7 +69,7 @@ export function Footer() {
             &copy; {new Date().getFullYear()} KTDS AX BD. All rights reserved.
           </p>
           <p className="font-mono text-xs text-muted-foreground/60">
-            Sprint 393 &middot; Phase 47
+            Sprint 394 &middot; Phase 47
           </p>
         </div>
       </div>

--- a/packages/web/src/routes/landing.tsx
+++ b/packages/web/src/routes/landing.tsx
@@ -69,7 +69,7 @@ function getSectionOrder(section: string): number {
    ═══════════════════════════════════════════════ */
 
 const SITE_META_FALLBACK = {
-  sprint: "Sprint 393",
+  sprint: "Sprint 394",
   phase: "Phase 47",
   phaseTitle: "Phase 47 동시 진행",
   tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼",
@@ -79,7 +79,7 @@ const STATS_FALLBACK = [
   { value: "2", label: "BD 파이프라인" },
   { value: "10+", label: "AI 에이전트" },
   { value: "63", label: "자동화 스킬" },
-  { value: "393", label: "Sprints" },
+  { value: "394", label: "Sprints" },
 ];
 
 // Build-time content from TinaCMS-managed Markdown


### PR DESCRIPTION
## Summary
S360 D-1 post-session daily-check full 모드 자동 보정 결과 — README + 랜딩 페이지 4 파일 Sprint 393 → 394 동기화 + README services 표시 drift 보정.

## Auto-fix (4)
1. `README.md` — API Services "~0 (F641 closure)" → "~1" (실제 ls 1건)
2. `packages/web/content/landing/hero.md` — stats Sprints 393 → 394
3. `packages/web/src/routes/landing.tsx` — SITE_META_FALLBACK.sprint + STATS_FALLBACK[3].value 393 → 394
4. `packages/web/src/components/landing/footer.tsx` — Sprint 393 → 394

## Daily Check 14항 결과
| 항목 | 결과 |
|------|------|
| Runtime (node/pnpm/git/turbo) | ✅ |
| tmux Server (3.6a match) | ✅ |
| Git Sync | ✅ up to date |
| Worktree/Branch/Signals | ✅ 0 stale |
| Dependencies | ✅ |
| TypeScript | ✅ 19/19 |
| Hooks | ✅ 4 exec |
| D1 (164/0154) | ✅ |
| SPEC.md 수치 | ✅ (시각 routes=4/services=1/schemas=13 일치) |
| Plugin Drift | ✅ ax=0 bkit=0 |
| Model Drift source | ✅ 0 |
| Sonnet Alias | ✅ SSOT=CLI |
| dist Orphan | ⚠️ 2 stale build (src 존재, `pnpm --filter @foundry-x/shared build` 권장 — 자동 보정 안 함) |
| Disk/Cache | ℹ️ turbo empty, PW 1MB |

## Risk
- 회귀 위험 0 (content/표시 수치만, 동작 변경 0)
- 5/15 시연 영향 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)