### PR TITLE
feat(cq): F662 — CQ 5축 graph_session 종결 hook 연결 + failure_reason 분류

### DIFF
--- a/docs/02-design/features/sprint-396.design.md
+++ b/docs/02-design/features/sprint-396.design.md
@@ -1,0 +1,92 @@
+---
+code: FX-DSGN-396
+title: F662 CQ 5축 graph_session hook 연결 — 상세 설계
+version: 1.0
+status: Active
+category: Design
+phase: 47
+sprint: 396
+f_items:
+  - F662
+req:
+  - FX-REQ-724
+created: 2026-05-16
+session: S362
+---
+
+# Sprint 396 Design — F662 CQ graph_session hook 연결
+
+## §1 범위 (Gap Fill)
+
+F632 era baseline 위에 5개 gap을 채움:
+- (a) D1 migration: `graph_session_id` + `failure_reason` 컬럼 추가
+- (b) `discovery-stage-runner.ts`: `autoTriggerCQEvaluator` 추가 + run-all hook 연결
+- (c) `CQEvaluator.evaluate()`: `graphSessionId` 파라미터 + failure_reason 분류
+- (d) `types.ts`: `FailureReason` 타입 + `CQEvaluationResult` 확장
+- (e) Integration test: T4~T7 (graph_session_id INSERT + failure_reason 2 케이스)
+
+## §2 데이터 모델
+
+### D1 cq_evaluations (after 0155 migration)
+
+| 컬럼 | 타입 | 비고 |
+|------|------|------|
+| id | TEXT PK | UUID |
+| org_id | TEXT | |
+| question_id | TEXT | synthetic: `auto-cq-{graphSessionId}` |
+| axis_scores | TEXT | JSON |
+| total_score | INTEGER | 0~100 |
+| handoff_decision | TEXT | handoff / human_review |
+| evaluated_at | INTEGER | epoch ms |
+| graph_session_id | TEXT NULL | F662 신규 |
+| failure_reason | TEXT NULL | F662 신규 (human_error / infra_issue) |
+
+## §3 failure_reason 분류 로직
+
+```
+parseAxisScores(llmResponse.content) → null?
+  YES (LLM 응답 파싱 실패) → usedDefault=true
+    totalScore < 90 → failureReason = "infra_issue"
+  NO (파싱 성공) → usedDefault=false
+    totalScore < 90 → failureReason = "human_error"
+    totalScore >= 90 → failureReason = null
+```
+
+## §4 autoTriggerCQEvaluator 흐름
+
+```
+graph-session run-all 완료
+  → sessionService.updateStatus("completed")
+  → metaTask = autoTriggerMetaAgent(...)
+  → cqTask   = autoTriggerCQEvaluator(db, sessionId, orgId, apiKey, result)
+  → waitUntil(Promise.all([metaTask, cqTask]))
+
+autoTriggerCQEvaluator 내부:
+  → AuditBus(db, default-hmac-key)
+  → LLMService(undefined, apiKey)  -- anthropic REST fallback
+  → CQEvaluator.evaluate({
+       orgId, questionId="auto-cq-{graphSessionId}",
+       llmCallContext={sessionId=graphSessionId, response=JSON.stringify(result).slice(0,4000)},
+       graphSessionId
+     })
+  → INSERT cq_evaluations.graph_session_id = graphSessionId
+```
+
+## §5 파일 매핑
+
+| 파일 | 변경 유형 | 비고 |
+|------|----------|------|
+| `packages/api/src/db/migrations/0155_cq_evaluations_graph_session.sql` | 신규 | ALTER + INDEX |
+| `packages/api/src/core/cq/types.ts` | 수정 | FailureReason + CQEvaluationResult 확장 |
+| `packages/api/src/core/cq/services/cq-evaluator.service.ts` | 수정 | evaluate() 확장 |
+| `packages/api/src/core/cq/services/review-cycle.service.ts` | 수정 | lint fix (pre-existing) |
+| `packages/api/src/core/cq/cq-graph-hook.test.ts` | 신규 | T4~T7 |
+| `packages/api/src/core/discovery/routes/discovery-stage-runner.ts` | 수정 | autoTriggerCQEvaluator + hook |
+
+## §6 Out-of-scope
+
+- F663 HITL 5-state 머신 / hitl_queue
+- F664 HITL Console UI
+- F665 CQ 작성 가이드
+- 5축 정확도 정밀화 (MVP 임시정의 유지)
+- KV 캐싱, 별 평가 Worker

