### PR TITLE
fix(content): S360 session-end content sync — Sprint 394→395

### DIFF
--- a/packages/web/content/landing/hero.md
+++ b/packages/web/content/landing/hero.md
@@ -12,7 +12,7 @@ stats:
     label: "AI 에이전트"
   - value: "63"
     label: "자동화 스킬"
-  - value: "394"
+  - value: "395"
     label: "Sprints"
 ---
 

--- a/packages/web/src/components/landing/footer.tsx
+++ b/packages/web/src/components/landing/footer.tsx
@@ -69,7 +69,7 @@ export function Footer() {
             &copy; {new Date().getFullYear()} KTDS AX BD. All rights reserved.
           </p>
           <p className="font-mono text-xs text-muted-foreground/60">
-            Sprint 394 &middot; Phase 47
+            Sprint 395 &middot; Phase 47
           </p>
         </div>
       </div>

--- a/packages/web/src/routes/landing.tsx
+++ b/packages/web/src/routes/landing.tsx
@@ -69,7 +69,7 @@ function getSectionOrder(section: string): number {
    ═══════════════════════════════════════════════ */
 
 const SITE_META_FALLBACK = {
-  sprint: "Sprint 394",
+  sprint: "Sprint 395",
   phase: "Phase 47",
   phaseTitle: "Phase 47 동시 진행",
   tagline: "사업기회 발굴부터 데모까지, AI가 자동화하는 BD 플랫폼",
@@ -79,7 +79,7 @@ const STATS_FALLBACK = [
   { value: "2", label: "BD 파이프라인" },
   { value: "10+", label: "AI 에이전트" },
   { value: "63", label: "자동화 스킬" },
-  { value: "394", label: "Sprints" },
+  { value: "395", label: "Sprints" },
 ];
 
 // Build-time content from TinaCMS-managed Markdown


### PR DESCRIPTION
## Summary
S360 본 세션 8 master commits 완결 후 `content-sync-check.sh` drift 4건 발견 — Sprint 394→395 갱신 누락.

## Drift (4건 → 0)
1. `packages/web/content/landing/hero.md` — stats Sprints 394 → 395
2. `packages/web/src/routes/landing.tsx` — SITE_META_FALLBACK.sprint 394 → 395
3. `packages/web/src/routes/landing.tsx` — STATS_FALLBACK[3].value 394 → 395
4. `packages/web/src/components/landing/footer.tsx` — Sprint 394 → 395

## Root Cause
Sprint 394 session-end (`a208a9c8`) + Sprint 395 session-end (`af470a9b`)에서 README SYNC block만 갱신, 랜딩 페이지 3 file + hero.md는 미갱신 → drift 누적.

## S360 메타 학습
- session-end skill Phase 0c-3 자동 실행 강제화 권고
- 매 sprint session-end 시점에 4 file content sync 자동 보정 + 같은 PR 포함

## Verification
- `bash scripts/content-sync-check.sh` → **OK (Sprint 395, Phase 47)**
- 회귀 위험 0, 5/15 시연 영향 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)