--- a/packages/api/src/core/cq/cq-graph-hook.test.ts
+++ b/packages/api/src/core/cq/cq-graph-hook.test.ts
@@ -1,0 +1,108 @@
+// F662: graph_session 종결 CQ hook + failure_reason 자동 분류 integration test
+import { describe, it, expect, vi } from "vitest";
+import { CQEvaluator } from "./services/cq-evaluator.service.js";
+
+interface BindCapture {
+  args: unknown[];
+}
+
+function makeD1MockCapturing(questionRow: unknown = null) {
+  const binds: BindCapture[] = [];
+  return {
+    _binds: () => binds,
+    prepare: vi.fn().mockImplementation(() => ({
+      bind: vi.fn().mockImplementation((...args: unknown[]) => {
+        binds.push({ args });
+        return {
+          run: vi.fn().mockResolvedValue({ success: true }),
+          first: vi.fn().mockResolvedValue(questionRow),
+          all: vi.fn().mockResolvedValue({ results: [] }),
+        };
+      }),
+    })),
+  };
+}
+
+function makeAuditBusMock() {
+  return { emit: vi.fn().mockResolvedValue(undefined) };
+}
+
+function makeLLMMockParseable(rawScore: number) {
+  const axes = ["ontology_usage", "tool_selection", "code_quality", "result_match", "governance"];
+  const body = Object.fromEntries(axes.map((k) => [k, { rawScore, reasoning: "ok" }]));
+  return {
+    generate: vi.fn().mockResolvedValue({ content: JSON.stringify(body), model: "test", tokensUsed: 0 }),
+  };
+}
+
+function makeLLMMockUnparseable() {
+  return {
+    generate: vi.fn().mockResolvedValue({ content: "NOT_JSON", model: "test", tokensUsed: 0 }),
+  };
+}
+
+describe("F662 CQEvaluator — graph_session hook + failure_reason", () => {
+  const orgId = "org-f662";
+  const questionId = "auto-cq-graph-session-1";
+  const graphSessionId = "graph-session-1";
+  const llmCtx = { sessionId: graphSessionId, response: '{"result":"ok"}' };
+
+  it("T4: graphSessionId 제공 → cq_evaluations INSERT에 graph_session_id 포함", async () => {
+    const db = makeD1MockCapturing();
+    const bus = makeAuditBusMock();
+    const llm = makeLLMMockParseable(95);
+    const evaluator = new CQEvaluator(db as unknown as D1Database, llm as any, bus as any);
+
+    const result = await evaluator.evaluate({ orgId, questionId, llmCallContext: llmCtx, graphSessionId });
+
+    expect(result.graphSessionId).toBe(graphSessionId);
+    expect(result.failureReason).toBeUndefined();
+
+    // INSERT bind 캡처 확인: SELECT + INSERT 순으로 2회 prepare
+    const insertBind = db._binds().find((b) => b.args.includes(graphSessionId));
+    expect(insertBind).toBeDefined();
+  });
+
+  it("T5: 파싱 성공 + totalScore<90 → failureReason='human_error'", async () => {
+    const db = makeD1MockCapturing();
+    const bus = makeAuditBusMock();
+    const llm = makeLLMMockParseable(60);
+    const evaluator = new CQEvaluator(db as unknown as D1Database, llm as any, bus as any);
+
+    const result = await evaluator.evaluate({ orgId, questionId, llmCallContext: llmCtx, graphSessionId });
+
+    expect(result.handoffDecision).toBe("human_review");
+    expect(result.totalScore).toBeLessThan(90);
+    expect(result.failureReason).toBe("human_error");
+
+    // audit-bus emit payload에 failureReason 포함 확인
+    const emitCalls = (bus.emit as ReturnType<typeof vi.fn>).mock.calls;
+    const evalCall = emitCalls.find((c: unknown[]) => c[0] === "cq.evaluated");
+    expect(evalCall?.[1]).toMatchObject({ failureReason: "human_error", graphSessionId });
+  });
+
+  it("T6: LLM 응답 파싱 실패 → failureReason='infra_issue'", async () => {
+    const db = makeD1MockCapturing();
+    const bus = makeAuditBusMock();
+    const llm = makeLLMMockUnparseable();
+    const evaluator = new CQEvaluator(db as unknown as D1Database, llm as any, bus as any);
+
+    const result = await evaluator.evaluate({ orgId, questionId, llmCallContext: llmCtx, graphSessionId });
+
+    expect(result.handoffDecision).toBe("human_review");
+    expect(result.failureReason).toBe("infra_issue");
+  });
+
+  it("T7: graphSessionId 미제공 → failureReason/graphSessionId undefined (F632 baseline 회귀 0)", async () => {
+    const db = makeD1MockCapturing();
+    const bus = makeAuditBusMock();
+    const llm = makeLLMMockParseable(95);
+    const evaluator = new CQEvaluator(db as unknown as D1Database, llm as any, bus as any);
+
+    const result = await evaluator.evaluate({ orgId, questionId: "q-1", llmCallContext: { sessionId: "s-1", response: "ok" } });
+
+    expect(result.handoffDecision).toBe("handoff");
+    expect(result.graphSessionId).toBeUndefined();
+    expect(result.failureReason).toBeUndefined();
+  });
+});

--- a/packages/api/src/core/cq/services/cq-evaluator.service.ts
+++ b/packages/api/src/core/cq/services/cq-evaluator.service.ts
@@ -1,4 +1,5 @@
-import { AuditBus, generateTraceId, generateSpanId } from "../../infra/types.js";
+import type { AuditBus } from "../../infra/types.js";
+import { generateTraceId, generateSpanId } from "../../infra/types.js";
 import {
   CQ_AXES,
   CQ_AXIS_WEIGHTS,
@@ -6,6 +7,7 @@ import {
   type AxisScore,
   type CQEvaluationResult,
   type CQHandoffDecision,
+  type FailureReason,
 } from "../types.js";
 
 const CQ_EVAL_SYSTEM_PROMPT = `You are a quality evaluation agent. Evaluate the given LLM response on 5 axes.
@@ -71,6 +73,7 @@ export class CQEvaluator {
     orgId: string;
     questionId: string;
     llmCallContext: { sessionId: string; response: string; toolCalls?: unknown[] };
+    graphSessionId?: string;
   }): Promise<CQEvaluationResult> {
     const question = await this.db
       .prepare("SELECT id, question_text, answer_text FROM cq_questions WHERE id = ?")
@@ -86,7 +89,9 @@ export class CQEvaluator {
     const userPrompt = buildCQEvalPrompt(questionData, input.llmCallContext);
     const llmResponse = await this.llm.generate(CQ_EVAL_SYSTEM_PROMPT, userPrompt);
 
-    let axisScores = parseAxisScores(llmResponse.content) ?? defaultAxisScores();
+    const parsedScores = parseAxisScores(llmResponse.content);
+    const usedDefault = parsedScores === null;
+    const axisScores = parsedScores ?? defaultAxisScores();
 
     let total = 0;
     for (const axis of CQ_AXES) {
@@ -97,24 +102,45 @@ export class CQEvaluator {
     const totalScore = Math.round(total);
 
     const handoffDecision: CQHandoffDecision = totalScore >= 90 ? "handoff" : "human_review";
+    // F662: <90점 자동 분류 — LLM 파싱 실패면 infra_issue, 파싱 성공이지만 낮으면 human_error
+    const failureReason: FailureReason = totalScore < 90
+      ? (usedDefault ? "infra_issue" : "human_error")
+      : null;
+
     const id = crypto.randomUUID();
     const evaluatedAt = Date.now();
+    const graphSessionId = input.graphSessionId ?? null;
 
     await this.db
       .prepare(
-        `INSERT INTO cq_evaluations (id, org_id, question_id, axis_scores, total_score, handoff_decision, evaluated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO cq_evaluations
+           (id, org_id, question_id, axis_scores, total_score, handoff_decision, evaluated_at, graph_session_id, failure_reason)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
-      .bind(id, input.orgId, input.questionId, JSON.stringify(axisScores), totalScore, handoffDecision, evaluatedAt)
+      .bind(id, input.orgId, input.questionId, JSON.stringify(axisScores), totalScore, handoffDecision, evaluatedAt, graphSessionId, failureReason)
       .run();
 
     const ctx = { traceId: generateTraceId(), spanId: generateSpanId(), sampled: true };
-    await this.auditBus.emit("cq.evaluated", { id, orgId: input.orgId, totalScore, handoffDecision }, ctx);
+    await this.auditBus.emit(
+      "cq.evaluated",
+      { id, orgId: input.orgId, totalScore, handoffDecision, graphSessionId, failureReason },
+      ctx,
+    );
 
     if (handoffDecision === "handoff") {
-      await this.auditBus.emit("cq.handoff", { evaluationId: id, orgId: input.orgId, totalScore }, ctx);
+      await this.auditBus.emit("cq.handoff", { evaluationId: id, orgId: input.orgId, totalScore, graphSessionId }, ctx);
     }
 
-    return { id, orgId: input.orgId, questionId: input.questionId, axisScores, totalScore, handoffDecision, evaluatedAt };
+    return {
+      id,
+      orgId: input.orgId,
+      questionId: input.questionId,
+      axisScores,
+      totalScore,
+      handoffDecision,
+      evaluatedAt,
+      graphSessionId: graphSessionId ?? undefined,
+      failureReason: failureReason ?? undefined,
+    };
   }
 }

--- a/packages/api/src/core/cq/services/review-cycle.service.ts
+++ b/packages/api/src/core/cq/services/review-cycle.service.ts
@@ -1,4 +1,5 @@
-import { AuditBus, generateTraceId, generateSpanId } from "../../infra/types.js";
+import type { AuditBus } from "../../infra/types.js";
+import { generateTraceId, generateSpanId } from "../../infra/types.js";
 import { type ReviewCycleResult, type ReviewCycleStage } from "../types.js";
 
 interface LLMProvider {

--- a/packages/api/src/core/cq/types.ts
+++ b/packages/api/src/core/cq/types.ts
@@ -25,6 +25,11 @@ export interface AxisScore {
 
 export type CQHandoffDecision = "handoff" | "human_review";
 
+// F662: <90점 자동 실패 분류
+// human_error — LLM 파싱 정상이지만 콘텐츠 품질 미달
+// infra_issue — LLM 응답 파싱 실패 (빈 응답, 포맷 오류)
+export type FailureReason = "human_error" | "infra_issue" | null;
+
 export interface CQEvaluationResult {
   id: string;
   orgId: string;
@@ -33,6 +38,8 @@ export interface CQEvaluationResult {
   totalScore: number;
   handoffDecision: CQHandoffDecision;
   evaluatedAt: number;
+  graphSessionId?: string;
+  failureReason?: FailureReason;
 }
 
 export const REVIEW_CYCLE_STAGES = [

--- a/packages/api/src/core/discovery/routes/discovery-stage-runner.ts
+++ b/packages/api/src/core/discovery/routes/discovery-stage-runner.ts
@@ -9,6 +9,8 @@ import type { Env } from "../../../env.js";
 import { MODEL_SONNET } from "@foundry-x/shared";
 import type { TenantVariables } from "../../../middleware/tenant.js";
 import { DiagnosticCollector, MetaAgent, MetaApprovalService, ProposalRubric, createAgentRunner, createRoutedRunner } from "../../agent/types.js";
+import { AuditBus, LLMService } from "../../infra/types.js";
+import { CQEvaluator } from "../../cq/types.js";
 import { StageRunnerService } from "../services/stage-runner-service.js";
 import { DiscoveryGraphService } from "../services/discovery-graph-service.js";
 import type { DiscoveryType } from "../services/analysis-path-v82.js";
@@ -63,6 +65,42 @@ export async function autoTriggerMetaAgent(
   }
 
   console.log("[F544] autoTrigger saved", { saved: proposals.length, sessionId });
+}
+
+/**
+ * F662: graph_session 종결 후 CQ 5축 자동 평가 hook.
+ * autoTriggerMetaAgent 패턴 재사용 — fire-and-forget, 에러 시 조용히 처리.
+ * synthetic questionId(auto-cq-{sessionId})로 cq_questions 미등록 상태에서도 동작.
+ */
+export async function autoTriggerCQEvaluator(
+  db: D1Database,
+  graphSessionId: string,
+  orgId: string,
+  apiKey: string,
+  graphResult: unknown,
+): Promise<void> {
+  const bus = new AuditBus(db, "default-hmac-key-32chars-pad");
+  const llm = new LLMService(undefined, apiKey);
+  const evaluator = new CQEvaluator(db, llm, bus);
+
+  const questionId = `auto-cq-${graphSessionId}`;
+  const responseText = JSON.stringify(graphResult).slice(0, 4000);
+
+  console.log("[F662] autoTriggerCQEvaluator start", { graphSessionId, orgId });
+
+  const result = await evaluator.evaluate({
+    orgId,
+    questionId,
+    llmCallContext: { sessionId: graphSessionId, response: responseText },
+    graphSessionId,
+  });
+
+  console.log("[F662] autoTriggerCQEvaluator complete", {
+    graphSessionId,
+    totalScore: result.totalScore,
+    handoffDecision: result.handoffDecision,
+    failureReason: result.failureReason,
+  });
 }
 
 const StageRunSchema = z.object({
@@ -267,11 +305,15 @@ discoveryStageRunnerRoute.post("/biz-items/:id/discovery-graph/run-all", async (
     });
     await sessionService.updateStatus(sessionId, "completed");
     // F544: waitUntil로 Workers 응답 후에도 완료 보장 (void fire-and-forget → 컨텍스트 종료 위험 해소)
-    const triggerTask = autoTriggerMetaAgent(
+    const metaTask = autoTriggerMetaAgent(
       c.env.DB, sessionId, apiKey, bizItemId, c.env.META_AGENT_MODEL,
     ).catch((e) => console.error("[F544] MetaAgent auto-trigger failed:", e));
+    // F662: graph_session 종결 → CQ 5축 자동 평가 hook
+    const cqTask = autoTriggerCQEvaluator(
+      c.env.DB, sessionId, orgId, apiKey, result,
+    ).catch((e) => console.error("[F662] CQ auto-trigger failed:", e));
     try {
-      c.executionCtx.waitUntil(triggerTask);
+      c.executionCtx.waitUntil(Promise.all([metaTask, cqTask]));
     } catch {
       // non-Worker 환경(테스트 등)에서는 waitUntil 없음 — fire-and-forget fallback
     }

--- a/packages/api/src/db/migrations/0155_cq_evaluations_graph_session.sql
+++ b/packages/api/src/db/migrations/0155_cq_evaluations_graph_session.sql
@@ -1,0 +1,7 @@
+-- F662: graph_session 종결 CQ 자동 평가 hook
+-- graph_session_id: discovery graph 실행 세션 연결
+-- failure_reason: <90점 자동 분류 (human_error | infra_issue)
+-- SQLite ALTER TABLE은 ADD COLUMN만 지원 — CHECK 제약은 service 레이어에서 검증
+ALTER TABLE cq_evaluations ADD COLUMN graph_session_id TEXT;
+ALTER TABLE cq_evaluations ADD COLUMN failure_reason TEXT;
+CREATE INDEX IF NOT EXISTS idx_cq_evaluations_graph_session ON cq_evaluations(graph_session_id);

--- a/reports/sprint-396-cq-hook-integration.md
+++ b/reports/sprint-396-cq-hook-integration.md
@@ -1,0 +1,76 @@
+# Sprint 396 — F662 CQ graph_session hook Integration Report
+
+**날짜**: 2026-05-16  
+**세션**: S362  
+**Sprint**: 396  
+**F-item**: F662
+
+## P-a: D1 migration 0155 생성
+
+```
+packages/api/src/db/migrations/0155_cq_evaluations_graph_session.sql
+  ALTER TABLE cq_evaluations ADD COLUMN graph_session_id TEXT;
+  ALTER TABLE cq_evaluations ADD COLUMN failure_reason TEXT;
+  CREATE INDEX IF NOT EXISTS idx_cq_evaluations_graph_session ON cq_evaluations(graph_session_id);
+```
+
+Latest migration before: `0154_audit_logs_trace_id.sql`  
+New migration: `0155_cq_evaluations_graph_session.sql`
+
+## P-b: autoTriggerCQEvaluator 동작 확인
+
+`discovery-stage-runner.ts:87-122` (autoTriggerCQEvaluator) 신규 추가.  
+run-all handler line 305에서 호출:
+```typescript
+const cqTask = autoTriggerCQEvaluator(c.env.DB, sessionId, orgId, apiKey, result)
+  .catch((e) => console.error("[F662] CQ auto-trigger failed:", e));
+c.executionCtx.waitUntil(Promise.all([metaTask, cqTask]));
+```
+
+## P-c: graph_session_id INSERT 검증
+
+Integration test T4 PASS:
+```
+✓ T4: graphSessionId 제공 → cq_evaluations INSERT에 graph_session_id 포함 (2ms)
+```
+
+D1 mock bind() capture → args.includes(graphSessionId) = true
+
+## P-d: failure_reason 자동 분류
+
+```
+✓ T5: 파싱 성공 + totalScore<90 → failureReason='human_error' (1ms)
+✓ T6: LLM 응답 파싱 실패 → failureReason='infra_issue' (0ms)
+```
+
+## P-e: audit-bus emit cq.evaluated payload
+
+T5 검증:
+```typescript
+const evalCall = emitCalls.find((c) => c[0] === "cq.evaluated");
+expect(evalCall?.[1]).toMatchObject({ failureReason: "human_error", graphSessionId });
+// → PASS
+```
+
+## P-f: 회귀 0 확인
+
+```
+Test Files  267 passed | 1 skipped (268)
+Tests  2466 passed | 2 skipped (2468)
+```
+
+F632 T1~T3 + F662 T4~T7 = 7/7 CQ tests PASS.  
+F606/F607 audit-bus trace_id chain T1~T2 PASS.
+
+## P-g: typecheck PASS
+
+```
+pnpm exec tsc --noEmit  →  0 errors (turbo 우회, S337 rule 적용)
+```
+
+## reports/ 디렉토리 실파일 ls
+
+```
+sprint-396-cq-hook-integration.md        ← 본 파일
+sprint-396-failure-classification-samples.md ← 분류 샘플 3건+
+```

--- a/reports/sprint-396-failure-classification-samples.md
+++ b/reports/sprint-396-failure-classification-samples.md
@@ -1,0 +1,83 @@
+# Sprint 396 — F662 failure_reason 분류 샘플
+
+**날짜**: 2026-05-16  
+**목적**: <90점 자동 분류 로직 (human_error vs infra_issue) 검증 샘플 3건+
+
+## 분류 로직 요약
+
+```typescript
+const parsedScores = parseAxisScores(llmResponse.content);
+const usedDefault = parsedScores === null;
+const axisScores = parsedScores ?? defaultAxisScores();
+
+const failureReason: FailureReason = totalScore < 90
+  ? (usedDefault ? "infra_issue" : "human_error")
+  : null;
+```
+
+## 샘플 케이스
+
+### Case 1: 정상 파싱 + 낮은 점수 → human_error
+
+**입력**:
+- LLM rawScore: 60 (모든 축)
+- parseAxisScores() → 성공 (usedDefault=false)
+
+**계산**:
+- ontology_usage: 60 × 0.25 = 15.0
+- tool_selection: 60 × 0.20 = 12.0
+- code_quality: 60 × 0.15 = 9.0
+- result_match: 60 × 0.30 = 18.0
+- governance: 60 × 0.10 = 6.0
+- totalScore = 60 → handoffDecision = "human_review"
+
+**결과**: `failureReason = "human_error"` ✅ (T5 PASS)
+
+---
+
+### Case 2: LLM 응답 파싱 실패 → infra_issue
+
+**입력**:
+- LLM response: "NOT_JSON" (파싱 불가)
+- parseAxisScores() → null (usedDefault=true)
+- defaultAxisScores() 사용: 모든 축 rawScore=50
+
+**계산**:
+- totalScore = 50 → handoffDecision = "human_review"
+
+**결과**: `failureReason = "infra_issue"` ✅ (T6 PASS)
+
+---
+
+### Case 3: 고득점 → null (handoff)
+
+**입력**:
+- LLM rawScore: 95 (모든 축)
+- parseAxisScores() → 성공
+
+**계산**:
+- totalScore = 95 → handoffDecision = "handoff"
+
+**결과**: `failureReason = null` ✅ (T7 PASS — F632 baseline 회귀 0)
+
+---
+
+### Case 4: 경계값 90점 → null (handoff)
+
+**이론적 케이스**:
+- rawScore = 90 → totalScore = 90 → handoffDecision = "handoff"
+- `totalScore < 90` 조건이 false → failureReason = null
+
+**결과**: handoff + failureReason=null (handoff 임계값 inclusive)
+
+---
+
+## 분류 coverage
+
+| 상황 | failureReason | handoffDecision |
+|------|--------------|----------------|
+| LLM 파싱 실패 + 점수 낮음 | infra_issue | human_review |
+| LLM 파싱 성공 + 점수 낮음 | human_error | human_review |
+| LLM 파싱 성공 + 점수 높음 (≥90) | null | handoff |
+
+**모든 케이스 test 검증 완료** (T4~T7, 2466/2468 전체 테스트 PASS)


### PR DESCRIPTION
## Summary

- **F662** (FX-REQ-724, P0, Sprint 396) — CQ 5축 평가 graph_session 종결 hook 연결 (gap fill)
- F632 baseline 위에 5개 gap을 채움

### 변경 내역

| 파일 | 변경 |
|------|------|
| `0155_cq_evaluations_graph_session.sql` | ALTER TABLE + INDEX 신규 |
| `core/cq/types.ts` | `FailureReason` type + `CQEvaluationResult` 확장 |
| `core/cq/services/cq-evaluator.service.ts` | `evaluate()` graphSessionId + failure_reason |
| `core/discovery/routes/discovery-stage-runner.ts` | `autoTriggerCQEvaluator` + run-all hook |
| `core/cq/cq-graph-hook.test.ts` | T4~T7 integration test 신규 (4 PASS) |
| `reports/sprint-396-*.md` | 실파일 2건 생성 (S360 hallucination 회피) |

### Phase Exit (P-a~P-h)

- ✅ P-a: migration 0155 생성 (graph_session_id + failure_reason + INDEX)
- ✅ P-b: autoTriggerCQEvaluator 동작 (waitUntil fire-and-forget)
- ✅ P-c: graph_session_id INSERT 검증 (T4 PASS)
- ✅ P-d: failure_reason 분류 PASS (T5 human_error + T6 infra_issue)
- ✅ P-e: audit-bus emit cq.evaluated payload에 graphSessionId+failureReason 포함 (T5 검증)
- ✅ P-f: 회귀 0 — Tests 2466/2468 PASS (F632 T1~T3 + F662 T4~T7)
- ✅ P-g: typecheck 0 errors (turbo 우회 실행, S337 rule)
- ⏳ P-h: dual_ai_reviews INSERT — CI 실행 후 자동 확인

### Match Rate

Design §5 파일 매핑 6개 vs 실제 변경 9개 (design.md + 2×reports = meta, 코드 6 일치)  
**Match Rate: 100%** (Out-of-scope 변경 0)

---
🤖 Sprint Autopilot (claude-sonnet-4-6)

<!-- fx-pr-enrich -->
### Sprint Metadata
- Sprint: 396
- F-items: F662
- Match Rate: 100%
<!-- /fx-pr-enrich -->